### PR TITLE
Mise à jour de l'indication des champs obligatoires / optionnels des formulaires

### DIFF
--- a/envergo/geodata/conftest.py
+++ b/envergo/geodata/conftest.py
@@ -8,18 +8,20 @@ from envergo.geodata.tests.factories import MapFactory, ZoneFactory
 def france_map():
     """Fixture for a map containing mainland France territory."""
 
-    map = MapFactory(name='France map', data_type='')
+    map = MapFactory(name="France map", data_type="")
 
     # This is a rough pentagon that I manually drew on geoportail and that contains
     # France's mainland.
-    pentagon = Polygon([
-        (2.239523057461999,51.37848260569899),
-        (-5.437949095065911,48.830042871275225),
-        (-2.020973593289057,42.22052255703733),
-        (7.672371135600932,42.3263119734425),
-        (9.759728555096416,49.41947007260785),
-        (2.239523057461999,51.37848260569899),
-    ])
+    pentagon = Polygon(
+        [
+            (2.239523057461999, 51.37848260569899),
+            (-5.437949095065911, 48.830042871275225),
+            (-2.020973593289057, 42.22052255703733),
+            (7.672371135600932, 42.3263119734425),
+            (9.759728555096416, 49.41947007260785),
+            (2.239523057461999, 51.37848260569899),
+        ]
+    )
     zone = ZoneFactory(map=map, geometry=MultiPolygon([pentagon]))
 
     return map

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -160,6 +160,20 @@ class Moulinette:
         criterions = [perimeter.criterion for perimeter in perimeters]
         return criterions
 
+    def get_zones(self):
+        """For debug purpose only.
+
+        Return the Zone objects containing the queried coordinates.
+        """
+        zones = (
+            Zone.objects.filter(geometry__dwithin=(self.catalog["coords"], D(m=0)))
+            .select_related("map")
+            .prefetch_related("map__perimeters")
+            .filter(map__perimeters__isnull=False)
+            .distinct()
+        )
+        return zones
+
     def is_evaluation_available(self):
         """Moulinette evaluations are only available on some departments.
 

--- a/envergo/moulinette/tests/factories.py
+++ b/envergo/moulinette/tests/factories.py
@@ -1,4 +1,3 @@
-
 import factory
 from factory.django import DjangoModelFactory
 
@@ -12,4 +11,4 @@ class PerimeterFactory(DjangoModelFactory):
 
     name = "Loi sur l'eau Zone humide"
     map = factory.SubFactory(MapFactory)
-    criterion = 'envergo.moulinette.regulations.loisurleau.ZoneHumide'
+    criterion = "envergo.moulinette.regulations.loisurleau.ZoneHumide"

--- a/envergo/moulinette/tests/test_models.py
+++ b/envergo/moulinette/tests/test_models.py
@@ -12,9 +12,9 @@ pytestmark = pytest.mark.django_db
 def loisurleau_criterions(france_map):
 
     classes = [
-        'envergo.moulinette.regulations.loisurleau.ZoneHumide',
-        'envergo.moulinette.regulations.loisurleau.ZoneInondable',
-        'envergo.moulinette.regulations.loisurleau.Ruissellement',
+        "envergo.moulinette.regulations.loisurleau.ZoneHumide",
+        "envergo.moulinette.regulations.loisurleau.ZoneInondable",
+        "envergo.moulinette.regulations.loisurleau.Ruissellement",
     ]
     perimeters = [PerimeterFactory(map=france_map, criterion=path) for path in classes]
     return perimeters
@@ -62,9 +62,7 @@ def test_3310_small_footprint_outside_wetlands(moulinette_data, monkeypatch):
     """Project with footprint < 700m² are not subject to the 3310."""
 
     # Make sure the project in in a wetland
-    monkeypatch.setattr(
-        "envergo.moulinette.models.fetch_wetlands_around_25m", no_zones
-    )
+    monkeypatch.setattr("envergo.moulinette.models.fetch_wetlands_around_25m", no_zones)
 
     moulinette = Moulinette(moulinette_data, moulinette_data)
     assert moulinette.loi_sur_leau.zone_humide.result == "non_concerne"
@@ -111,9 +109,7 @@ def test_3310_medium_footprint_close_to_wetlands(moulinette_data, monkeypatch):
     """Project with 700 <= footprint <= 1000m² close to a wetland."""
 
     # Make sure the project in close to a wetland
-    monkeypatch.setattr(
-        "envergo.moulinette.models.fetch_wetlands_around_25m", no_zones
-    )
+    monkeypatch.setattr("envergo.moulinette.models.fetch_wetlands_around_25m", no_zones)
     monkeypatch.setattr(
         "envergo.moulinette.models.fetch_wetlands_around_100m", create_zones
     )
@@ -127,9 +123,7 @@ def test_3310_medium_footprint_inside_potential_wetlands(moulinette_data, monkey
     """Project with 700 <= footprint <= 1000m² inside a potential wetland."""
 
     # Make sure the project is in a potential wetland
-    monkeypatch.setattr(
-        "envergo.moulinette.models.fetch_wetlands_around_25m", no_zones
-    )
+    monkeypatch.setattr("envergo.moulinette.models.fetch_wetlands_around_25m", no_zones)
     monkeypatch.setattr(
         "envergo.moulinette.models.fetch_wetlands_around_100m", no_zones
     )
@@ -167,9 +161,7 @@ def test_3310_large_footprint_close_to_wetlands(moulinette_data, monkeypatch):
     """Project with footprint >= 1000m² close to a wetland."""
 
     # Make sure the project in in a wetland
-    monkeypatch.setattr(
-        "envergo.moulinette.models.fetch_wetlands_around_25m", no_zones
-    )
+    monkeypatch.setattr("envergo.moulinette.models.fetch_wetlands_around_25m", no_zones)
     monkeypatch.setattr(
         "envergo.moulinette.models.fetch_wetlands_around_100m", create_zones
     )
@@ -183,9 +175,7 @@ def test_3310_large_footprint_inside_potential_wetland(moulinette_data, monkeypa
     """Project with footprint >= 1000m² inside a potential wetland."""
 
     # Make sure the project in in a wetland
-    monkeypatch.setattr(
-        "envergo.moulinette.models.fetch_wetlands_around_25m", no_zones
-    )
+    monkeypatch.setattr("envergo.moulinette.models.fetch_wetlands_around_25m", no_zones)
     monkeypatch.setattr(
         "envergo.moulinette.models.fetch_wetlands_around_100m", no_zones
     )

--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 pytestmark = pytest.mark.django_db
 
 
-HOME_TITLE = "Évaluez si votre projet de construction est soumis à la Loi sur l'eau"
+HOME_TITLE = "Évaluez à quelles réglementations votre projet de construction est soumis"
 RESULT_TITLE = "Réglementations environnementales : évaluation personnalisée"
 FORM_ERROR = (
     "Nous n'avons pas pu traiter votre demande car le formulaire contient des erreurs."

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -72,7 +72,7 @@ class MoulinetteHome(FormView):
             lng, lat = form.cleaned_data["lng"], form.cleaned_data["lat"]
             context["display_marker"] = True
             context["center_map"] = [lng, lat]
-            context["default_zoom"] = 16
+            context["default_zoom"] = 15
         else:
             # By default, show all metropolitan france in map
             context["display_marker"] = False

--- a/envergo/pages/templatetags/utils.py
+++ b/envergo/pages/templatetags/utils.py
@@ -29,5 +29,5 @@ def is_input_file(field):
 def add_classes(field, classes):
     """Add some classes to the field widget html."""
     css_classes = field.field.widget.attrs.get("class", "").split(" ")
-    all_classes = list(set(classes.split(" ")) | set(css_classes))
+    all_classes = sorted(list(set(classes.split(" ")) | set(css_classes)))
     return field.as_widget(attrs={"class": " ".join(all_classes)})

--- a/envergo/static/js/libs/moulinette_accordion_maps.js
+++ b/envergo/static/js/libs/moulinette_accordion_maps.js
@@ -29,7 +29,7 @@
       scrollWheelZoom: false,
       touchZoom: false,
       keyboard: false
-    }).setView(centerCoords, 17);
+    }).setView(centerCoords, 16);
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 22,

--- a/envergo/static/js/libs/moulinette_map.js
+++ b/envergo/static/js/libs/moulinette_map.js
@@ -60,14 +60,14 @@
     return marker;
   };
 
-  MoulinetteMap.prototype.setMarkerPosition = function(latLng) {
+  MoulinetteMap.prototype.setMarkerPosition = function(latLng, zoomLevel) {
 
     if (!this.map.hasLayer(this.marker)) {
       this.marker.addTo(this.map);
     }
 
     this.marker.setLatLng(latLng);
-    this.map.panTo(latLng);
+    this.map.setView(latLng, zoomLevel);
   };
 
   MoulinetteMap.prototype.setFieldValue = function(latLng) {
@@ -75,12 +75,6 @@
     latField.value = latLng.lat.toFixed(5);
     var lngField = document.getElementById(this.options.lngFieldId);
     lngField.value = latLng.lng.toFixed(5);
-  };
-
-  MoulinetteMap.prototype.setMinZoom = function(minZoom) {
-    if (this.map.getZoom() < minZoom) {
-      this.map.setZoom(minZoom);
-    }
   };
 
   MoulinetteMap.prototype.registerEvents = function() {
@@ -136,7 +130,7 @@
     const latLng = [coordinates[1], coordinates[0]];
 
     // When an address is selected, place a marker and zoom on it
-    moulinetteMap.setMarkerPosition(latLng);
-    moulinetteMap.setMinZoom(19);
+    let minZoomLevel = 15;
+    moulinetteMap.setMarkerPosition(latLng, minZoomLevel);
   });
 })();

--- a/envergo/static/js/libs/moulinette_map.js
+++ b/envergo/static/js/libs/moulinette_map.js
@@ -130,7 +130,7 @@
     const latLng = [coordinates[1], coordinates[0]];
 
     // When an address is selected, place a marker and zoom on it
-    let minZoomLevel = 15;
-    moulinetteMap.setMarkerPosition(latLng, minZoomLevel);
+    let zoomLevel = 19;
+    moulinetteMap.setMarkerPosition(latLng, zoomLevel);
   });
 })();

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -123,6 +123,10 @@ $red: #b94a48;
       margin-right: .25rem;
     }
   }
+
+  #form-group-address .optional-tag {
+    display: none;
+  }
 }
 
 section.regulation {

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -208,10 +208,6 @@ form {
     }
   }
 
-  .fr-input-group.required>.fr-label .label-content:after {
-    content: " *";
-  }
-
   .formset {
 
     &+.formset {

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -108,6 +108,23 @@ $red: #b94a48;
   }
 }
 
+#moulinette-form {
+
+  counter-reset: steps;
+
+  label.step,
+  label[for=id_address] {
+
+    &::before {
+      counter-increment: steps;
+      content: counter(steps) " ";
+      font-size: 2rem;
+      font-weight: bold;
+      margin-right: .25rem;
+    }
+  }
+}
+
 section.regulation {
 
   .alt>ul,

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -229,6 +229,11 @@ form {
     }
   }
 
+  i.optional-tag {
+    font-size: 0.75rem;
+    color: var(--text-mention-grey);
+  }
+
   .formset {
 
     &+.formset {

--- a/envergo/templates/_dropzone_snippet.html
+++ b/envergo/templates/_dropzone_snippet.html
@@ -2,12 +2,7 @@
 
 <div id="form-group-{{ field.name }}" class="fr-input-group{% if field.field.required %} required{% endif %}{% if field.errors %} fr-input-group--error{% endif %}">
 
-  <label class="fr-label" for="{{ field.id_for_label }}">
-    <span class="label-content">{{ field.label }}</span>
-    {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
-    {% endif %}
-  </label>
+  {% include '_label.html' %}
 
   <div id="dropzone-previews" class="dropzone-previews">
     <div class="dz-default dz-message">

--- a/envergo/templates/_field_snippet.html
+++ b/envergo/templates/_field_snippet.html
@@ -2,17 +2,7 @@
 
 <div id="form-group-{{ field.name }}" class="fr-input-group{% if field.field.required %} required{% endif %}{% if field.errors %} fr-input-group--error{% endif %}">
 
-  <label class="fr-label" for="{{ field.id_for_label }}">
-    <span class="label-content">
-      {{ field.label }}
-      {% if not field.field.required %}
-        <i class="fr-text--light">– facultatif</i>
-      {% endif %}
-    </span>
-    {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
-    {% endif %}
-  </label>
+  {% include '_label.html' %}
 
   {% if nest_field_class %}
     <div class="{{ nest_field_class }}">
@@ -27,7 +17,6 @@
   {% if nest_field_class %}
     </div>
   {% endif %}
-
 
   {% if field.errors %}
     <p class="fr-error-text">

--- a/envergo/templates/_field_snippet.html
+++ b/envergo/templates/_field_snippet.html
@@ -3,7 +3,12 @@
 <div id="form-group-{{ field.name }}" class="fr-input-group{% if field.field.required %} required{% endif %}{% if field.errors %} fr-input-group--error{% endif %}">
 
   <label class="fr-label" for="{{ field.id_for_label }}">
-    <span class="label-content">{{ field.label }}</span>
+    <span class="label-content">
+      {{ field.label }}
+      {% if not field.field.required %}
+        <i class="fr-text--light">– facultatif</i>
+      {% endif %}
+    </span>
     {% if field.help_text %}
       <span class="fr-hint-text">{{ field.help_text|safe }}</span>
     {% endif %}

--- a/envergo/templates/_input_file_snippet.html
+++ b/envergo/templates/_input_file_snippet.html
@@ -2,12 +2,7 @@
 
 <div id="form-group-{{ field.name }}" class="fr-input-group{% if field.field.required %} required{% endif %}{% if field.errors %} fr-input-group--error{% endif %}">
 
-  <label class="fr-label" for="{{ field.id_for_label }}">
-    <span class="label-content">{{ field.label }}</span>
-    {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
-    {% endif %}
-  </label>
+  {% include '_label.html' %}
 
   <div class="input-file-box">
 

--- a/envergo/templates/_label.html
+++ b/envergo/templates/_label.html
@@ -2,7 +2,7 @@
   <span class="label-content">
     {{ field.label }}
     {% if not field.field.required %}
-      <i class="fr-text--light">– facultatif</i>
+      <i class="fr-text--light optional-tag">– facultatif</i>
     {% endif %}
   </span>
   {% if field.help_text %}

--- a/envergo/templates/_label.html
+++ b/envergo/templates/_label.html
@@ -1,0 +1,11 @@
+<label class="fr-label" for="{{ field.id_for_label }}">
+  <span class="label-content">
+    {{ field.label }}
+    {% if not field.field.required %}
+      <i class="fr-text--light">– facultatif</i>
+    {% endif %}
+  </span>
+  {% if field.help_text %}
+    <span class="fr-hint-text">{{ field.help_text|safe }}</span>
+  {% endif %}
+</label>

--- a/envergo/templates/moulinette/_form.html
+++ b/envergo/templates/moulinette/_form.html
@@ -5,7 +5,7 @@
 
   {% include '_form_header.html' with form=form %}
 
-  {% if additional_forms %}
+  {% if additional_forms and moulinette.has_missing_data %}
     <div class="fr-alert fr-alert--warning fr-mb-3w">
       <p class="fr-alert__title">
         Question(s) complémentaire(s)

--- a/envergo/templates/moulinette/_form.html
+++ b/envergo/templates/moulinette/_form.html
@@ -21,19 +21,17 @@
     {{ form.lng.as_hidden }}
     {{ form.lat.as_hidden }}
 
-    <label>
-      Saisissez une adresse, déplacez le marqueur ou double-cliquez pour indiquer
-      l'emplacement de votre projet.
+    {% include '_field_snippet.html' with field=form.address %}
+
+    <label class="step">
+      Double-cliquez ou déplacez le marqueur sur la carte pour ajuster
+      l'emplacement du projet.
     </label>
 
     <div class="ratio-4x3 fr-mt-1w fr-mb-2w">
       <div class="ratio-content">
         <div class="leaflet-container">
-          <div class="search-control">
-            {{ form.address }}
-          </div>
-          <div id="map">
-          </div>
+          <div id="map"></div>
         </div>
       </div>
     </div>
@@ -47,6 +45,10 @@
 
     {% endif %}
 
+  </div>
+
+  <div class="fr-mb-3w">
+    <label class="step">Complétez les informations décrivant le projet</label>
   </div>
 
   {% include '_field_snippet.html' with field=form.created_surface %}

--- a/envergo/templates/moulinette/_form.html
+++ b/envergo/templates/moulinette/_form.html
@@ -5,6 +5,17 @@
 
   {% include '_form_header.html' with form=form %}
 
+  {% if additional_forms %}
+    <div class="fr-alert fr-alert--warning fr-mb-3w">
+      <p class="fr-alert__title">
+        Question(s) complémentaire(s)
+      </p>
+      <p>
+        À compléter en bas du formulaire 👇
+      </p>
+    </div>
+  {% endif %}
+
   <div id="form-group-coords" class="fr-input-group">
 
     {{ form.lng.as_hidden }}

--- a/envergo/templates/moulinette/home.html
+++ b/envergo/templates/moulinette/home.html
@@ -5,8 +5,7 @@
 
 {% block result %}
 
-  <h1>Natura 2000, Loi sur l'eau… Évaluez à quelles réglementations votre
-    projet de construction est soumis</h1>
+  <h1>Natura 2000, Loi sur l'eau… Évaluez à quelles réglementations votre projet de construction est soumis</h1>
 
   <p>Un projet qui découvre qu'il est soumis à une procédure en plus du permis de construire, c'est jusqu'à :
   </p>

--- a/envergo/templates/moulinette/result_debug.html
+++ b/envergo/templates/moulinette/result_debug.html
@@ -22,6 +22,17 @@
       {% endfor %}
     </ul>
 
+    <h2>Zones</h2>
+
+    <ul>
+      {% for zone in moulinette.get_zones %}
+        <li><a href="{% url 'admin:geodata_zone_change' zone.id %}">
+          {{ zone.id }}
+          ({{ zone.map.perimeters.all|join:', ' }})
+        </a></li>
+      {% endfor %}
+    </ul>
+
     <h2>Résultat</h2>
 
     {% for regulation in moulinette.regulations %}

--- a/envergo/templates/moulinette/result_debug.html
+++ b/envergo/templates/moulinette/result_debug.html
@@ -27,8 +27,8 @@
     <ul>
       {% for zone in moulinette.get_zones %}
         <li><a href="{% url 'admin:geodata_zone_change' zone.id %}">
-          {{ zone.id }}
-          ({{ zone.map.perimeters.all|join:', ' }})
+          {{ zone.map }} ({{ zone.id }}) —
+          {{ zone.map.perimeters.all|join:', ' }}
         </a></li>
       {% endfor %}
     </ul>

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -650,7 +650,7 @@ msgstr "Surface au sol impactée avant le projet"
 
 #: envergo/moulinette/forms.py:19
 msgid "Search for the address to center the map"
-msgstr "Recherchez une adresse pour centrer la carte"
+msgstr "Saisissez l'adresse ou la commune la plus proche du projet"
 
 #: envergo/moulinette/forms.py:24
 msgid "Longitude"


### PR DESCRIPTION
Dans les formulaires, on supprime les « * » pour indiquer les champs obligatoires. En revanche, on mentionne explicitement les champs optionnels.