### PR TITLE
Exclue les visites de bots des stats moulinette

### DIFF
--- a/envergo/analytics/utils.py
+++ b/envergo/analytics/utils.py
@@ -1,6 +1,49 @@
+import logging
+import socket
+
 from django.conf import settings
 
 from envergo.analytics.models import Event
+
+logger = logging.getLogger(__name__)
+
+
+def is_request_from_a_bot(request):
+    """Check that the requests comes certain domains identified as bots.
+
+    We perform a reverse dns lookup of the user agent ip, and compare it
+    against known domain origin for bots.
+
+    """
+
+    bot_domains = [
+        "googlebot.com",
+        "search.msn.com",
+        "search.qwant.com",
+        "amazonaws.com",  # Trello preview bot, among others
+        "vultrusercontent.com",  # Updown.io
+        "compute.outscale.com",  # Mattermost
+    ]
+
+    request_ip = request.META.get("HTTP_X_REAL_IP", None)
+    if request_ip is None:
+        return False
+
+    # Find domain corresponding to ip
+    socket.setdefaulttimeout(3)
+    try:
+        host = socket.gethostbyaddr(request_ip)[0]
+    except OSError:
+        return False
+
+    logger.info(f"Request from ip {request_ip}, found matching domain {host}")
+
+    # Does the request's domain matches a known bot domain?
+    for bot_domain in bot_domains:
+        if host.endswith(bot_domain):
+            return True
+
+    return False
 
 
 def log_event(category, event, request, **kwargs):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseRedirect, QueryDict
 from django.urls import reverse
 from django.views.generic import FormView
 
-from envergo.analytics.utils import log_event
+from envergo.analytics.utils import is_request_from_a_bot, log_event
 from envergo.evaluations.models import RESULTS
 from envergo.moulinette.forms import MoulinetteForm
 from envergo.moulinette.models import Moulinette
@@ -171,7 +171,9 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             if moulinette.is_evaluation_available():
                 export["result"] = moulinette.result()
 
-            log_event("simulateur", "soumission", request, **export)
+            if not is_request_from_a_bot(request):
+                log_event("simulateur", "soumission", request, **export)
+
             return res
         else:
             return HttpResponseRedirect(reverse("moulinette_home"))


### PR DESCRIPTION
On essaye de détecter si une requête provient d'un bot identifié, auquel cas on évite de logguer la requête.