### PR TITLE
Log des événements liés au processus de sélection d'emplacement du projet simulateur

### DIFF
--- a/envergo/static/js/libs/address_autocomplete.js
+++ b/envergo/static/js/libs/address_autocomplete.js
@@ -116,6 +116,8 @@
           .then((response) => response.json())
           .then(({ features }) => {
             populateResults(features);
+            const event = new CustomEvent('EnvErgo:address_autocomplete_populated', { detail: features });
+            window.dispatchEvent(event);
           })
           .catch((error) => console.log(error));
       }

--- a/envergo/static/js/libs/map_widget_events.js
+++ b/envergo/static/js/libs/map_widget_events.js
@@ -1,0 +1,22 @@
+// Use Matomo API for analytics
+var _paq = window._paq || [];
+
+// Log and event when a choice is selected in the address autocomplete widget
+window.addEventListener('EnvErgo:citycode_selected', function() {
+  _paq.push(['trackEvent', 'Form', 'Address', 'Confirm']);
+}, { once: true });
+
+// Log an event when the address autocomplete widget is used
+window.addEventListener('EnvErgo:address_autocomplete_populated', function(evt) {
+  _paq.push(['trackEvent', 'Form', 'Address', 'Type']);
+}, { once: true });
+
+// Log an event when the map widget marker is moved
+window.addEventListener('EnvErgo:map_marker_moved', function(evt) {
+  _paq.push(['trackEvent', 'Form', 'Marker', 'Moved']);
+}, { once: true });
+
+// Log an event when the map is double-clicked
+window.addEventListener('EnvErgo:map_dbl_clicked', function(evt) {
+  _paq.push(['trackEvent', 'Form', 'Map', 'DblClicked']);
+}, { once: true });

--- a/envergo/static/js/libs/moulinette_map.js
+++ b/envergo/static/js/libs/moulinette_map.js
@@ -68,6 +68,9 @@
 
     this.marker.setLatLng(latLng);
     this.map.setView(latLng, zoomLevel);
+
+    const event = new CustomEvent('EnvErgo:map_marker_moved', { detail: latLng });
+    window.dispatchEvent(event);
   };
 
   MoulinetteMap.prototype.setFieldValue = function(latLng) {
@@ -84,9 +87,14 @@
      * (instead of the classic "zooming" behaviour.
      */
     this.map.on('dblclick', function(event) {
+
       L.DomEvent.preventDefault(event);
       const latLng = event.latlng;
       this.setMarkerPosition(latLng);
+
+      const newEvent = new CustomEvent('EnvErgo:map_dbl_clicked', { detail: latLng });
+      window.dispatchEvent(newEvent);
+
     }.bind(this));
 
     /**

--- a/envergo/templates/moulinette/_form_scripts.html
+++ b/envergo/templates/moulinette/_form_scripts.html
@@ -15,3 +15,4 @@
 <script defer src="{% static 'js/libs/address_autocomplete.js' %}"></script>
 <script defer src="{% static 'js/libs/moulinette_map.js' %}"></script>
 <script defer src="{% static 'js/libs/feedback_form.js' %}"></script>
+<script defer src="{% static 'js/libs/map_widget_events.js' %}"></script>


### PR DESCRIPTION
On veut savoir comment est utilisé le widget de sélection d'emplacement du projet (widget d'autocomplétion d'adresse + carte). On envoie donc des événements Matomo.