### PR TITLE
Retente les notifications mattermost échouées

### DIFF
--- a/envergo/evaluations/tasks.py
+++ b/envergo/evaluations/tasks.py
@@ -14,7 +14,7 @@ from envergo.utils.mattermost import notify
 logger = logging.getLogger(__name__)
 
 
-@app.task
+@app.task(autoretry_for=(Exception,))
 def confirm_request_to_admin(request_id, host):
     """Send a Mattermost notification to confirm the evaluation request."""
 

--- a/envergo/utils/mattermost.py
+++ b/envergo/utils/mattermost.py
@@ -14,7 +14,10 @@ def notify(msg):
     endpoint = settings.MATTERMOST_ENDPOINT
     if endpoint:
         payload = {"text": msg}
-        requests.post(endpoint, json=payload)
+        r = requests.post(endpoint, json=payload)
+
+        # Make sure we get an error if the notification failed
+        r.raise_for_status()
     else:
         logger.warning(
             f"No mattermost endpoint configured. Doing nothing. Message: {msg}"


### PR DESCRIPTION
Configure Celery pour retenter les notifications Mattermost ayant échoué.