### PR TITLE
Force les couleurs des polygones des zones humides

### DIFF
--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -150,7 +150,7 @@ class ZoneHumide(MoulinetteCriterion):
                 {
                     "polygon": potentials_polygon,
                     "color": LIGHTBLUE,
-                    "label": "ZH potentielle",
+                    "label": "Zone humide potentielle",
                 },
             ]
             wetlands_maps = [zone.map for zone in close_qs.select_related("map")]

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -167,7 +167,7 @@ class ZoneHumide(MoulinetteCriterion):
                     "polygon": geometries.aggregate(polygon=Union(F("geom")))[
                         "polygon"
                     ],
-                    "color": "dodgerblue",
+                    "color": LIGHTBLUE,
                     "label": "Zone humide potentielle",
                 }
             ]

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -11,6 +11,9 @@ from envergo.moulinette.regulations import (
     MoulinetteRegulation,
 )
 
+BLUE = "#0000FF"
+LIGHTBLUE = "#00BFFF"
+
 
 class ZoneHumide(MoulinetteCriterion):
     slug = "zone_humide"
@@ -110,7 +113,7 @@ class ZoneHumide(MoulinetteCriterion):
                     "polygon": geometries.aggregate(polygon=Union(F("geom")))[
                         "polygon"
                     ],
-                    "color": "blue",
+                    "color": BLUE,
                     "label": "Zone humide",
                 }
             ]
@@ -124,7 +127,7 @@ class ZoneHumide(MoulinetteCriterion):
                     "polygon": geometries.aggregate(polygon=Union(F("geom")))[
                         "polygon"
                     ],
-                    "color": "blue",
+                    "color": BLUE,
                     "label": "Zone humide",
                 }
             ]
@@ -143,10 +146,10 @@ class ZoneHumide(MoulinetteCriterion):
             ]
 
             polygons = [
-                {"polygon": wetlands_polygon, "color": "blue", "label": "Zone humide"},
+                {"polygon": wetlands_polygon, "color": BLUE, "label": "Zone humide"},
                 {
                     "polygon": potentials_polygon,
-                    "color": "lightblue",
+                    "color": LIGHTBLUE,
                     "label": "ZH potentielle",
                 },
             ]

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -175,7 +175,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             if moulinette.is_evaluation_available():
                 export["result"] = moulinette.result()
 
-            if not is_request_from_a_bot(request):
+            if not (moulinette.has_missing_data() or is_request_from_a_bot(request)):
                 log_event("simulateur", "soumission", request, **export)
 
             return res


### PR DESCRIPTION
Le nommage des couleurs par mots clés (`blue`, `lightblue`) semble produire des incohérences entre navigateurs.