### PR TITLE
ZH : tenir compte de surface créée uniquement

### DIFF
--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -46,9 +46,9 @@ class ZoneHumide(MoulinetteCriterion):
         else:
             wetland_status = "outside"
 
-        if self.catalog["project_surface"] >= 1000:
+        if self.catalog["created_surface"] >= 1000:
             project_size = "big"
-        elif self.catalog["project_surface"] >= 700:
+        elif self.catalog["created_surface"] >= 700:
             project_size = "medium"
         else:
             project_size = "small"

--- a/envergo/moulinette/tests/test_models.py
+++ b/envergo/moulinette/tests/test_models.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(autouse=True)
-def loisurleau_criterions(france_map):
+def loisurleau_criterions(france_map):  # noqa
 
     classes = [
         "envergo.moulinette.regulations.loisurleau.ZoneHumide",


### PR DESCRIPTION
Modifie le mode de calcul du critère `Loi sur l'eau > Zone Humide` pour ne prendre en compte que la surface créée.