### PR TITLE
Affiche les polygones fusionnés sur la carte

### DIFF
--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 
 import requests
 from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.utils.layermapping import LayerMapping
 from django.core.serializers import serialize
 from django.db.models import QuerySet
@@ -179,3 +180,13 @@ def get_commune_from_coords(lng, lat, timeout=0.5):
         pass
 
     return data["nom"] if data else None
+
+
+def merge_geometries(polygons):
+    """Return a single polygon that is the fusion of the given polygons."""
+
+    merged = GEOSGeometry("POLYGON EMPTY", srid=4326)
+    for polygon in polygons:
+        merged = merged.union(polygon)
+
+    return merged

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -77,7 +77,8 @@ class MoulinetteRegulation:
 @dataclass
 class MapPolygon:
     """Data that can be displayed and labeled on a leaflet map as a polygon."""
-    perimeters: list  # List of `envergo.geofr.Perimeter` objects
+
+    perimeters: list  # List of `envergo.geofr.Perimeter` objects
     color: str
     label: str
 
@@ -96,6 +97,7 @@ class MapPolygon:
 @dataclass
 class Map:
     """Data for a map that will be displayed with Leaflet."""
+
     center: tuple  # Coordinates to center the map
     entries: list  # List of `MapPolygon` objects
     caption: str  # Legend displayed below the map

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -1,8 +1,9 @@
 import json
+from dataclasses import dataclass
 from functools import cached_property
 
 from envergo.evaluations.models import RESULTS
-from envergo.geodata.utils import to_geojson
+from envergo.geodata.utils import merge_geometries, to_geojson
 
 
 class MoulinetteRegulation:
@@ -73,21 +74,33 @@ class MoulinetteRegulation:
         return None
 
 
+@dataclass
+class MapPolygon:
+    """Data that can be displayed and labeled on a leaflet map as a polygon."""
+    perimeters: list  # List of `envergo.geofr.Perimeter` objects
+    color: str
+    label: str
+
+    @property
+    def geometry(self):
+        geometries = [p.geometry for p in self.perimeters]
+        merged_geometry = merge_geometries(geometries)
+        return merged_geometry
+
+    @property
+    def maps(self):
+        perimeter_maps = [p.map for p in self.perimeters]
+        return perimeter_maps
+
+
+@dataclass
 class Map:
     """Data for a map that will be displayed with Leaflet."""
-
-    def __init__(self, center, polygons, caption, sources, truncate=True, zoom=16):
-        self.center = center
-        self.polygons = polygons
-        self.caption = caption
-        self.sources = sources
-        self.zoom = zoom
-
-        # Should we display the entire region?
-        # This is used to prevent the ability to fine tune one's project and
-        # get around the law by building a project at the exact limit of a
-        # given zone.
-        self.truncate = truncate
+    center: tuple  # Coordinates to center the map
+    entries: list  # List of `MapPolygon` objects
+    caption: str  # Legend displayed below the map
+    truncate: bool = True  # Should the displayed polygons be truncated?
+    zoom: int = 16  # the map zoom to pass to leaflet
 
     def to_json(self):
 
@@ -102,14 +115,14 @@ class Map:
                 "polygons": [
                     {
                         "polygon": to_geojson(
-                            polygon["polygon"].buffer(0).intersection(buffer)
+                            entry.geometry.buffer(0).intersection(buffer)
                         )
                         if self.truncate
-                        else to_geojson(polygon["polygon"].buffer(0)),
-                        "color": polygon["color"],
-                        "label": polygon["label"],
+                        else to_geojson(entry.geometry.buffer(0)),
+                        "color": entry.color,
+                        "label": entry.label,
                     }
-                    for polygon in self.polygons
+                    for entry in self.entries
                 ],
                 "caption": self.caption,
                 "sources": [
@@ -118,6 +131,14 @@ class Map:
             }
         )
         return data
+
+    @property
+    def sources(self):
+        maps = set()
+        for entry in self.entries:
+            for map in entry.maps:
+                maps.add(map)
+        return maps
 
 
 class MoulinetteCriterion:

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -5,6 +5,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from envergo.evaluations.models import RESULTS
 from envergo.moulinette.regulations import (
     Map,
+    MapPolygon,
     MoulinetteCriterion,
     MoulinetteRegulation,
 )
@@ -106,82 +107,33 @@ class ZoneHumide(MoulinetteCriterion):
             for zone in self.catalog["potential_wetlands"]
             if zone.map.display_for_user
         ]
-        polygons = None
+        map_polygons = None
 
         if inside_qs:
             caption = "Le projet se situe dans une zone humide référencée."
-            polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in inside_qs:
-                polygon = polygon.union(zone.geom)
-
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": BLUE,
-                    "label": "Zone humide",
-                }
-            ]
-            maps = set([zone.map for zone in inside_qs])
+            map_polygons = [MapPolygon(inside_qs, BLUE, "Zone humide")]
 
         elif close_qs and not potential_qs:
             caption = "Le projet se situe à proximité d'une zone humide référencée."
-            polygon = GEOSGeometry("POLYGON EMPTY")
-            for zone in close_qs:
-                polygon = polygon.union(zone.geom)
-
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": BLUE,
-                    "label": "Zone humide",
-                }
-            ]
-            maps = set([zone.map for zone in close_qs])
+            map_polygons = [MapPolygon(close_qs, BLUE, "Zone humide")]
 
         elif close_qs and potential_qs:
             caption = "Le projet se situe à proximité d'une zone humide référencée et dans une zone humide potentielle."
-
-            wetlands_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in close_qs:
-                wetlands_polygon = wetlands_polygon.union(zone.geom)
-
-            potentials_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in potential_qs:
-                potentials_polygon = potentials_polygon.union(zone.geom)
-
-            polygons = [
-                {"polygon": wetlands_polygon, "color": BLUE, "label": "Zone humide"},
-                {
-                    "polygon": potentials_polygon,
-                    "color": LIGHTBLUE,
-                    "label": "Zone humide potentielle",
-                },
+            map_polygons = [
+                MapPolygon(close_qs, BLUE, "Zone humide"),
+                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle"),
             ]
-            wetlands_maps = [zone.map for zone in close_qs]
-            potential_maps = [zone.map for zone in potential_qs]
-            maps = set(wetlands_maps + potential_maps)
 
         elif potential_qs:
             caption = "Le projet se situe dans une zone humide potentielle."
-            potentials_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in potential_qs:
-                potentials_polygon = potentials_polygon.union(zone.geom)
+            map_polygons = [MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")]
 
-            polygons = [
-                {
-                    "polygon": potentials_polygon,
-                    "color": LIGHTBLUE,
-                    "label": "Zone humide potentielle",
-                }
-            ]
-            maps = set([zone.map for zone in potential_qs])
-
-        if polygons:
-            criterion_map = Map(
+        if map_polygons:
+             criterion_map = Map(
                 center=self.catalog["coords"],
-                polygons=polygons,
+                entries=map_polygons,
                 caption=caption,
-                sources=maps,
+                truncate=False,
             )
         else:
             criterion_map = None
@@ -234,31 +186,18 @@ class ZoneInondable(MoulinetteCriterion):
         return result
 
     def _get_map(self):
-        polygons = None
         zone_qs = [
             zone for zone in self.catalog["flood_zones_12"] if zone.map.display_for_user
         ]
-        polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-        for zone in zone_qs:
-            polygon = polygon.union(zone.geom)
 
         if zone_qs:
             caption = "Le projet se situe dans une zone inondable."
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": "red",
-                    "label": "Zone inondable",
-                }
-            ]
-            maps = set([zone.map for zone in zone_qs])
-
-        if polygons:
+            map_polygons = [MapPolygon(zone_qs, "red", "Zone inondable")]
             criterion_map = Map(
                 center=self.catalog["coords"],
-                polygons=polygons,
+                entries=map_polygons,
                 caption=caption,
-                sources=maps,
+                truncate=False,
             )
         else:
             criterion_map = None

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -126,10 +126,12 @@ class ZoneHumide(MoulinetteCriterion):
 
         elif potential_qs:
             caption = "Le projet se situe dans une zone humide potentielle."
-            map_polygons = [MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")]
+            map_polygons = [
+                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
+            ]
 
         if map_polygons:
-             criterion_map = Map(
+            criterion_map = Map(
                 center=self.catalog["coords"],
                 entries=map_polygons,
                 caption=caption,

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -1,7 +1,5 @@
 from functools import cached_property
 
-from django.contrib.gis.geos import GEOSGeometry
-
 from envergo.evaluations.models import RESULTS
 from envergo.moulinette.regulations import (
     Map,

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -103,82 +103,33 @@ class ZoneHumide44(MoulinetteCriterion):
             for zone in self.catalog["potential_wetlands"]
             if zone.map.display_for_user
         ]
-        polygons = None
+        map_polygons = None
 
         if inside_qs:
             caption = "Le projet se situe dans une zone humide référencée."
-            polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in inside_qs:
-                polygon = polygon.union(zone.geom)
-
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": BLUE,
-                    "label": "Zone humide",
-                }
-            ]
-            maps = set([zone.map for zone in inside_qs])
+            map_polygons = [MapPolygon(inside_qs, BLUE, "Zone humide")]
 
         elif close_qs and not potential_qs:
             caption = "Le projet se situe à proximité d'une zone humide référencée."
-            polygon = GEOSGeometry("POLYGON EMPTY")
-            for zone in close_qs:
-                polygon = polygon.union(zone.geom)
-
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": BLUE,
-                    "label": "Zone humide",
-                }
-            ]
-            maps = set([zone.map for zone in close_qs])
+            map_polygons = [MapPolygon(close_qs, BLUE, "Zone humide")]
 
         elif close_qs and potential_qs:
             caption = "Le projet se situe à proximité d'une zone humide référencée et dans une zone humide potentielle."
-
-            wetlands_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in close_qs:
-                wetlands_polygon = wetlands_polygon.union(zone.geom)
-
-            potentials_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in potential_qs:
-                potentials_polygon = potentials_polygon.union(zone.geom)
-
-            polygons = [
-                {"polygon": wetlands_polygon, "color": BLUE, "label": "Zone humide"},
-                {
-                    "polygon": potentials_polygon,
-                    "color": LIGHTBLUE,
-                    "label": "Zone humide potentielle",
-                },
+            map_polygons = [
+                MapPolygon(close_qs, BLUE, "Zone humide"),
+                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle"),
             ]
-            wetlands_maps = [zone.map for zone in close_qs]
-            potential_maps = [zone.map for zone in potential_qs]
-            maps = set(wetlands_maps + potential_maps)
 
         elif potential_qs:
             caption = "Le projet se situe dans une zone humide potentielle."
-            potentials_polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-            for zone in potential_qs:
-                potentials_polygon = potentials_polygon.union(zone.geom)
+            map_polygons = [MapPolygon(potential_qs, "dodgerblue", "Zone humide potentielle")]
 
-            polygons = [
-                {
-                    "polygon": potentials_polygon,
-                    "color": "dodgerblue",
-                    "label": "Zone humide potentielle",
-                }
-            ]
-            maps = set([zone.map for zone in potential_qs])
-
-        if polygons:
-            criterion_map = Map(
+        if map_polygons:
+             criterion_map = Map(
                 center=self.catalog["coords"],
-                polygons=polygons,
+                entries=map_polygons,
                 caption=caption,
-                sources=maps,
+                truncate=False,
             )
         else:
             criterion_map = None
@@ -227,31 +178,18 @@ class ZoneInondable44(MoulinetteCriterion):
         return result
 
     def _get_map(self):
-        polygons = None
         zone_qs = [
             zone for zone in self.catalog["flood_zones_12"] if zone.map.display_for_user
         ]
-        polygon = GEOSGeometry("POLYGON EMPTY", srid=4326)
-        for zone in zone_qs:
-            polygon = polygon.union(zone.geom)
 
         if zone_qs:
             caption = "Le projet se situe dans une zone inondable."
-            polygons = [
-                {
-                    "polygon": polygon,
-                    "color": "red",
-                    "label": "Zone inondable",
-                }
-            ]
-            maps = set([zone.map for zone in zone_qs])
-
-        if polygons:
+            map_polygons = [MapPolygon(zone_qs, "red", "Zone inondable")]
             criterion_map = Map(
                 center=self.catalog["coords"],
-                polygons=polygons,
+                entries=map_polygons,
                 caption=caption,
-                sources=maps,
+                truncate=False,
             )
         else:
             criterion_map = None

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -122,10 +122,12 @@ class ZoneHumide44(MoulinetteCriterion):
 
         elif potential_qs:
             caption = "Le projet se situe dans une zone humide potentielle."
-            map_polygons = [MapPolygon(potential_qs, "dodgerblue", "Zone humide potentielle")]
+            map_polygons = [
+                MapPolygon(potential_qs, "dodgerblue", "Zone humide potentielle")
+            ]
 
         if map_polygons:
-             criterion_map = Map(
+            criterion_map = Map(
                 center=self.catalog["coords"],
                 entries=map_polygons,
                 caption=caption,
@@ -303,11 +305,15 @@ class Natura2000(MoulinetteRegulation):
             return None
 
         # Let's find the first perimeter with a map that we can display
-        perimeters = [p for p in self.moulinette.perimeters if p.criterion in self.criterion_classes and not p.criterion == IOTA]
+        perimeters = [
+            p
+            for p in self.moulinette.perimeters
+            if p.criterion in self.criterion_classes and not p.criterion == IOTA
+        ]
         if not perimeters:
             return None
 
-        map_polygons = [MapPolygon(perimeters, 'green', 'Site Natura 2000')]
+        map_polygons = [MapPolygon(perimeters, "green", "Site Natura 2000")]
 
         if self.get_distance_to_n2000() <= 0.0:
             caption = "Le projet se situe sur un site Natura 2000."

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -1,7 +1,6 @@
 from functools import cached_property
 
 from django import forms
-from django.contrib.gis.geos import GEOSGeometry
 from django.utils.translation import gettext_lazy as _
 
 from envergo.evaluations.models import RESULTS

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from envergo.evaluations.models import RESULTS
 from envergo.moulinette.regulations import (
     Map,
+    MapPolygon,
     MoulinetteCriterion,
     MoulinetteRegulation,
 )
@@ -364,25 +365,11 @@ class Natura2000(MoulinetteRegulation):
             return None
 
         # Let's find the first perimeter with a map that we can display
-        perimeter = next(
-            (
-                p
-                for p in self.moulinette.perimeters
-                if p.criterion in self.criterion_classes and not p.criterion == IOTA
-            ),
-            None,
-        )
-        if not perimeter:
+        perimeters = [p for p in self.moulinette.perimeters if p.criterion in self.criterion_classes and not p.criterion == IOTA]
+        if not perimeters:
             return None
 
-        polygons = [
-            {
-                "polygon": perimeter.geometry,
-                "color": "green",
-                "label": "Site Natura 2000",
-            }
-        ]
-        maps = [perimeter.map]
+        map_polygons = [MapPolygon(perimeters, 'green', 'Site Natura 2000')]
 
         if self.get_distance_to_n2000() <= 0.0:
             caption = "Le projet se situe sur un site Natura 2000."
@@ -394,9 +381,8 @@ class Natura2000(MoulinetteRegulation):
 
         map = Map(
             center=self.catalog["coords"],
-            polygons=polygons,
+            entries=map_polygons,
             caption=caption,
-            sources=maps[:1],
             truncate=False,
             zoom=15,
         )

--- a/envergo/templates/evaluations/detail/moulinette.html
+++ b/envergo/templates/evaluations/detail/moulinette.html
@@ -51,7 +51,7 @@
   {% endfor %}
 
   <div class="fr-alert fr-alert--info fr-my-5w">
-    <p>EnvErgo est un service du ministère de la transition écologique. Il vise à aider les acteurs de l'aménagement en phase amont de leurs projets.</p>
+    <p>EnvErgo est un service du Ministère de la Transition Écologique. Il vise à aider les acteurs de l'aménagement en phase amont de leurs projets.</p>
     <p><i>Les avis rendus ne valent pas position de l'administration</i>. Ils ne couvrent pas l'exhaustivité des réglementations spécifiques à certains projets.</p>
   </div>
 


### PR DESCRIPTION
Dans le simulateur, un critère correspond parfois à plusieurs polygones sur une carte, et on n'en affichait qu'un seul.

On calcule aujourd'hui l'union de tous les polygones possibles avant de les affiches sur les cartes des résultats de critères.