### PR TITLE
Update loi_sur_leau.html

### DIFF
--- a/envergo/templates/pages/faq/loi_sur_leau.html
+++ b/envergo/templates/pages/faq/loi_sur_leau.html
@@ -274,14 +274,6 @@
         </button>
       </h3>
       <div class="fr-collapse" id="accordion-consequences_omission">
-        <p class="fr-highlight">
-          <strong>Votre demande de permis de construire peut être rejetée si vous n'avez pas déposé de dossier Loi sur
-          l'eau.</strong>
-        </p>
-        <p>
-          Le service urbanisme qui étudie votre demande est en droit de vous demander des pièces complémentaires, pour
-          déterminer si vous avez ou non déposé un dossier Loi sur l'eau pour votre projet.
-        </p>
         <p>
           Un contrôle par la police de l'eau peut avoir lieu avant, pendant les travaux, ou après la réalisation du
           projet. Une tierce partie (riverain, association, collectivité) peut déclencher un recours auprès de la


### PR DESCRIPTION
Retire la mention erronnée selon laquelle la DAU peut être refusée s'il manque un dossier loi sur l'eau