### PR TITLE
Create the postgis raster extension if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ $ npm install
 $ python manage.py collectstatic
 ```
 
+#### Résoudre l'erreur "raster does not exist"
+
+Dans les versions les plus récentes de postgis, il est nécessaire [d'installer l'extension "raster"](https://docs.djangoproject.com/fr/5.0/ref/contrib/gis/install/postgis/#post-installation).
+Si, lors du `docker-compose up` ci-dessus vous avez ce type d'erreur :
+
+    envergo_postgres  | 2024-05-13 14:35:21.651 UTC [35] ERROR:  type "raster" does not exist at character 118
+
+il vous faudra créer cette extension (dans un autre terminal, avec le `docker-compose up` qui tourne en parallèle) :
+
+```bash
+$ docker-compose run --rm postgres create_raster
+```
+
+puis interrompre et relancer le `docker-compose up`. Les migrations Django devraient alors s'exécuter sans erreur.
+
+
 ### Qualité du code
 
 De nombreux outils sont mis en place pour garantir la qualité et l'homogénéité du code.

--- a/compose/postgres/maintenance/create_raster
+++ b/compose/postgres/maintenance/create_raster
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+
+### Create the postgres RASTER extension.
+###
+### Usage:
+###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres create_raster
+
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+working_dir="$(dirname ${0})"
+source "${working_dir}/_sourced/messages.sh"
+
+
+message_welcome "Creating the postgis raster extension for the '${POSTGRES_DB}' database..."
+
+
+export PGHOST="${POSTGRES_HOST}"
+export PGPORT="${POSTGRES_PORT}"
+export PGUSER="${POSTGRES_USER}"
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+export PGDATABASE="${POSTGRES_DB}"
+
+psql -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+psql -c 'CREATE EXTENSION IF NOT EXISTS postgis_raster;'
+
+
+message_success "Postgis raster extension created for the '${POSTGRES_DB}' database."


### PR DESCRIPTION
Hi there team ;)

When I'm running the `docker-compose up` command on my Apple Silicon, it seems I'm having a newer version of postgis which needs the manual installation of the `raster` extension.

This is a possible fix, let me know if it's of any use, and if you'd like me to update it?

Edit: this doesn't work for tests, I guess it needs the test database to also have the extension created. Another solution would be to experiment with [CreateExtension](https://docs.djangoproject.com/fr/5.0/ref/contrib/postgres/operations/#django.contrib.postgres.operations.CreateExtension) instead.