### PR TITLE
Synchro du démonstrateur 2150 et du simulateur

### DIFF
--- a/envergo/geodata/views.py
+++ b/envergo/geodata/views.py
@@ -140,11 +140,11 @@ class CatchmentAreaDebug(FormView):
             catchment_area_500 = round(catchment_area / 500) * 500
 
             # Compute values relevant to the moulinette result
-            if catchment_area_500 < 7000:
-                value_action_requise = max(0, 7000 - catchment_area_500)
+            if catchment_area_500 < 9000:
+                value_action_requise = max(0, 9000 - catchment_area_500)
                 value_soumis = 10000
             else:
-                value_action_requise = 1000
+                value_action_requise = 500
                 value_soumis = 10000
 
             context["result_available"] = True

--- a/envergo/templates/geodata/2150_debug.html
+++ b/envergo/templates/geodata/2150_debug.html
@@ -49,10 +49,10 @@
           </span> m²
         </p>
 
-        <h2 class="fr-h4">Ce que le simulateur EnvErgo pourrait répondre</h2>
+        <h2 class="fr-h4">Ce que le simulateur EnvErgo répond</h2>
 
         <p>
-          Pour évaluer si un projet franchit ou non le seuil de 1 ha de la rubrique 2.1.5.0. de la Loi sur l'eau, le simulateur répondrait – selon la surface du projet :
+          Pour évaluer si un projet franchit ou non le seuil de 1 ha de la rubrique 2.1.5.0. de la Loi sur l'eau, le simulateur répond – selon la surface du projet :
         </p>
 
         <ul>
@@ -85,12 +85,11 @@
       {% else %}
         {% if form.is_bound %}
           <h2 class="fr-h4">Département non disponible</h2>
+          <p>Le calcul de bassin versant n'est pas encore disponible dans ce département.</p>
         {% else %}
           <h2 class="fr-h4">Essayez notre démonstrateur</h2>
+          <p>Sélectionnez un point sur la carte et lancez la simulation.</p>
         {% endif %}
-        <p>
-          Le démonstrateur n'est disponible que pour les départements suivants : <a href="{% url '2150_debug' %}?lng=-4.03177&lat=48.38986">Finistère (29)</a> et <a href="{% url '2150_debug' %}?lng=5.63161&lat=45.24054">Isère (38)</a>.
-        </p>
       {% endif %}
 
       {% if debug %}


### PR DESCRIPTION
Le critère « Écoulement avec bassin versant » et le démonstrateur 2150 utilisent les mêmes calculs.