### PR TITLE
Prevent storing project owner details when we should not send him the evaluation

### DIFF
--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -632,6 +632,14 @@ class Request(models.Model):
         )
         return evaluation
 
+    def save(self, *args, **kwargs):
+        # do not store project owner emails and phone if the user does not want to send the eval to the project owner
+        if not self.send_eval_to_project_owner:
+            self.project_owner_emails = []
+            self.project_owner_phone = ""
+
+        super().save(*args, **kwargs)
+
 
 def request_file_format(instance, filename):
     _, extension = splitext(filename)


### PR DESCRIPTION
Fix le bug remonté par Nicolas dans Mattermost :
![image](https://github.com/MTES-MCT/envergo/assets/17543560/62810b48-6815-4a1e-82e8-c82b93e3d863)


@thibault je ne sais pas si la solution de surchargé la méthode `save` du model te convient ? Je sais que certain ne sont pas fan. 