### PR TITLE
Corrige un problème de fonctionnement de la carte quand la page est rendue depuis le cache

### DIFF
--- a/envergo/static/js/libs/moulinette_map.js
+++ b/envergo/static/js/libs/moulinette_map.js
@@ -18,6 +18,7 @@
     this.configureLeaflet();
     this.map = this.initializeMap();
     this.marker = this.initializeMarker();
+    this.initialLatLng = this.marker.getLatLng();
 
     if (this.options.displayMarker) {
       this.marker.addTo(this.map);
@@ -189,6 +190,10 @@
     }.bind(this));
   };
 
+  MoulinetteMap.prototype.reset = function () {
+    this.setMarkerPosition(this.initialLatLng);
+  };
+
 })(this, L, window._paq);
 
 
@@ -206,6 +211,18 @@
       mapType: MAP_TYPE,
     }
     moulinetteMap = new MoulinetteMap(options);
+  });
+
+  window.addEventListener("pageshow", function (event) {
+    // This event occur when the user navigates back, and the page is
+    // rendered from cache.
+    // In that case, we want to display the initial marker position,
+    // so the widget map and the result maps are in sync.
+    // The "pageshow" event fires after the "load" event, so the map is
+    // already initialized.
+    if (event.persisted) {
+      moulinetteMap.reset();
+    }
   });
 
   window.addEventListener('EnvErgo:citycode_selected', function (event) {


### PR DESCRIPTION
https://trello.com/c/yerTb5BB/932-probl%C3%A8me-de-cache-qui-cr%C3%A9e-incoh%C3%A9rence-carto-entre-laffichage-dans-le-formulaire-et-le-r%C3%A9sultat

Si l'utilisateur effectue plusieurs simulations, et qu'il effectue un retour arrière, il récupère la page précédente dans l'état exact dans laquelle il l'a laissée, c'est à dire avec le marquer positionné sur les coordonnées de la simulation suivante.

J'ai fait en sorte qu'en cas de rendu depuis le cache, le marquer soit re-déplacé sur la position initiale correspond à la simulation de la page courante.