### PR TITLE
Fix : le formulaire moulinette peut être soumis quand la page est rendu du cache

### DIFF
--- a/envergo/static/js/libs/form_submit_feedback.js
+++ b/envergo/static/js/libs/form_submit_feedback.js
@@ -9,10 +9,10 @@
   exports.SimulationForm = SimulationForm;
 
   SimulationForm.prototype.init = function () {
-    this.formElt.addEventListener('submit', this.onFormSubmit.bind(this));
+    this.formElt.addEventListener('submit', this.deactivate.bind(this));
   };
 
-  SimulationForm.prototype.onFormSubmit = function (evt) {
+  SimulationForm.prototype.deactivate = function (evt) {
     this.buttonElt.disabled = true;
 
     let textElt = document.createElement('span');
@@ -22,9 +22,35 @@
     this.buttonElt.insertAdjacentElement("afterend", textElt);
   };
 
+  SimulationForm.prototype.activate = function () {
+    this.buttonElt.disabled = false;
+    let textElt = this.formElt.querySelector('.submit-feedback-hint-text');
+    if (textElt) {
+      textElt.remove();
+    }
+  };
+
 })(this);
 
-window.addEventListener('load', function () {
-  const form = document.getElementById(SIMULATION_FORM_ID);
-  new SimulationForm(form).init();
-});
+(function () {
+  let simulationForm;
+
+
+  window.addEventListener('load', function () {
+    const form = document.getElementById(SIMULATION_FORM_ID);
+    simulationForm = new SimulationForm(form);
+    simulationForm.init();
+  });
+
+  window.addEventListener("pageshow", function (event) {
+    // When the form is submitted, we disable the submission button with a
+    // message to make sure the user understands that the form is being
+    // submitted.
+    // When the user navigates back, and the page is rendered from cache,
+    // the button is re-rendered deactivated.
+    // In that case, we need to make sure the form can be submitted again.
+    if (event.persisted && simulationForm) {
+      simulationForm.activate();
+    }
+  });
+})();

--- a/envergo/static/js/libs/moulinette_map.js
+++ b/envergo/static/js/libs/moulinette_map.js
@@ -220,7 +220,7 @@
     // so the widget map and the result maps are in sync.
     // The "pageshow" event fires after the "load" event, so the map is
     // already initialized.
-    if (event.persisted) {
+    if (event.persisted && moulinetteMap) {
       moulinetteMap.reset();
     }
   });


### PR DESCRIPTION
https://trello.com/c/4Z5YqLNo/950-le-retour-sur-la-home-apr%C3%A8s-une-simulation-montre-un-formluaire-bloqu%C3%A9We reactive the form when the page is rendered from cache