### PR TITLE
Tracke les pages de résultat du simulateur avec des urls distinctes

### DIFF
--- a/envergo/moulinette/urls.py
+++ b/envergo/moulinette/urls.py
@@ -38,6 +38,12 @@ urlpatterns = [
                     RedirectView.as_view(pattern_name="moulinette_result"),
                     name="moulinette_missing_data",
                 ),
+                # This is another "fake" url, only for matomo tracking
+                path(
+                    _("debug/"),
+                    RedirectView.as_view(pattern_name="moulinette_result"),
+                    name="moulinette_result_debug",
+                ),
                 path(
                     "<slug:regulation>/",
                     MoulinetteRegulationResult.as_view(),

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -311,8 +311,20 @@ class MoulinetteResult(MoulinetteMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        # Let's build custom uris for better matomo tracking
+        # Depending on the moulinette result, we want to track different uris
+        # as if they were distinct pages.
         current_url = self.request.build_absolute_uri()
         tracked_url = update_qs(current_url, {"mtm_source": "shareBtn"})
+
+        # Url without any query parameters
+        clean_url = self.request.build_absolute_uri(self.request.path)
+        debug_url = self.request.build_absolute_uri(reverse("moulinette_result_debug"))
+        missing_data_url = self.request.build_absolute_uri(
+            reverse("moulinette_missing_data")
+        )
+
         context["current_url"] = tracked_url
         context["envergo_url"] = self.request.build_absolute_uri("/")
 
@@ -336,11 +348,13 @@ class MoulinetteResult(MoulinetteMixin, FormView):
                 .annotate(type=Concat("map__map_type", V("-"), "map__data_type"))
                 .order_by("type", "distance", "map__name")
             )
+            context["matomo_custom_url"] = debug_url
 
-        if moulinette and moulinette.has_missing_data():
-            context["matomo_custom_url"] = self.request.build_absolute_uri(
-                reverse("moulinette_missing_data")
-            )
+        elif moulinette and moulinette.has_missing_data():
+            context["matomo_custom_url"] = missing_data_url
+
+        elif moulinette:
+            context["matomo_custom_url"] = clean_url
 
         if moulinette and moulinette.catalog:
             lng = moulinette.catalog.get("lng")

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -319,7 +319,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         tracked_url = update_qs(current_url, {"mtm_source": "shareBtn"})
 
         # Url without any query parameters
-        clean_url = self.request.build_absolute_uri(self.request.path)
+        stripped_url = self.request.build_absolute_uri(self.request.path)
         debug_url = self.request.build_absolute_uri(reverse("moulinette_result_debug"))
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")
@@ -354,7 +354,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             context["matomo_custom_url"] = missing_data_url
 
         elif moulinette:
-            context["matomo_custom_url"] = clean_url
+            context["matomo_custom_url"] = stripped_url
 
         if moulinette and moulinette.catalog:
             lng = moulinette.catalog.get("lng")

--- a/envergo/templates/base.html
+++ b/envergo/templates/base.html
@@ -54,6 +54,9 @@
       <script>
         var EVENTS_URL = "{% url 'events' %}";
         var CSRF_TOKEN = '{{ csrf_token }}';
+        {% if matomo_custom_url %}
+          var MATOMO_CUSTOM_URL = "{{ matomo_custom_url }}";
+        {% endif %}
       </script>
       {% block extra_js %}{% endblock %}
       {% include '_analytics.html' %}

--- a/envergo/templates/moulinette/missing_data.html
+++ b/envergo/templates/moulinette/missing_data.html
@@ -19,8 +19,3 @@
   </p>
 
 {% endblock %}
-
-{% block extra_js %}
-  {{ block.super }}
-  <script>var MATOMO_CUSTOM_URL = "{{ matomo_custom_url }}";</script>
-{% endblock %}


### PR DESCRIPTION
https://trello.com/c/NzodgW7h/957-mettre-%C3%A0-jour-les-mots-clefs-exclus-dans-matomo

Pour éviter que les différentes pages de résultats du simulateur soient considérées comme des pages différents dans le rapport « pages » de matomo, on tire parti de la fonction `_paq.push(['setCustomUrl', …]);` de matomo, en fabriquant des urls dédiées.

Cela évite d'avoir à spécifier manuellement des paramètres d'url à ignorer dans matomo.