### PR TITLE
[Super Simu] Affiche le champ adresse sur la page résultat

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Le workflow de collaboration git en vigueur est le suivant :
  - sauf en cas de branche triviale et au jugé, les branches doivent passer par une revue de code avant d'être fusionnées
  - la branche `staging` contient du code fonctionnel, mais en cours de validation ; cette branche est déployée automatiquement sur l'environnement de staging permanent
  - Les Pull Requests doivent systématiquement être fusionnées dans `main`, et uniquement après validation complete
- - si la création d'une review app dédiée est jugée trop fastidieuse, une branche de dev peut être fusionnée dans `staging` pour en vaciliter la validation.
+ - si la création d'une review app dédiée est jugée trop fastidieuse, une branche de dev peut être fusionnée dans `staging` pour en faciliter la validation.
  - il est interdit de pusher du code sur `prod` qui ne soit pas déjà dans `main`
  - pour effectuer une mise en prod, on fusionne `main` dans `prod` (fast forward)
  - de façon exceptionnelle, pour déployer un correctif urgemment en prod sans

--- a/envergo/geodata/conftest.py
+++ b/envergo/geodata/conftest.py
@@ -81,24 +81,49 @@ def mock_geo_api_data():
     with patch(
         "envergo.geodata.utils.get_data_from_coords", new=Mock()
     ) as mock_geo_data:
-        mock_geo_data.return_value = {
-            "type": "housenumber",
-            "name": "10 La Pommeraie",
-            "label": "10 La Pommeraie 44140 Montbert",
-            "street": "La Pommeraie",
-            "postcode": "44140",
-            "citycode": "44102",
-            "city": "Montbert",
-            "oldcitycode": None,
-            "oldcity": None,
-            "context": "44, Loire-Atlantique, Pays de la Loire",
-            "importance": 0.47452,
-            "housenumber": "10",
-            "id": "44102_haa6rn_00010",
-            "x": 359347.63,
-            "y": 6670527.5,
-            "distance": 78,
-            "score": 0.9922,
-            "_type": "address",
-        }
+        mock_geo_data.return_value = [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-1.3866392402397603, 47.14711855636099],
+                },
+                "properties": {
+                    "id": "44070000AR0238",
+                    "departmentcode": "44",
+                    "municipalitycode": "070",
+                    "oldmunicipalitycode": "000",
+                    "districtcode": "000",
+                    "section": "AR",
+                    "sheet": "01",
+                    "number": "0238",
+                    "city": "La Haie-Fouassière",
+                    "distance": 11,
+                    "score": 0.9989,
+                    "_type": "parcel",
+                },
+            },
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [-1.386865, 47.146822]},
+                "properties": {
+                    "type": "street",
+                    "name": "Rue du Breil",
+                    "postcode": "44690",
+                    "citycode": "44070",
+                    "city": "La Haie-Fouassière",
+                    "oldcitycode": None,
+                    "oldcity": None,
+                    "context": "44, Loire-Atlantique, Pays de la Loire",
+                    "importance": 0.49222,
+                    "id": "44070_0553",
+                    "x": 367734.49,
+                    "y": 6681070.77,
+                    "label": "Rue du Breil 44690 La Haie-Fouassière",
+                    "distance": 27,
+                    "score": 0.9973,
+                    "_type": "address",
+                },
+            },
+        ]
         yield mock_geo_data

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -224,14 +224,13 @@ def get_address_from_coords(lng, lat, timeout=0.5):
     # try to find the address first, fallback on the parcel if not found to get at least the city and department
     data = get_data_from_coords(lng, lat, timeout, index="address,parcel", limit=5)
     address = None
-    for item in data:
-        if item["properties"]["_type"] == "address":
-            address = item["properties"]["label"]
-            break
-        if not address and item["properties"]["_type"] == "parcel":
-            address = (
-                f"{item['properties']['city']} ({item['properties']['departmentcode']})"
-            )
+    if data:
+        for item in data:
+            if item["properties"]["_type"] == "address":
+                address = item["properties"]["label"]
+                break
+            if not address and item["properties"]["_type"] == "parcel":
+                address = f"{item['properties']['city']} ({item['properties']['departmentcode']})"
 
     return address
 

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -221,7 +221,7 @@ def get_address_from_coords(lng, lat, timeout=0.5):
     Returns None in case anything goes wrong with the request.
     """
 
-    # try to find the address first, fallback on the parcel if not found
+    # try to find the address first, fallback on the parcel if not found to get at least the city and department
     data = get_data_from_coords(lng, lat, timeout, index="address,parcel", limit=5)
     address = None
     for item in data:

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -189,8 +189,8 @@ def to_geojson(obj, geometry_field="geometry"):
     return json.loads(geojson)
 
 
-def get_data_from_coords(lng, lat, timeout=0.5, index="address"):
-    url = f"https://data.geopf.fr/geocodage/reverse?lon={lng}&lat={lat}&index={index}&limit=1"  # noqa
+def get_data_from_coords(lng, lat, timeout=0.5, index="address", limit=1):
+    url = f"https://data.geopf.fr/geocodage/reverse?lon={lng}&lat={lat}&index={index}&limit={limit}"  # noqa
 
     if is_test():
         raise NotImplementedError("You should mock this function in tests")
@@ -201,7 +201,7 @@ def get_data_from_coords(lng, lat, timeout=0.5, index="address"):
         res = requests.get(url, timeout=timeout)
         if res.status_code == 200:
             json = res.json()
-            data = json["features"][0]["properties"]
+            data = json["features"]
     except (
         requests.exceptions.RequestException,
         KeyError,
@@ -221,8 +221,19 @@ def get_address_from_coords(lng, lat, timeout=0.5):
     Returns None in case anything goes wrong with the request.
     """
 
-    data = get_data_from_coords(lng, lat, timeout)
-    return data["label"] if data else None
+    # try to find the address first, fallback on the parcel if not found
+    data = get_data_from_coords(lng, lat, timeout, index="address,parcel", limit=5)
+    address = None
+    for item in data:
+        if item["properties"]["_type"] == "address":
+            address = item["properties"]["label"]
+            break
+        if not address and item["properties"]["_type"] == "parcel":
+            address = (
+                f"{item['properties']['city']} ({item['properties']['departmentcode']})"
+            )
+
+    return address
 
 
 def get_commune_from_coords(lng, lat, timeout=0.5):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -213,15 +213,19 @@ class MoulinetteMixin:
             )
 
         additional_forms = self.get_additional_forms(moulinette)
-        for form in additional_forms:
-            for field in form:
-                get.setlist(field.html_name, form.data.getlist(field.html_name))
+        for additional_form in additional_forms:
+            for field in additional_form:
+                get.setlist(
+                    field.html_name, additional_form.data.getlist(field.html_name)
+                )
 
         if self.should_activate_optional_criteria():
             optional_forms = self.get_optional_forms(moulinette)
-            for form in optional_forms:
-                for field in form:
-                    get.setlist(field.html_name, form.data.getlist(field.html_name))
+            for optional_form in optional_forms:
+                for field in optional_form:
+                    get.setlist(
+                        field.html_name, optional_form.data.getlist(field.html_name)
+                    )
 
         url_params = get.urlencode()
         url = reverse("moulinette_result")
@@ -365,6 +369,9 @@ class MoulinetteResult(MoulinetteMixin, FormView):
                 address = get_address_from_coords(lng, lat)
                 if address:
                     context["address"] = address
+                    context["form"].data[
+                        "address"
+                    ] = address  # add address as a submitted data to display it in the rendered form
                 else:
                     context["address_coords"] = f"{lat}, {lng}"
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -374,6 +374,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
                     ] = address  # add address as a submitted data to display it in the rendered form
                 else:
                     context["address_coords"] = f"{lat}, {lng}"
+                    context["form"].data["address"] = f"{lat}, {lng}"
 
         return context
 


### PR DESCRIPTION
On geocode systématiquement l'adresse à partir des coordonnées GPS.
Soit l'IGN retourne une adresse, soit une parcelle dans laquelle on peut trouver le nom de la commune et le numéro du département, soit rien du tout.

On affichera donc par ordre de préférence :

1. Adresse (géocodée, peut etre différente de celle entrée initialement)
2. Ville + numéro départment
3. Coordonnées GPS


[Ce ticket](https://trello.com/c/2rYGCMyl/968-etq-utilisateur-qui-soumet-le-formulaire-le-champ-adresse-rempli-sur-la-page-r%C3%A9sultat-est-toujours-rempli-supersimu4)

