### PR TITLE
Retour de l'entrée "simulateur" dans le menu

### DIFF
--- a/envergo/templates/_header.html
+++ b/envergo/templates/_header.html
@@ -49,6 +49,7 @@
     <nav class="fr-nav" role="navigation" aria-label="Menu principal">
       <ul class="fr-nav__list">
         <li class="fr-nav__item">{% menu_item 'home' "Accueil" %}</li>
+        <li class="fr-nav__item">{% menu_item 'moulinette_home' "Simulateur" 'HomePage' 'SimulationClick' 'Nav' %}</li>
         <li class="fr-nav__item">{% project_owner_menu %}</li>
         <li class="fr-nav__item">{% evalreq_menu 'HomePage' 'RequestClick' 'Nav' %}</li>
         <li class="fr-nav__item">{% faq_menu %}</li>

--- a/envergo/templates/_slim_header.html
+++ b/envergo/templates/_slim_header.html
@@ -26,16 +26,30 @@
       <div id="slim-menu" class="fr-header__tools">
         <div class="fr-header__tools-links">
           <ul class="fr-btns-group">
+            <li>
+              <a class="fr-btn"
+                 href="{% url 'moulinette_home' %}"
+                 data-event-category="HomePage"
+                 data-event-action="SimulationClick"
+                 data-event-name="Nav">Simulateur</a>
+            </li>
             <li>{% project_owner_menu is_slim=True %}</li>
             <li>
-              <a class="fr-btn" href="{% url 'request_evaluation' %}">Services urbanisme</a>
+              <a class="fr-btn"
+                 href="{% url 'request_evaluation' %}"
+                 data-event-category="HomePage"
+                 data-event-action="RequestClick"
+                 data-event-name="Nav">Services urbanisme</a>
             </li>
             <li>
               <a class="fr-btn" href="{% url 'faq' %}">Questions fréquentes</a>
             </li>
             <li>
               <a href="{% url 'request_evaluation' %}"
-                 class="fr-btn fr-btn--sm main-cta fr-hidden-lg fr-unhidden-xl">Demander un avis réglementaire</a>
+                 class="fr-btn fr-btn--sm main-cta fr-hidden-lg fr-unhidden-xl"
+                 data-event-category="HomePage"
+                 data-event-action="RequestClick"
+                 data-event-name="CTA">Demander un avis réglementaire</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
J'en ai profité pour mettre en conformité le tracking des entrées du menu clasique (en haut de bas) et du menu "slim" (lorsque l'on scroll vers le bas).

Attention cela risque de rendre incohérent la "cinématique" des analytics.