### PR TITLE
Corrige un problème de variable surchargée par erreur

### DIFF
--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -364,7 +364,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
                 if address:
                     context["address"] = address
                 else:
-                    context["coords"] = f"{lat}, {lng}"
+                    context["address_coords"] = f"{lat}, {lng}"
 
         return context
 

--- a/envergo/templates/evaluations/_specifications.html
+++ b/envergo/templates/evaluations/_specifications.html
@@ -5,9 +5,9 @@
     <li>
       <strong>Adresse :</strong> {{ address }}
     </li>
-  {% elif coords %}
+  {% elif address_coords %}
     <li>
-      <strong>Coordonnées GPS :</strong> {{ coords }}
+      <strong>Coordonnées GPS :</strong> {{ address_coords }}
     </li>
   {% endif %}
   {% if evaluation.application_number %}<li>Demande de permis n° {{ evaluation.application_number }}</li>{% endif %}


### PR DESCRIPTION
La variable `coords` est déjà utilisée dans le code.

https://github.com/MTES-MCT/envergo/blob/main/envergo/moulinette/models.py#L826

Par conséquent, quand le géocoding ne fonctionne pas, cette variable est remplacée par du texte, ce qui fait planter notamment la page de debug.

J'ai manqué de diligeance lors de ma review de code précédente :|