### PR TITLE
Caractérisation de la moulinette en fonction du site

### DIFF
--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -266,7 +266,7 @@ class Evaluation(models.Model):
     def get_moulinette(self):
         """Return the moulinette instance for this evaluation."""
         from envergo.moulinette.forms import MoulinetteForm
-        from envergo.moulinette.models import Moulinette
+        from envergo.moulinette.models import get_moulinette_class_from_url
         from envergo.moulinette.utils import compute_surfaces
 
         if not hasattr(self, "_moulinette"):
@@ -276,7 +276,8 @@ class Evaluation(models.Model):
             form.is_valid()
             params = form.cleaned_data
             activate_optional_criteria = True
-            self._moulinette = Moulinette(
+            MoulinetteClass = get_moulinette_class_from_url(self.moulinette_url)
+            self._moulinette = MoulinetteClass(
                 params, raw_params, activate_optional_criteria
             )
 

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1216,6 +1216,18 @@ def get_moulinette_class_from_request(request):
     return cls
 
 
+def get_moulinette_class_from_url(url):
+    """Return the correct Moulinette class depending on the current site."""
+
+    if "envergo" in url:
+        cls = AmenagementMoulinette
+    elif "haie" in url:
+        cls = HaieMoulinette
+    else:
+        raise RuntimeError("Cannot find the moulinette to use")
+    return cls
+
+
 class FakeMoulinette(Moulinette):
     """This is a custom Moulinette subclass used for debugging purpose.
 

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -790,6 +790,8 @@ class Moulinette:
     or other regulations.
     """
 
+    REGULATIONS = ["loi_sur_leau", "natura2000", "eval_env", "sage", "bcae8"]
+
     def __init__(self, data, raw_data, activate_optional_criteria=True):
         if isinstance(raw_data, QueryDict):
             self.raw_data = raw_data.dict()
@@ -963,7 +965,7 @@ class Moulinette:
         """Find the activated regulations and their criteria."""
 
         regulations = (
-            Regulation.objects.all()
+            Regulation.objects.filter(regulation__in=self.REGULATIONS)
             .order_by("weight")
             .prefetch_related(Prefetch("criteria", queryset=self.criteria))
             .prefetch_related(Prefetch("perimeters", queryset=self.perimeters))
@@ -1192,6 +1194,14 @@ class Moulinette:
         for regulation in self.regulations:
             for required_action in regulation.required_actions_interdit():
                 yield required_action
+
+
+class AmenagementMoulinette(Moulinette):
+    REGULATIONS = ["loi_sur_leau", "natura2000", "eval_env", "sage"]
+
+
+class HaieMoulinette(Moulinette):
+    REGULATIONS = ["bcae8"]
 
 
 class FakeMoulinette(Moulinette):

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1204,6 +1204,18 @@ class HaieMoulinette(Moulinette):
     REGULATIONS = ["bcae8"]
 
 
+def get_moulinette_class_from_request(request):
+    """Return the correct Moulinette class depending on the current site."""
+
+    if request.site.domain == settings.ENVERGO_AMENAGEMENT_DOMAIN:
+        cls = AmenagementMoulinette
+    elif request.site.domain == settings.ENVERGO_HAIE_DOMAIN:
+        cls = HaieMoulinette
+    else:
+        raise RuntimeError("Unknown site!")
+    return cls
+
+
 class FakeMoulinette(Moulinette):
     """This is a custom Moulinette subclass used for debugging purpose.
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -14,7 +14,12 @@ from envergo.analytics.utils import is_request_from_a_bot, log_event
 from envergo.evaluations.models import RESULTS
 from envergo.geodata.utils import get_address_from_coords
 from envergo.moulinette.forms import MoulinetteDebugForm, MoulinetteForm
-from envergo.moulinette.models import Criterion, FakeMoulinette, Moulinette
+from envergo.moulinette.models import (
+    Criterion,
+    FakeMoulinette,
+    Moulinette,
+    get_moulinette_class_from_request,
+)
 from envergo.moulinette.utils import compute_surfaces
 from envergo.utils.urls import update_qs
 
@@ -77,7 +82,8 @@ class MoulinetteMixin:
 
         form = context["form"]
         if form.is_valid():
-            moulinette = Moulinette(
+            MoulinetteClass = get_moulinette_class_from_request(self.request)
+            moulinette = MoulinetteClass(
                 form.cleaned_data,
                 form.data,
                 self.should_activate_optional_criteria(),

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -17,7 +17,6 @@ from envergo.moulinette.forms import MoulinetteDebugForm, MoulinetteForm
 from envergo.moulinette.models import (
     Criterion,
     FakeMoulinette,
-    Moulinette,
     get_moulinette_class_from_request,
 )
 from envergo.moulinette.utils import compute_surfaces
@@ -243,7 +242,8 @@ class MoulinetteMixin:
         if hasattr(self, "moulinette"):
             moulinette = self.moulinette
         else:
-            moulinette = Moulinette(
+            MoulinetteClass = get_moulinette_class_from_request(self.request)
+            moulinette = MoulinetteClass(
                 form_data,
                 form.data,
                 self.should_activate_optional_criteria(),


### PR DESCRIPTION
Voici une autre suggestion de modification par rapport à ta PR sur le MVP haie.

Le code suivant n'est pas destiné à être fonctionnel, c'est plus du prototype pour discuter du principe.

Ces modifs ont été guidées selon les principes suivants :

La solution actuelle est techniquement fonctionnelle (passer un objet site à la moulinette). En revanche, elle me semble améliorable du point de vue de la modelisation.

En effet, l'objet `Site` est un mécanisme plutôt bas niveau, technique, qui nous permet d'orienter la requête et de modifier la chaîne d'héritage des templates. La moulinette est un objet plutôt très haut niveau et proche du métier. Ces deux classes ne sont pas du tout au même niveau d'abstraction, cela me semble problématique que l'un doive manipuler l'autre.

Cela contraint également à modifier la modélisation d'une manière qui s'éloigne de la réalité. Ainsi, on est contraint de créer un lien evaluation -> site ou réglementation -> site ce qui aujourd'hui n'a pas vraiment d'utilité en soi.

La solution actuelle ne permet pas vraiment d'adresser les éventuelles différences de comportement entre les simulateurs des deux sites.

D'un point de vue de la modélisation, cela me paraîtrait plus cohérent qu'on aille du plus générique au plus spécifique dans la chaîne d'héritage. Ainsi, que la vue décide du comportement à appeler en sélectionnant un simulateur spécifique, plutôt que le simulateur lui-même ait besoin de connaître la notion de site.

La suggestion suivante fonctionne ainsi :

 - la Moulinette n'a pas besoin de connaître la notion de site
 - on définit des sous-classes de Moulinette avec des comportements spécifiques
 - c'est la vue, qui travaille au niveau de la requête, qui décide quel simulateur elle va instancier
 - il y a des helpers dans le fichier `moulinette/models.py` pour sélectionner la bonne sous-classe, mais c'est écrit franchement à l'arrache.
 - enfin, puisque les évaluations stockent une url complète de simulateur, on peut se baser sur cette url pour décider du bon type de simulateur à instancier (idem, c'est codé avec les pieds, c'est juste pour l'idée)

Il y a pas mal de petits détails que je n'ai pas traité, mais je voulais déjà discuter de l'idée globale. Qu'en penses-tu ?