### PR TITLE
Affiche le périmètre des critères

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -385,6 +385,9 @@ class Regulation(models.Model):
         """Should / can a perimeter map be displayed?"""
         return all((self.is_activated(), self.show_map, self.map))
 
+    def has_several_perimeters(self):
+        return len(self.perimeters.all()) > 1
+
 
 class Criterion(models.Model):
     """A single criteria for a regulation (e.g. Loi sur l'eau > Zone humide)."""

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -355,6 +355,11 @@ section.regulation {
   .fr-accordion {
     .fr-accordion__btn {
       color: inherit;
+
+      span.title .perimeter {
+        font-weight: 300;
+        color: var(--grey-925-100);
+      }
     }
 
     .fr-accordion__btn[aria-expanded="true"] {

--- a/envergo/templates/moulinette/_result_regulation_criterion.html
+++ b/envergo/templates/moulinette/_result_regulation_criterion.html
@@ -17,6 +17,10 @@
       {% endif %}
 
       <span class="title">
+        {% if criterion.perimeter and regulation.has_several_perimeters %}
+          <span class="perimeter">{{ criterion.perimeter }}</span>
+          <br />
+        {% endif %}
         <strong>{{ criterion.title }}</strong>
         {% if criterion.subtitle %}
           <br>


### PR DESCRIPTION
https://trello.com/c/ayBXSpvO/1051-afficher-le-nom-du-sage-dans-laccord%C3%A9on-du-crit%C3%A8re-quand-plusieurs-sage-activ%C3%A9s