### PR TITLE
Eviter envoi à la ddtm natura 2000 si uniquement N2000 > IOTA

### DIFF
--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -512,7 +512,11 @@ class EvaluationEmail:
                 else:
                     logger.warning("Manque l'email de la police de l'eau")
 
-            if moulinette.natura2000 and moulinette.natura2000.result == "soumis":
+            if (
+                moulinette.natura2000
+                and moulinette.natura2000.result == "soumis"
+                and not moulinette.natura2000.iota_only()
+            ):
                 if config.ddtm_n2000_email:
                     bcc_recipients.append(config.ddtm_n2000_email)
                 else:

--- a/envergo/evaluations/tests/test_eval_emails.py
+++ b/envergo/evaluations/tests/test_eval_emails.py
@@ -637,3 +637,16 @@ def test_petitioner_icpe(rf, moulinette_url):
         "nous n’avons pas envoyé cet avis directement au porteur, car EnvErgo ne se prononce pas encore"
         not in body
     )
+
+
+@pytest.mark.parametrize("footprint", [1200])
+def test_n2000_iota_only_no_bcc(rf, moulinette_url):
+    eval, moulinette = fake_moulinette(
+        moulinette_url, "soumis", "soumis", "non_soumis", "non_soumis"
+    )
+    moulinette.regulations[1].configure_mock(iota_only=lambda: True)
+
+    req = rf.get("/")
+    eval_email = eval.get_evaluation_email()
+    email = eval_email.get_email(req)
+    assert "ddtm_n2000@example.org" not in email.bcc


### PR DESCRIPTION
[This ticket](https://trello.com/c/9jyOya46/1003-eviter-envoi-%C3%A0-la-ddtm-natura-2000-si-uniquement-n2000-iota)
