### PR TITLE
Distingue le staging et les review apps

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -131,14 +131,15 @@ INSTALLED_APPS += ["anymail"]  # noqa F405
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 # https://anymail.readthedocs.io/en/stable/esps/sendinblue/
 
+ENV_NAME = env("ENV_NAME")
 IS_REVIEW_APP = env.bool("IS_REVIEW_APP", default=False)
 
 # Different settings between scalingo prod and review apps
-if IS_REVIEW_APP:
+if ENV_NAME == "production":
+    EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
+else:
     # Send emails to stdout for logging purpose
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-else:
-    EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
 
 ANYMAIL = {
     "SENDINBLUE_API_KEY": env("SENDINBLUE_API_KEY"),
@@ -229,8 +230,6 @@ CELERY_CACHE_BACKEND = "django-cache"
 
 # Your stuff...
 # ------------------------------------------------------------------------------
-
-ENV_NAME = env("ENV_NAME")
 
 SELF_DECLARATION_FORM_ID = env("DJANGO_SELF_DECLARATION_FORM_ID")
 


### PR DESCRIPTION
Aujourd'hui on a deux paramètres distincts mais qui font exactement la même chose : IS_REVIEW_APP et ENVIRONNEMENT.

Cela créé des bugs : https://trello.com/c/ZzvnsL16/1057-probl%C3%A8me-sur-le-script-deployenvironnement

Je suggère de distinguer l'environnement (production / staging) et le format (review app ou non).

Une fois cette modif validée, il faudra penser à changer la variable d'environnement `IS_REVIEW_APP` de True à False dans le dashboard scalingo de staging.