### PR TITLE
Mise à jour du calcul de la valeur "autorisation urba nécessaire ?"

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -328,7 +328,7 @@ class Regulation(models.Model):
                 autor_urba_form.is_valid()
                 and autor_urba_form.cleaned_data["autorisation_urba"] == "none"
             ):
-                return True
+                return False
         except AttributeError:
             pass
 

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -315,30 +315,24 @@ class Regulation(models.Model):
         """Is an "autorisation d'urbanisme" needed?
 
         This is a custom check for the N2000 regulation.
-        Such an authorization is required if the projet is a "lotissement" or if the
-        answer to the "autorisation d'urbanisme" question is anything other than "no".
+        Such an authorization is required if the answer to the "autorisation d'urbanisme"
+        question is anything other than "no".
+
+        Also, the value is "True" by default if the "autorisation_urba" question is
+        not present.
         """
-        try:
-            lotissement_form = self.get_criterion("lotissement").get_form()
-            if (
-                lotissement_form.is_valid()
-                and lotissement_form.cleaned_data["is_lotissement"] == "oui"
-            ):
-                return True
-        except AttributeError:
-            pass
 
         try:
             autor_urba_form = self.get_criterion("autorisation_urba").get_form()
             if (
                 autor_urba_form.is_valid()
-                and autor_urba_form.cleaned_data["autorisation_urba"] != "none"
+                and autor_urba_form.cleaned_data["autorisation_urba"] == "none"
             ):
                 return True
         except AttributeError:
             pass
 
-        return False
+        return True
 
     def display_perimeter(self):
         """Should / can a perimeter be displayed?"""

--- a/envergo/moulinette/tests/test_natura2000.py
+++ b/envergo/moulinette/tests/test_natura2000.py
@@ -34,6 +34,22 @@ def n2000_criteria(france_map):  # noqa
             evaluator="envergo.moulinette.regulations.natura2000.IOTA",
             activation_map=france_map,
         ),
+        CriterionFactory(
+            title="Autorisation urbanisme",
+            regulation=regulation,
+            evaluator="envergo.moulinette.regulations.natura2000.AutorisationUrbanisme",
+            activation_map=france_map,
+            evaluator_settings={
+                "result_code_matrix": {
+                    "pa": "soumis",
+                    "pc": "soumis",
+                    "amenagement_dp": "soumis",
+                    "construction_dp": "soumis",
+                    "none": "non_soumis",
+                    "other": "a_verifier",
+                }
+            },
+        ),
     ]
     return criteria
 
@@ -47,6 +63,7 @@ def moulinette_data(footprint):
         "existing_surface": 0,
         "created_surface": footprint,
         "final_surface": footprint,
+        "autorisation_urba": "none",
     }
 
 
@@ -141,3 +158,33 @@ def test_zi_medium_footprint_outside_flood_zones(moulinette_data):
     moulinette = MoulinetteAmenagement(moulinette_data, moulinette_data)
     moulinette.evaluate()
     assert moulinette.natura2000.zone_inondable.result == "non_concerne"
+
+
+@pytest.mark.parametrize("footprint", [300])
+def test_autorisation_urba_value(moulinette_data):
+    """Check the custom "autorisation_urba" property.
+
+    We need a custom property to check if the project requires an
+    "autorisation d'urbanisme".
+
+    It will always be the case unless the user explicitly states otherwise.
+    """
+    moulinette_data["autorisation_urba"] = "pa"
+    moulinette = Moulinette(moulinette_data, moulinette_data)
+    assert moulinette.natura2000.autorisation_urba.result == "soumis"
+    assert moulinette.natura2000.autorisation_urba_needed() is True
+
+    moulinette_data["autorisation_urba"] = "other"
+    moulinette = Moulinette(moulinette_data, moulinette_data)
+    assert moulinette.natura2000.autorisation_urba.result == "a_verifier"
+    assert moulinette.natura2000.autorisation_urba_needed() is True
+
+    moulinette_data["autorisation_urba"] = "none"
+    moulinette = Moulinette(moulinette_data, moulinette_data)
+    assert moulinette.natura2000.autorisation_urba.result == "non_soumis"
+    assert moulinette.natura2000.autorisation_urba_needed() is False
+
+    del moulinette_data["autorisation_urba"]
+    moulinette = Moulinette(moulinette_data, moulinette_data)
+    assert moulinette.natura2000.autorisation_urba.result == "non_disponible"
+    assert moulinette.natura2000.autorisation_urba_needed() is True


### PR DESCRIPTION
https://trello.com/c/2uOSctjN/961-joindre-lein-%C3%A0-la-dau

Pour le rendu des templates, on a besoin de savoir si un projet est soumis à une autorisation d'urbanisme.

La réponse est toujours oui, sauf si l'usager indique explicitement le contraire en répondant « aucun » à la question « le projet est-il soumis à autorisation d'urbanisme ? ».

La valeur était calculée un peu différemment avant cette modification, la valeur par défaut était différente si la question n'était pas présente dans le formulaire.