### PR TITLE
Permettre la lecture seule des critères, moulinette, périmètres, réglementation aux non admin

### DIFF
--- a/envergo/geodata/admin.py
+++ b/envergo/geodata/admin.py
@@ -288,7 +288,7 @@ class ZoneAdmin(gis_admin.GISModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.defer("geometry", "map__geometry")
+        return qs.select_related("map").defer("geometry", "map__geometry")
 
 
 @admin.register(Department)

--- a/envergo/moulinette/admin.py
+++ b/envergo/moulinette/admin.py
@@ -60,9 +60,10 @@ class CriterionAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["activation_map"].queryset = self.fields[
-            "activation_map"
-        ].queryset.defer("geometry")
+        if "activation_map" in self.fields:
+            self.fields["activation_map"].queryset = self.fields[
+                "activation_map"
+            ].queryset.defer("geometry")
 
     def get_initial_for_field(self, field, field_name):
         """Prevent Evaluator choice to be instanciated.
@@ -135,7 +136,7 @@ class CriterionAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.defer("activation_map__geometry")
+        return qs.select_related("activation_map").defer("activation_map__geometry")
 
     @admin.display(description=_("Evaluator"))
     def evaluator_column(self, obj):
@@ -186,9 +187,10 @@ class CriterionAdmin(admin.ModelAdmin):
 class PerimeterAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["activation_map"].queryset = self.fields[
-            "activation_map"
-        ].queryset.defer("geometry")
+        if "activation_map" in self.fields:
+            self.fields["activation_map"].queryset = self.fields[
+                "activation_map"
+            ].queryset.defer("geometry")
 
     def get_initial_for_field(self, field, field_name):
         """Prevent Criterion choice to be instanciated.
@@ -223,7 +225,7 @@ class PerimeterAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.defer("activation_map__geometry")
+        return qs.select_related("activation_map").defer("activation_map__geometry")
 
     @admin.display(
         ordering="activation_distance",
@@ -250,9 +252,10 @@ class MoulinetteConfigForm(forms.ModelForm):
 
         # Let's not fetch the department geometries when displaying the
         # department select widget
-        self.fields["department"].queryset = self.fields["department"].queryset.defer(
-            "geometry"
-        )
+        if "department" in self.fields:
+            self.fields["department"].queryset = self.fields[
+                "department"
+            ].queryset.defer("geometry")
 
     def clean_criteria_values(self):
         """Ensure an empty value can be converted to an empty json dict."""
@@ -290,7 +293,11 @@ class MoulinetteConfigAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.order_by("department__department").defer("department__geometry")
+        return (
+            qs.select_related("department")
+            .order_by("department__department")
+            .defer("department__geometry")
+        )
 
 
 @admin.register(MoulinetteTemplate)

--- a/envergo/moulinette/admin.py
+++ b/envergo/moulinette/admin.py
@@ -134,6 +134,17 @@ class CriterionAdmin(admin.ModelAdmin):
     sortable_by = ["backend_title", "activation_map", "activation_distance"]
     inlines = [MoulinetteTemplateInline]
 
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        if not request.user.has_perm("moulinette.change_criterion"):
+            # Replace 'evaluator' with 'evaluator_column' for users without edit rights
+            for fieldset in fieldsets:
+                fields = list(fieldset[1]["fields"])
+                if "evaluator" in fields:
+                    fields[fields.index("evaluator")] = "evaluator_column"
+                fieldset[1]["fields"] = tuple(fields)
+        return fieldsets
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.select_related("activation_map").defer("activation_map__geometry")


### PR DESCRIPTION
[Ce ticket](https://trello.com/c/8NTnlwrC/1064-permettre-la-lecture-seule-des-crit%C3%A8res-moulinette-p%C3%A9rim%C3%A8tres-r%C3%A9glementation-aux-non-admin)

Je pense que la lecture seule est cassée depuis [le travail sur les perf dans l'admin](https://github.com/MTES-MCT/envergo/commit/f5c5a0ad83b779400cfb8bb7bb6a3d186d19e894).

Les queryset ignoraient certains champs (`defer`), mais ne récuperait pas forcement le model depuis la db (`select_related`). Du coup, lorsque l'objet devait être affiché, il était de nouveau appelé, mais cette fois avec l'ensemble de ses champs.