### PR TITLE
Modification de la vue "liste" des avis, pour faire apparaître le statut "publié"

### DIFF
--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -187,7 +187,10 @@ class EvaluationAdmin(admin.ModelAdmin):
             super()
             .get_queryset(request)
             .select_related("request")
-            .annotate(nb_versions=Count("versions"))
+            .annotate(
+                nb_versions=Count("versions"),
+                nb_emails_sent=Count("regulatory_notice_logs"),
+            )
             .prefetch_related(
                 Prefetch(
                     "versions",
@@ -372,7 +375,7 @@ class EvaluationAdmin(admin.ModelAdmin):
 
     @admin.display(description="Nb. emails envoyés")
     def nb_emails_sent(self, obj):
-        return RegulatoryNoticeLog.objects.filter(evaluation=obj).count()
+        return obj.nb_emails_sent
 
     @admin.display(description=_("Versions"))
     def versions(self, obj):

--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -98,10 +98,9 @@ class EvaluationAdmin(admin.ModelAdmin):
     list_display = [
         "reference",
         "created_at",
-        "has_moulinette_url",
         "application_number",
         "urbanism_department_emails",
-        "request_link",
+        "nb_emails_sent",
         "nb_versions",
     ]
     form = EvaluationAdminForm
@@ -198,25 +197,9 @@ class EvaluationAdmin(admin.ModelAdmin):
         )
         return qs
 
-    @admin.display(description=_("Versions"), ordering="nb_versions")
+    @admin.display(description="Nb. avis publiés", ordering="nb_versions")
     def nb_versions(self, obj):
         return obj.nb_versions
-
-    @admin.display(description=_("Request"), ordering="request")
-    def request_link(self, obj):
-        if not obj.request:
-            return ""
-
-        request = obj.request
-        request_admin_url = reverse(
-            "admin:evaluations_request_change", args=[request.reference]
-        )
-        link = f'<a href="{request_admin_url}">{request}</a>'
-        return mark_safe(link)
-
-    @admin.display(description=_("Url"), boolean=True)
-    def has_moulinette_url(self, obj):
-        return bool(obj.moulinette_url)
 
     def get_urls(self):
         urls = super().get_urls()
@@ -386,6 +369,10 @@ class EvaluationAdmin(admin.ModelAdmin):
             },
         )
         return mark_safe(content)
+
+    @admin.display(description="Nb. emails envoyés")
+    def nb_emails_sent(self, obj):
+        return RegulatoryNoticeLog.objects.filter(evaluation=obj).count()
 
     @admin.display(description=_("Versions"))
     def versions(self, obj):

--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -188,8 +188,8 @@ class EvaluationAdmin(admin.ModelAdmin):
             .get_queryset(request)
             .select_related("request")
             .annotate(
-                nb_versions=Count("versions"),
-                nb_emails_sent=Count("regulatory_notice_logs"),
+                nb_versions=Count("versions", distinct=True),
+                nb_emails_sent=Count("regulatory_notice_logs", distinct=True),
             )
             .prefetch_related(
                 Prefetch(

--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -201,7 +201,7 @@ class Evaluation(models.Model):
         models.EmailField(),
         blank=True,
         default=list,
-        verbose_name=_("Urbanism department email address(es)"),
+        verbose_name="Email service ADS",
     )
     urbanism_department_phone = PhoneNumberField(
         _("Urbanism department phone number"), max_length=20, blank=True

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -213,10 +213,6 @@ msgstr "E-mails envoyés"
 msgid "Legacy regulatory notice data"
 msgstr "Ancien format d'avis réglementaire"
 
-#: envergo/evaluations/admin.py:242
-msgid "Request"
-msgstr "Demande"
-
 #: envergo/evaluations/admin.py:254 envergo/moulinette/models.py:584
 msgid "Url"
 msgstr "Url"


### PR DESCRIPTION
https://trello.com/c/MQUS3vKG/893-ar-statique-2-bis-modification-de-la-vue-liste-des-avis-pour-faire-appara%C3%AEtre-le-statut-publi%C3%A9-des-avis

Je ne maitrise pas bien le système de versionning des AR, j'ai cru comprendre que le “Nb. avis publiés” correspondait à la propriété `nb_versions`.