### PR TITLE
Enlever le footer sur la page résultat du GUH

### DIFF
--- a/envergo/templates/moulinette/base_result.html
+++ b/envergo/templates/moulinette/base_result.html
@@ -58,9 +58,7 @@
 {% endblock %}
 
 {% block after-content %}{% endblock %}
-{% block footer %}
-  {% include 'moulinette/_actions_banner.html' %}
-{% endblock %}
+{% block footer %}{% endblock %}
 
 {% block extra_body %}
   {% include '_share_url_modal.html' with title="Partager cette simulation" content='<p>Avec ce lien le destinataire pourra directement consulter cette page web présentant :</p> <ul class="fr-mb-0w"> <li>les mêmes caractéristiques de projet (localisation et surfaces) ;</li> <li>les mêmes résultats de simulation.</li> </ul>' shorten_url=True share_url=share_btn_url %}


### PR DESCRIPTION
[Ce ticket](https://trello.com/c/PcE6Klkn/1087-enlever-le-footer-sur-la-page-r%C3%A9sultat-du-guh)

Attention à ne pas perdre cette modification en cas de refonte du template de résultat.