### PR TITLE
Corrige la fonctionnalité d'impression

### DIFF
--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -1033,9 +1033,7 @@ div.hero-alt {
 
     & > main,
     & > footer {
-      @media only screen and (width > 991px) {
-        padding-left: calc(400% / 12);
-      }
+      padding-left: calc(400% / 12);
     }
 
     #project-summary,
@@ -1053,6 +1051,22 @@ div.hero-alt {
       left: 0;
       bottom: 0;
       padding-top: 5rem;
+    }
+  }
+}
+
+// For print, move the project summary above the project result
+@media only print {
+  .moulinette-result-body main {
+    display: flex;
+    flex-flow: column;
+
+    #project-summary {
+      order: 1;
+    }
+
+    #project-result {
+      order: 2;
     }
   }
 }

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -42,8 +42,9 @@
               data-btn="bottom">Partager cette page par email</button>
     </li>
     <li>
-      <button class="js fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-download-fill share-btn"
-              onclick="window.print();">Imprimer cette simulation</button>
+      <button class="js fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-file-download-fill print-btn">
+        Imprimer cette simulation
+      </button>
     </li>
   </ul>
 {% endblock %}
@@ -120,5 +121,4 @@
   <script defer src="{% static 'leaflet/draw/leaflet.draw.js' %}"></script>
   <script defer src="{% static 'js/libs/leaflet-icon-fix.js' %}"></script>
   <script defer src="{% static 'js/libs/moulinette_result_maps.js' %}"></script>
-  <script defer src="{% static 'js/libs/moulinette_print_buttons.js' %}"></script>
 {% endblock %}

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -120,4 +120,5 @@
   <script defer src="{% static 'leaflet/draw/leaflet.draw.js' %}"></script>
   <script defer src="{% static 'js/libs/leaflet-icon-fix.js' %}"></script>
   <script defer src="{% static 'js/libs/moulinette_result_maps.js' %}"></script>
+  <script defer src="{% static 'js/libs/moulinette_print_buttons.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
- réintroduit l'ordre correct des sections sur la page d'impression (grâce à flexbox !)
- ajoute l'url courte au moment de l'impression