### PR TITLE
Rappel des surfaces pour les AR + suppression de la surface initiale

### DIFF
--- a/envergo/templates/evaluations/_specifications.html
+++ b/envergo/templates/evaluations/_specifications.html
@@ -12,16 +12,12 @@
   {% endif %}
   {% if evaluation.application_number %}<li>Demande de permis n° {{ evaluation.application_number }}</li>{% endif %}
 
-  {% if form.created_surface %}
-    <li>{% field_summary form.created_surface %}</li>
+  {% if moulinette.main_form.created_surface %}
+    <li>{% field_summary moulinette.main_form.created_surface %}</li>
   {% endif %}
 
-  {% if form.existing_surface %}
-    <li>{% field_summary form.existing_surface %}</li>
-  {% endif %}
-
-  {% if form.final_surface %}
-    <li>{% field_summary form.final_surface %}</li>
+  {% if moulinette.main_form.final_surface %}
+    <li>{% field_summary moulinette.main_form.final_surface %}</li>
   {% endif %}
 
   {% include 'moulinette/_additional_specifications.html' %}


### PR DESCRIPTION
https://trello.com/c/ALMEzDFN/1103-ne-pas-afficher-la-surface-initiale-dans-le-recap-du-projet-puisquon-ne-la-jamais-demand%C3%A9e

https://trello.com/c/LTXZq85L/1120-le-rappel-des-surfaces-a-disparu-des-ar