### PR TITLE
Conserve les paramètres analytics dans l'url

### DIFF
--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -111,6 +111,8 @@ def test_moulinette_result_without_params_redirects_to_home(client):
 
 
 def test_moulinette_result_form_error(client):
+    """Bad params are cleaned from the result url."""
+
     MoulinetteConfigFactory()
 
     url = reverse("moulinette_result")
@@ -121,7 +123,10 @@ def test_moulinette_result_form_error(client):
     res = client.get(full_url)
 
     assert res.status_code == 302
-    assert res.url.endswith("/simulateur/formulaire/")
+    assert (
+        res.url
+        == "/simulateur/resultat/?created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381"
+    )
 
 
 def test_moulinette_result_mtm_keywords_are_not_bad_params(client):

--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -137,6 +137,22 @@ def test_moulinette_result_mtm_keywords_are_not_bad_params(client):
     assertTemplateUsed(res, "moulinette/result.html")
 
 
+def test_moulinette_result_custom_matomo_tracking_url(client):
+    MoulinetteConfigFactory(is_activated=True)
+
+    url = reverse("moulinette_result")
+    params = "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381&mtm_campaign=test"
+    full_url = f"{url}?{params}"
+    res = client.get(full_url)
+
+    assert res.status_code == 200
+    content = res.content.decode()
+    assert (
+        'var MATOMO_CUSTOM_URL = "http://testserver/simulateur/resultat/?mtm_campaign=test";'
+        in content
+    )
+
+
 def test_moulinette_home_form_error(client):
     url = reverse("moulinette_home")
     params = "bad_param=true"

--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -111,13 +111,30 @@ def test_moulinette_result_without_params_redirects_to_home(client):
 
 
 def test_moulinette_result_form_error(client):
+    MoulinetteConfigFactory()
+
     url = reverse("moulinette_result")
-    params = "bad_param=true"
+    params = (
+        "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381&bad_param=true"
+    )
     full_url = f"{url}?{params}"
     res = client.get(full_url)
 
     assert res.status_code == 302
     assert res.url.endswith("/simulateur/formulaire/")
+
+
+def test_moulinette_result_mtm_keywords_are_not_bad_params(client):
+    """Analytics params are not cleaned from the result url."""
+    MoulinetteConfigFactory(is_activated=True)
+
+    url = reverse("moulinette_result")
+    params = "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381&mtm_campaign=test"
+    full_url = f"{url}?{params}"
+    res = client.get(full_url)
+
+    assert res.status_code == 200
+    assertTemplateUsed(res, "moulinette/result.html")
 
 
 def test_moulinette_home_form_error(client):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -13,7 +13,7 @@ from envergo.evaluations.models import RESULTS
 from envergo.geodata.utils import get_address_from_coords
 from envergo.moulinette.models import get_moulinette_class_from_site
 from envergo.moulinette.utils import compute_surfaces
-from envergo.utils.urls import remove_from_qs, update_qs, url_with_only_mtm_params
+from envergo.utils.urls import extract_mtm_params, remove_from_qs, update_qs
 
 BODY_TPL = {
     RESULTS.soumis: "moulinette/eval_body_soumis.html",
@@ -371,13 +371,23 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         edit_url = update_qs(result_url, {"edit": "true"})
 
         # Url without any query parameters
-        stripped_url = url_with_only_mtm_params(current_url)
+        # We want to build "fake" urls for matomo tracking
+        # For example, if the current url is /simulateur/resultat/?debug=true,
+        # We want to track this as a custom url /simulateur/debug/
+        mtm_params = extract_mtm_params(current_url)
+
+        # We want to log the current simulation url stripped from any query parameters
+        # except for mtm_ ones
+        bare_url = self.request.build_absolute_uri(self.request.path)
+        matomo_bare_url = update_qs(bare_url, mtm_params)
         debug_url = self.request.build_absolute_uri(reverse("moulinette_result_debug"))
+        matomo_debug_url = update_qs(debug_url, mtm_params)
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")
         )
         form_url = self.request.build_absolute_uri(reverse("moulinette_home"))
         form_url_with_edit = update_qs(form_url, {"edit": "true"})
+        matomo_missing_data_url = update_qs(missing_data_url, mtm_params)
 
         context["current_url"] = current_url
         context["share_btn_url"] = share_btn_url
@@ -397,14 +407,17 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             context = {
                 **context,
                 **moulinette.get_debug_context(),
-                "matomo_custom_url": debug_url,
                 "result_url": result_url,
+                "matomo_custom_url": matomo_debug_url,
             }
+
+        # TODO This cannot happen, since we redirect to the form if data is missing
+        # Check that it can be safely removed
         elif moulinette and moulinette.has_missing_data():
-            context["matomo_custom_url"] = missing_data_url
+            context["matomo_custom_url"] = matomo_missing_data_url
 
         elif moulinette:
-            context["matomo_custom_url"] = stripped_url
+            context["matomo_custom_url"] = matomo_bare_url
             if moulinette.has_config() and moulinette.is_evaluation_available():
                 context["debug_url"] = debug_result_url
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -322,7 +322,6 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         res = self.render_to_response(context)
         moulinette = self.moulinette
         if moulinette:
-
             if (
                 "debug" not in self.request.GET
                 and not is_edit
@@ -352,6 +351,10 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         current_url = request.get_full_path()
         current_qs = parse_qs(urlparse(current_url).query)
         current_params = set(current_qs.keys())
+
+        # We don't want to take analytics params into account, so they stay in the url
+        current_params = set([p for p in current_params if not p.startswith("mtm_")])
+
         return expected_params == current_params
 
     def get_context_data(self, **kwargs):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -13,7 +13,7 @@ from envergo.evaluations.models import RESULTS
 from envergo.geodata.utils import get_address_from_coords
 from envergo.moulinette.models import get_moulinette_class_from_site
 from envergo.moulinette.utils import compute_surfaces
-from envergo.utils.urls import remove_from_qs, update_qs
+from envergo.utils.urls import remove_from_qs, update_qs, url_with_only_mtm_params
 
 BODY_TPL = {
     RESULTS.soumis: "moulinette/eval_body_soumis.html",
@@ -371,7 +371,7 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         edit_url = update_qs(result_url, {"edit": "true"})
 
         # Url without any query parameters
-        stripped_url = self.request.build_absolute_uri(self.request.path)
+        stripped_url = url_with_only_mtm_params(current_url)
         debug_url = self.request.build_absolute_uri(reverse("moulinette_result_debug"))
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")

--- a/envergo/utils/urls.py
+++ b/envergo/utils/urls.py
@@ -21,3 +21,14 @@ def remove_from_qs(url, key):
     new_query = urlencode(query, doseq=True)
     new_bits = bits._replace(query=new_query)
     return urlunsplit(new_bits)
+
+
+def url_with_only_mtm_params(url):
+    """Return an url with only mtm parameters."""
+
+    bits = urlsplit(url)
+    query = parse_qs(bits.query)
+    mtm_params = {k: v for k, v in query.items() if k.startswith("mtm_")}
+    new_query = urlencode(mtm_params, doseq=True)
+    new_bits = bits._replace(query=new_query)
+    return urlunsplit(new_bits)

--- a/envergo/utils/urls.py
+++ b/envergo/utils/urls.py
@@ -23,12 +23,10 @@ def remove_from_qs(url, key):
     return urlunsplit(new_bits)
 
 
-def url_with_only_mtm_params(url):
-    """Return an url with only mtm parameters."""
+def extract_mtm_params(url):
+    """Extract mtm parameters from an url."""
 
     bits = urlsplit(url)
     query = parse_qs(bits.query)
     mtm_params = {k: v for k, v in query.items() if k.startswith("mtm_")}
-    new_query = urlencode(mtm_params, doseq=True)
-    new_bits = bits._replace(query=new_query)
-    return urlunsplit(new_bits)
+    return mtm_params


### PR DESCRIPTION
https://trello.com/c/IQiWc0Jt/1102-mise-%C3%A0-plat-des-analytics-marketing-1-3

- les paramètres mtm_ sont conservés dans l'url des résultats du simulateur
- les paramètres mtm_ sont ajoutés aux urls custom matomo