### PR TITLE
Eviter les accents dans les emails

### DIFF
--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -29,6 +29,7 @@ from envergo.evaluations.models import (
     generate_reference,
 )
 from envergo.moulinette.models import get_moulinette_class_from_url
+from envergo.utils.fields import NoIdnEmailField
 
 logger = logging.getLogger(__name__)
 
@@ -44,13 +45,13 @@ class EvalAdminFormMixin(EvaluationFormMixin):
         required=False,
     )
     urbanism_department_emails = SimpleArrayField(
-        forms.EmailField(),
+        NoIdnEmailField(),
         label=_("Urbanism department email address(es)"),
         error_messages={"item_invalid": _("The %(nth)s address is invalid:")},
         widget=admin.widgets.AdminTextareaWidget(attrs={"rows": 3}),
     )
     project_owner_emails = SimpleArrayField(
-        forms.EmailField(),
+        NoIdnEmailField(),
         label=_("Project owner email(s)"),
         error_messages={"item_invalid": _("The %(nth)s address is invalid:")},
         widget=admin.widgets.AdminTextareaWidget(attrs={"rows": 3}),

--- a/envergo/evaluations/forms.py
+++ b/envergo/evaluations/forms.py
@@ -11,6 +11,7 @@ from envergo.evaluations.models import USER_TYPES, Request
 from envergo.evaluations.utils import extract_department
 from envergo.evaluations.validators import application_number_validator
 from envergo.geodata.models import Department
+from envergo.utils.fields import NoIdnEmailField
 
 
 class EvaluationFormMixin(forms.Form):
@@ -162,7 +163,7 @@ class WizardContactForm(EvaluationFormMixin, forms.ModelForm):
         widget=forms.RadioSelect,
     )
     urbanism_department_emails = SimpleArrayField(
-        forms.EmailField(),
+        NoIdnEmailField(),
         label=_("Urbanism department email address(es)"),
         error_messages={"item_invalid": _("The %(nth)s address is invalid:")},
     )
@@ -172,7 +173,7 @@ class WizardContactForm(EvaluationFormMixin, forms.ModelForm):
         required=False,
     )
     project_owner_emails = SimpleArrayField(
-        forms.EmailField(),
+        NoIdnEmailField(),
         label=_("Project sponsor email address(es)"),
         help_text=_("Petitioner, project manager…"),
         error_messages={"item_invalid": _("The %(nth)s address is invalid:")},
@@ -272,7 +273,7 @@ class RequestForm(WizardAddressForm, WizardContactForm):
 
 class EvaluationShareForm(forms.Form):
     emails = SimpleArrayField(
-        forms.EmailField(),
+        NoIdnEmailField(),
         label=_("Select your recipient(s) email address(es)"),
         help_text=_("Separate several addresses with a comma « , »"),
         error_messages={"item_invalid": _("The %(nth)s address is invalid:")},

--- a/envergo/users/admin.py
+++ b/envergo/users/admin.py
@@ -1,17 +1,27 @@
+from django import forms
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
 from envergo.users.forms import UserCreationForm
+from envergo.utils.fields import NoIdnEmailField
 
 User = get_user_model()
+
+
+class NoIdnUserCreationForm(UserCreationForm):
+    email = NoIdnEmailField(
+        required=True,
+        label=_("Email address"),
+        widget=forms.EmailInput(attrs={"class": "vTextField"}),
+    )
 
 
 @admin.register(User)
 class UserAdmin(auth_admin.UserAdmin):
 
-    add_form = UserCreationForm
+    add_form = NoIdnUserCreationForm
     fieldsets = (
         (None, {"fields": ("email", "password")}),
         (_("Personal info"), {"fields": ("name",)}),

--- a/envergo/users/forms.py
+++ b/envergo/users/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
 
 from envergo.users.models import User
+from envergo.utils.fields import NoIdnEmailField
 
 # This string is used in django's original AuthenticationForm
 # There is a typo in the string translation, so we add this variable here
@@ -17,7 +18,7 @@ _INVALID_LOGIN_ERROR_MSG = (
 
 
 class RegisterForm(UserCreationForm):
-    email = forms.EmailField(
+    email = NoIdnEmailField(
         label="Votre adresse e-mail",
         required=True,
         help_text="Nous enverrons un e-mail de confirmation à cette adresse avant de valider le compte.",

--- a/envergo/utils/fields.py
+++ b/envergo/utils/fields.py
@@ -1,0 +1,13 @@
+from django.forms import EmailField
+
+from envergo.utils.validators import NoIdnEmailValidator
+
+
+class NoIdnEmailField(EmailField):
+    """
+    Our email sending tool Brevo do not support Internationalized Domain Names (IDN).
+    This Field is a subclass of Django's EmailField that raises a validation error if there is diacritics,
+    ligatures or non-Latin character in the domain name.
+    """
+
+    default_validators = [NoIdnEmailValidator()]

--- a/envergo/utils/validators.py
+++ b/envergo/utils/validators.py
@@ -1,0 +1,29 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
+
+
+class NoIdnEmailValidator(EmailValidator):
+    """
+    Our email sending tool Brevo do not support Internationalized Domain Names (IDN).
+    This validator is a subclass of Django's EmailValidator that raises a validation error if there is diacritics,
+    ligatures or non-Latin character in the domain name.
+    """
+
+    def __call__(self, value):
+        # The maximum length of an email is 320 characters per RFC 3696
+        # section 3.
+        if not value or "@" not in value or len(value) > 320:
+            raise ValidationError(self.message, code=self.code, params={"value": value})
+
+        user_part, domain_part = value.rsplit("@", 1)
+
+        if not self.user_regex.match(user_part):
+            raise ValidationError(self.message, code=self.code, params={"value": value})
+
+        if domain_part not in self.domain_allowlist and not self.validate_domain_part(
+            domain_part
+        ):
+            if self.validate_domain_part(domain_part):
+                return
+
+            raise ValidationError(self.message, code=self.code, params={"value": value})


### PR DESCRIPTION
C'est un peu dommage d'écrire du code pour ne pas respecter les standards, mais il faut etre pragmatique dans la vie.

https://trello.com/c/PZu6Ka6S/1097-eviter-les-accents-dans-les-emails