### PR TITLE
Bug : case « envoyer au porteur de projet »

### DIFF
--- a/envergo/evaluations/forms.py
+++ b/envergo/evaluations/forms.py
@@ -220,6 +220,18 @@ class WizardContactForm(EvaluationFormMixin, forms.ModelForm):
             "Provide one or several addresses separated by commas « , »"
         )
 
+    def clean(self):
+        cleaned_data = super().clean()
+        user_type = cleaned_data.get("user_type")
+        send_eval_to_project_owner = cleaned_data.get("send_eval_to_project_owner")
+
+        # Remove project owner fields if the user does not want to send the evaluation to the project owner
+        if not send_eval_to_project_owner and user_type == USER_TYPES.instructor:
+            cleaned_data.pop("project_owner_emails", None)
+            cleaned_data.pop("project_owner_phone", None)
+
+        return cleaned_data
+
 
 # See https://docs.djangoproject.com/en/4.2/topics/http/file-uploads/#uploading-multiple-files
 class MultipleFileInput(forms.ClearableFileInput):

--- a/envergo/evaluations/forms.py
+++ b/envergo/evaluations/forms.py
@@ -230,6 +230,11 @@ class WizardContactForm(EvaluationFormMixin, forms.ModelForm):
             cleaned_data.pop("project_owner_emails", None)
             cleaned_data.pop("project_owner_phone", None)
 
+        # Remove urbanism_department fields if the user is a petitioner
+        if user_type == USER_TYPES.petitioner:
+            cleaned_data.pop("urbanism_department_emails", None)
+            cleaned_data.pop("urbanism_department_phone", None)
+
         return cleaned_data
 
 

--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -704,14 +704,6 @@ class Request(models.Model):
         )
         return evaluation
 
-    def save(self, *args, **kwargs):
-        # do not store project owner emails and phone if the user does not want to send the eval to the project owner
-        if not self.send_eval_to_project_owner:
-            self.project_owner_emails = []
-            self.project_owner_phone = ""
-
-        super().save(*args, **kwargs)
-
 
 def request_file_format(instance, filename):
     _, extension = splitext(filename)

--- a/envergo/evaluations/tests/test_forms.py
+++ b/envergo/evaluations/tests/test_forms.py
@@ -1,6 +1,6 @@
 import pytest
 
-from envergo.evaluations.forms import WizardAddressForm
+from envergo.evaluations.forms import WizardAddressForm, WizardContactForm
 from envergo.geodata.conftest import loire_atlantique_department  # noqa
 from envergo.moulinette.tests.factories import ConfigAmenagementFactory
 
@@ -39,3 +39,46 @@ def test_wizard_form_without_address_is_invalid(form_data):
     del form_data["address"]
     form = WizardAddressForm(form_data)
     assert not form.is_valid()
+
+
+def test_prevent_storing_project_owner_details_when_we_should_not_send_him_the_eval():
+    contact_data = {
+        "user_type": "instructor",
+        "project_owner_phone": "+33612345678",
+        "project_owner_emails": ["test@test.com"],
+        "send_eval_to_project_owner": False,
+        "urbanism_department_emails": ["test@test.com"],
+        "urbanism_department_phone": "+33612345678",
+    }
+    form = WizardContactForm(contact_data)
+    assert form.is_valid()
+    assert not form.cleaned_data.get("project_owner_phone")
+    assert not form.cleaned_data.get("project_owner_emails")
+
+    contact_data = {
+        "user_type": "instructor",
+        "project_owner_phone": "+33600000000",
+        "project_owner_emails": ["peti@test.com"],
+        "send_eval_to_project_owner": True,
+        "urbanism_department_emails": ["instru@test.com"],
+        "urbanism_department_phone": "+33612345678",
+    }
+    form = WizardContactForm(contact_data)
+    assert form.is_valid()
+    assert form.cleaned_data.get("project_owner_phone") == "+33600000000"
+    assert form.cleaned_data.get("project_owner_emails") == ["peti@test.com"]
+
+    contact_data = {
+        "user_type": "petitioner",
+        "project_owner_phone": "+33600000000",
+        "project_owner_emails": ["peti@test.com"],
+        "send_eval_to_project_owner": False,
+        "urbanism_department_emails": ["instru@test.com"],
+        "urbanism_department_phone": "+33612345678",
+    }
+    form = WizardContactForm(contact_data)
+    assert form.is_valid()
+    assert form.cleaned_data.get("project_owner_phone") == "+33600000000"
+    assert form.cleaned_data.get("project_owner_emails") == ["peti@test.com"]
+    assert not form.cleaned_data.get("urbanism_department_emails")
+    assert not form.cleaned_data.get("urbanism_department_phone")

--- a/envergo/evaluations/tests/test_models.py
+++ b/envergo/evaluations/tests/test_models.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from envergo.evaluations.models import Evaluation, Request
+from envergo.evaluations.models import Evaluation
 from envergo.evaluations.tests.factories import EvaluationFactory
 from envergo.geodata.conftest import loire_atlantique_department  # noqa
 from envergo.geodata.conftest import bizous_town_center, france_map  # noqa
@@ -84,30 +84,6 @@ def test_call_to_action_action(moulinette_url):
     evaluation.is_icpe = True
     evaluation.save()
     assert not evaluation.is_eligible_to_self_declaration()
-
-
-def test_prevent_storing_project_owner_details_when_we_should_not_send_him_the_eval():
-    request = Request(
-        address="123 rue de la Paix 75000 Paris",
-        project_owner_phone="+33612345678",
-        project_owner_emails=["test@test.com"],
-        send_eval_to_project_owner=False,
-    )
-    request.save()
-    request.refresh_from_db()
-    assert not request.project_owner_phone
-    assert not request.project_owner_emails
-
-    request = Request(
-        address="123 rue de la Paix 75000 Paris",
-        project_owner_phone="+33612345678",
-        project_owner_emails=["test@test.com"],
-        send_eval_to_project_owner=True,
-    )
-    request.save()
-    request.refresh_from_db()
-    assert request.project_owner_phone == "+33612345678"
-    assert request.project_owner_emails == ["test@test.com"]
 
 
 def test_evaluation_edition_triggers_an_automation():


### PR DESCRIPTION
[Ce ticket](https://trello.com/c/eSBVdZIS/1159-bug-case-envoyer-au-porteur-de-projet)

A noté : J'ai déplacé le code qui retirait les infos depuis le "save" du model, vers le "clean" du form. Cela me semble plus approprié.