### PR TITLE
Désactiver le CTA "demander un avis" depuis les pages formulaire avis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -194,6 +194,7 @@ TEMPLATES = [
                 "envergo.utils.context_processors.settings_context",
                 "envergo.utils.context_processors.multi_sites_context",
                 "envergo.analytics.context_processors.analytics",
+                "envergo.evaluations.context_processors.request_eval_context",
             ],
         },
     }

--- a/envergo/evaluations/context_processors.py
+++ b/envergo/evaluations/context_processors.py
@@ -3,6 +3,6 @@ from django.utils.translation import gettext_lazy as _
 
 def request_eval_context(request):
     context = {}
-    if request.path.startswith(f"/avis/{_("form/")}"):
+    if request.path.startswith(f"/avis/{_('form/')}"):
         context["is_request_btn_disabled"] = True
     return context

--- a/envergo/evaluations/context_processors.py
+++ b/envergo/evaluations/context_processors.py
@@ -1,0 +1,8 @@
+from django.utils.translation import gettext_lazy as _
+
+
+def request_eval_context(request):
+    context = {}
+    if request.path.startswith(f"/avis/{_("form/")}"):
+        context["is_request_btn_disabled"] = True
+    return context

--- a/envergo/evaluations/context_processors.py
+++ b/envergo/evaluations/context_processors.py
@@ -1,8 +1,5 @@
-from django.utils.translation import gettext_lazy as _
-
-
 def request_eval_context(request):
-    context = {}
-    if request.path.startswith(f"/avis/{_('form/')}"):
-        context["is_request_btn_disabled"] = True
+    """The "demander un avis" CTA must be disabled on the actual action form page."""
+
+    context = {"is_request_btn_disabled": request.path.startswith("/avis/formulaire/")}
     return context

--- a/envergo/templates/amenagement/_header.html
+++ b/envergo/templates/amenagement/_header.html
@@ -66,7 +66,7 @@
           </li>
 
           <li class="fr-nav__item btn-link fr-hidden fr-unhidden-xl">
-            <a href="{% url 'request_evaluation' %}"
+            <a {% if not is_request_btn_disabled %}href="{% url 'request_evaluation' %}"{% endif %}
                class="fr-btn fr-btn--sm"
                data-event-category="{{ tracking_name }}"
                data-event-action="RequestClick"

--- a/envergo/templates/amenagement/_slim_header.html
+++ b/envergo/templates/amenagement/_slim_header.html
@@ -47,8 +47,8 @@
               <a class="fr-btn" href="{% url 'faq' %}">Questions fréquentes</a>
             </li>
             <li>
-              <a href="{% url 'request_evaluation' %}"
-                 class="fr-btn fr-btn--sm main-cta fr-hidden-lg fr-unhidden-xl"
+              <a {% if not is_request_btn_disabled %}href="{% url 'request_evaluation' %}"{% endif %}
+                 class="fr-btn fr-btn--sm {% if not is_request_btn_disabled %}main-cta{% endif %} fr-hidden-lg fr-unhidden-xl"
                  data-event-category="{{ tracking_name }}"
                  data-event-action="RequestClick"
                  data-event-name="CTA">Demander un avis réglementaire</a>


### PR DESCRIPTION
https://trello.com/c/wkmQZS3o/1192-d%C3%A9sactiver-le-cta-demander-un-avis-depuis-les-pages-formulaire-avis