### PR TITLE
EnvErgo / Ne pas publier un AR par défaut avant que l'opérateur l'ait fait explicitement

### DIFF
--- a/envergo/evaluations/tests/test_views.py
+++ b/envergo/evaluations/tests/test_views.py
@@ -561,15 +561,14 @@ def test_eval_detail_shows_latest_published_version_content(client):
     assert "This is version 2" in res.content.decode()
 
 
-def test_eval_detail_without_versions_renders_content(client):
-    """When there is no existing version, the eval detail page renders the content dynamically."""
+def test_eval_detail_without_versions_does_not_render_content(client):
+    """When there is no existing version, the eval detail page is not available."""
     eval = EvaluationFactory(versions=[])
     assert eval.versions.count() == 0
 
     url = eval.get_absolute_url()
     res = client.get(url)
-    assert res.status_code == 200
-    assert "<h1>Avis réglementaire</h1>" in res.content.decode()
+    assert res.status_code == 404
 
 
 def test_only_one_version_can_be_published():

--- a/envergo/evaluations/views.py
+++ b/envergo/evaluations/views.py
@@ -97,6 +97,7 @@ class EvaluationDetailMixin:
     def get_queryset(self):
         qs = (
             Evaluation.objects.exclude(moulinette_url="")
+            .filter(versions__isnull=False)
             .select_related("request")
             .prefetch_related(
                 Prefetch(

--- a/envergo/evaluations/views.py
+++ b/envergo/evaluations/views.py
@@ -97,7 +97,6 @@ class EvaluationDetailMixin:
     def get_queryset(self):
         qs = (
             Evaluation.objects.exclude(moulinette_url="")
-            .filter(versions__isnull=False)
             .select_related("request")
             .prefetch_related(
                 Prefetch(
@@ -106,6 +105,11 @@ class EvaluationDetailMixin:
                 )
             )
         )
+
+        # AR not yet published should not be displayed unless in preview
+        if "preview" not in self.request.GET:
+            qs = qs.filter(versions__isnull=False).distinct()
+
         return qs
 
 

--- a/envergo/templates/admin/evaluations/evaluation/change_form.html
+++ b/envergo/templates/admin/evaluations/evaluation/change_form.html
@@ -28,12 +28,18 @@
          class="disableonchange">✉️ Envoyer e-mail avis</a>
     </li>
   {% endif %}
-  <li>
-    <a href="{{ absolute_url }}"
-       class="viewsitelink"
-       target="_blank"
-       rel="noopener">Voir l'avis publié</a>
-  </li>
+  {% if original.versions.count > 0 %}
+    <li>
+      <a href="{{ absolute_url }}"
+         class="viewsitelink"
+         target="_blank"
+         rel="noopener">Voir l'avis publié</a>
+    </li>
+  {% else %}
+    <li>
+      <a href="" class="disabled">⚠️ Aucun avis publié</a>
+    </li>
+  {% endif %}
 {% endblock %}
 
 {% block admin_change_form_document_ready %}

--- a/envergo/templates/evaluations/admin/publish.html
+++ b/envergo/templates/evaluations/admin/publish.html
@@ -26,12 +26,14 @@
          target="_blank"
          rel="noopener">👀 Prévisualiser</a>
     </li>
-    <li>
-      <a href="{{ object.get_absolute_url }}"
-         class="viewsitelink"
-         target="_blank"
-         rel="noopener">Voir l'avis publié</a>
-    </li>
+    {% if object.versions.count > 0 %}
+      <li>
+        <a href="{{ object.get_absolute_url }}"
+           class="viewsitelink"
+           target="_blank"
+           rel="noopener">Voir l'avis publié</a>
+      </li>
+    {% endif %}
   </ul>
 {% endblock %}
 


### PR DESCRIPTION
https://trello.com/c/jNQkBToT/1229-envergo-ne-pas-publier-un-ar-par-d%C3%A9faut-avant-que-lop%C3%A9rateur-lait-fait-explicitement