### PR TITLE
Haie / L'infobulle d'indication "cliquer pour..." s'affiche quand on est en train d'éditer un tracé

### DIFF
--- a/envergo/hedges/static/hedge_input/app.js
+++ b/envergo/hedges/static/hedge_input/app.js
@@ -224,8 +224,10 @@ createApp({
       let onRemove = hedgeList.removeHedge.bind(hedgeList);
       const newHedge = hedgeList.addHedge(map, onRemove, latLngs, additionalData);
 
-      newHedge.polyline.on('editable:vertex:new', () => {
-        showHelpBubble.value = true;
+      newHedge.polyline.on('editable:vertex:new', (event) => {
+        if(event.vertex.getNext() === undefined) { // do not display tooltip when adding a point to an existing hedge
+          showHelpBubble.value = true;
+        }
       });
 
       // Cacher la bulle d'aide à la fin du tracé


### PR DESCRIPTION
https://trello.com/c/MULIuO13/1233-haie-linfobulle-dindication-cliquer-pour-saffiche-quand-on-est-en-train-d%C3%A9diter-un-trac%C3%A9