### PR TITLE
Manque un `prefetch_related` sur la page de résultat haies

### DIFF
--- a/envergo/moulinette/admin.py
+++ b/envergo/moulinette/admin.py
@@ -352,6 +352,13 @@ class ConfigHaieAdminForm(forms.ModelForm):
             self.get_demarche_simplifiee_pre_fill_config_help_text()
         )
 
+        # Let's not fetch the department geometries when displaying the
+        # department select widget
+        if "department" in self.fields:
+            self.fields["department"].queryset = self.fields[
+                "department"
+            ].queryset.defer("geometry")
+
     def get_demarche_simplifiee_pre_fill_config_help_text(self):
         context = {
             "sources": ConfigHaie.get_demarche_simplifiee_value_sources(),

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -868,7 +868,9 @@ class ConfigHaie(ConfigBase):
          * the results of the regulations
         """
 
-        moulinette_instance = MoulinetteHaie({}, {})
+        regulations = Regulation.objects.filter(
+            regulation__in=MoulinetteHaie.REGULATIONS
+        ).prefetch_related("criteria")
         triage_form_fields = {
             (key, field.label) for key, field in TriageFormHaie.base_fields.items()
         }
@@ -890,7 +892,7 @@ class ConfigHaie(ConfigBase):
 
         regulation_results = set()
 
-        for regulation in moulinette_instance.regulations.all():
+        for regulation in regulations.all():
             regulation_sources = set()
             regulation_results.add(
                 (
@@ -1695,6 +1697,12 @@ class MoulinetteHaie(Moulinette):
         )
 
         return department
+
+    def get_regulations(self):
+        """Find the activated regulations and their criteria."""
+
+        regulations = super().get_regulations().prefetch_related("perimeters")
+        return regulations
 
 
 def get_moulinette_class_from_site(site):


### PR DESCRIPTION
https://trello.com/c/ijEqD2iY/1200-manque-un-prefetchrelated-sur-la-page-de-r%C3%A9sultat-haies

J'en ai profité pour également améliorer les perfs de la vue admin des config haies.