### PR TITLE
Erreur 500 - Erreur lors de l'affichage de la page d'erreur

### DIFF
--- a/envergo/templates/amenagement/base.html
+++ b/envergo/templates/amenagement/base.html
@@ -39,7 +39,10 @@
       </div>
     </div>
   </section>
-  {% include 'amenagement/_newsletter_opt_in.html' %}
+  {% if newsletter_opt_in_form %}
+    {# If an exception is raised, the newsletter_opt_in_form is not populated into the context#}
+    {% include 'amenagement/_newsletter_opt_in.html' %}
+  {% endif %}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
Context processor are not called when there is an exception.

Cela provoquait ce [genre d'erreur](https://sentry.incubateur.net/organizations/betagouv/issues/143439/?environment=production&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=11) qui poluait le sentry