### PR TITLE
Update sentry js loader

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -303,6 +303,7 @@ CELERY_TASK_TRACK_STARTED = True
 
 
 SENTRY_DSN = env("SENTRY_DSN", default="")
+SENTRY_KEY = env("SENTRY_KEY", default="")
 
 
 # Your stuff...

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -218,7 +218,7 @@ LOGGING = {
 # Sentry
 # ------------------------------------------------------------------------------
 SENTRY_DSN = env("SENTRY_DSN")
-SENTRY_KEY = env("SENTRY_KEY")
+SENTRY_KEY = env("SENTRY_KEY", default="")
 SENTRY_LOG_LEVEL = env.int("DJANGO_SENTRY_LOG_LEVEL", logging.INFO)
 
 sentry_logging = LoggingIntegration(

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -218,7 +218,7 @@ LOGGING = {
 # Sentry
 # ------------------------------------------------------------------------------
 SENTRY_DSN = env("SENTRY_DSN")
-SENTRY_KEY = env("SENTRY_KEY", default="")
+SENTRY_KEY = env("SENTRY_KEY")
 SENTRY_LOG_LEVEL = env.int("DJANGO_SENTRY_LOG_LEVEL", logging.INFO)
 
 sentry_logging = LoggingIntegration(

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -218,6 +218,7 @@ LOGGING = {
 # Sentry
 # ------------------------------------------------------------------------------
 SENTRY_DSN = env("SENTRY_DSN")
+SENTRY_KEY = env("SENTRY_KEY")
 SENTRY_LOG_LEVEL = env.int("DJANGO_SENTRY_LOG_LEVEL", logging.INFO)
 
 sentry_logging = LoggingIntegration(

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-{% if SENTRY_DSN %}
-  <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SECRET_KEY }}.min.js"
+{% if SENTRY_KEY %}
+  <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SENTRY_KEY }}.min.js"
           crossorigin="anonymous"></script>
 {% endif %}

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -1,6 +1,6 @@
 {% load static %}
 
 {% if SENTRY_DSN %}
-  <script src='https://js.sentry-cdn.com/238aed8c0da24d48b8543973041f2f8c.min.js'
+  <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SENTRY_DSN }}.min.js"
           crossorigin="anonymous"></script>
 {% endif %}

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -1,6 +1,6 @@
 {% load static %}
 
 {% if SENTRY_DSN %}
-  <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SENTRY_DSN }}.min.js"
+  <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SECRET_KEY }}.min.js"
           crossorigin="anonymous"></script>
 {% endif %}

--- a/envergo/utils/context_processors.py
+++ b/envergo/utils/context_processors.py
@@ -41,6 +41,7 @@ def settings_context(_request):
         "DEBUG": settings.DEBUG,
         "ANALYTICS": analytics,
         "SENTRY_DSN": settings.SENTRY_DSN,
+        "SENTRY_KEY": settings.SENTRY_KEY,
         "ENV_NAME": settings.ENV_NAME,
         "CRISP_CHATBOX_ENABLED": chatbox_enabled,
         "CRISP_WEBSITE_ID": crisp_website_id,


### PR DESCRIPTION
Ajout du loader-script dans sentry.

Il faudrait ajouter `SENTRY_KEY` dans les variables d'environnement sur scalingo, pour éviter d'avoir la clé en dur dans le script.