### PR TITLE
Update ecoulement_avec_bv_action_requise.html

### DIFF
--- a/envergo/templates/moulinette/loi_sur_leau/ecoulement_avec_bv_action_requise.html
+++ b/envergo/templates/moulinette/loi_sur_leau/ecoulement_avec_bv_action_requise.html
@@ -18,9 +18,11 @@
   </p>
 {% else %}
   <p>La surface totale du projet est de {{ final_surface }} m².</p>
+  {% if catchment_surface > 0 %}
   <p>
     Au vu de la topographie du terrain environnant le projet, l’aire du bassin versant intercepté est susceptible d’atteindre {{ catchment_surface }} m².
   </p>
+  {% endif %}
 {% endif %}
 
 <p>

--- a/envergo/templates/moulinette/loi_sur_leau/ecoulement_avec_bv_action_requise.html
+++ b/envergo/templates/moulinette/loi_sur_leau/ecoulement_avec_bv_action_requise.html
@@ -19,9 +19,9 @@
 {% else %}
   <p>La surface totale du projet est de {{ final_surface }} m².</p>
   {% if catchment_surface > 0 %}
-  <p>
-    Au vu de la topographie du terrain environnant le projet, l’aire du bassin versant intercepté est susceptible d’atteindre {{ catchment_surface }} m².
-  </p>
+    <p>
+      Au vu de la topographie du terrain environnant le projet, l’aire du bassin versant intercepté est susceptible d’atteindre {{ catchment_surface }} m².
+    </p>
   {% endif %}
 {% endif %}
 

--- a/envergo/templates/moulinette/natura2000/result_action_requise.html
+++ b/envergo/templates/moulinette/natura2000/result_action_requise.html
@@ -11,21 +11,6 @@
     une action du porteur de projet est requise.
   </p>
 
-  <p>Le projet peut être soumis à Natura 2000 pour plusieurs raisons :</p>
-  <ul>
-    <li>
-      s’il s’avère soumis à la Loi sur l’eau – <a href="#regulation_loi_sur_leau">voir section « Loi sur l'eau »</a> sur cette page ;
-    </li>
-
-    {% if moulinette.natura2000.autorisation_urba.result == 'a_verifier' %}
-      <li>
-        ou dans certains cas, s’il est soumis à une autorisation d’urbanisme – voir rubrique <a href="#criterion-{{ regulation.autorisation_urba.unique_slug }}">{{ regulation.autorisation_urba }}</a> » ci-dessous ;
-      </li>
-    {% endif %}
-
-    <li>ou s’il a certains impacts sur le milieu ; une action du porteur de projet est requise à ce titre.</li>
-  </ul>
-
 {% else %}
 
   {% if moulinette.natura2000.autorisation_urba.result == 'a_verifier' %}


### PR DESCRIPTION
Dans le cas où le bassin versant calculé est de zéro m2, il est inutile et contre productif de préciser sa valeur, voir remarque https://trello.com/c/yiJY5NLW/498-cas-o%C3%B9-le-bv-intercept%C3%A9-est-0

Ticket : https://trello.com/c/yDh6oMc2/1514-exception-cas-bv-vaut-z%C3%A9ro