### PR TITLE
Fix/carto ratio fix1

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -445,7 +445,7 @@ class Regulation(models.Model):
                 entries=polygons,
                 truncate=False,
                 zoom=None,
-                ratio="ratio-2x1 ratio-sm-4x5",
+                ratio_classes="ratio-2x1 ratio-sm-4x5",
                 fixed=False,
             )
             return map

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -445,7 +445,7 @@ class Regulation(models.Model):
                 entries=polygons,
                 truncate=False,
                 zoom=None,
-                ratio="2x1",
+                ratio="ratio-2x1 ratio-sm-4x5",
                 fixed=False,
             )
             return map

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -61,7 +61,7 @@ class Map:
     caption: str = None  # Legend displayed below the map
     truncate: bool = True  # Should the displayed polygons be truncated?
     zoom: int = 17  # the map zoom to pass to leaflet
-    ratio: str = (
+    ratio_classes: str = (
         "ratio-4x3 ratio-sm-4x5"  # Check for "project.scss" for available ratios
     )
     fixed: bool = True  # Is the map fixed or can it be zoomed and dragged?

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -61,7 +61,7 @@ class Map:
     caption: str = None  # Legend displayed below the map
     truncate: bool = True  # Should the displayed polygons be truncated?
     zoom: int = 17  # the map zoom to pass to leaflet
-    ratio: str = "4x3"  # Check for "project.scss" for available ratios
+    ratio: str = "16x9 2x3"  # Check for "project.scss" for available ratios
     fixed: bool = True  # Is the map fixed or can it be zoomed and dragged?
     type: str = "criterion"  # Can be "criterion" or "regulation"
 

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -61,7 +61,9 @@ class Map:
     caption: str = None  # Legend displayed below the map
     truncate: bool = True  # Should the displayed polygons be truncated?
     zoom: int = 17  # the map zoom to pass to leaflet
-    ratio: str = "4x3"  # Check for "project.scss" for available ratios
+    ratio: str = (
+        "ratio-4x3 ratio-sm-4x5"  # Check for "project.scss" for available ratios
+    )
     fixed: bool = True  # Is the map fixed or can it be zoomed and dragged?
     type: str = "criterion"  # Can be "criterion" or "regulation"
 

--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -61,7 +61,7 @@ class Map:
     caption: str = None  # Legend displayed below the map
     truncate: bool = True  # Should the displayed polygons be truncated?
     zoom: int = 17  # the map zoom to pass to leaflet
-    ratio: str = "16x9 2x3"  # Check for "project.scss" for available ratios
+    ratio: str = "4x3"  # Check for "project.scss" for available ratios
     fixed: bool = True  # Is the map fixed or can it be zoomed and dragged?
     type: str = "criterion"  # Can be "criterion" or "regulation"
 

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -632,7 +632,9 @@ form#request-evaluation-form {
 .ratio-1x1,
 .ratio-4x3,
 .ratio-2x3,
+.ratio-4x5,
 .ratio-sm-2x3,
+.ratio-sm-4x5,
 .ratio-2x1,
 .ratio-16x9 {
   width: 100%;
@@ -655,6 +657,12 @@ form#request-evaluation-form {
 .ratio-2x3 {
   &::before {
     padding-bottom: 150%;
+  }
+}
+
+.ratio-4x5 {
+  &::before {
+    padding-bottom: 125%;
   }
 }
 
@@ -682,10 +690,16 @@ form#request-evaluation-form {
   }
 }
 
-@media (width < 767px) and (orientation: portrait) {
+@media (width < 767px) and (aspect-ratio < 2/3) {
   .ratio-sm-2x3 {
     &::before {
       padding-bottom: 150%;
+    }
+  }
+
+  .ratio-sm-4x5 {
+    &::before {
+      padding-bottom: 125%;
     }
   }
 }

--- a/envergo/templates/_map_snippet.html
+++ b/envergo/templates/_map_snippet.html
@@ -1,5 +1,5 @@
 <figure class="fr-content-media" role="group">
-  <div class="ratio-{{ map.ratio_classes }}">
+  <div class="{{ map.ratio_classes }}">
     <div class="ratio-content">
       <div class="leaflet-container">
         <div id="map-{{ map_id }}"></div>

--- a/envergo/templates/_map_snippet.html
+++ b/envergo/templates/_map_snippet.html
@@ -1,5 +1,5 @@
 <figure class="fr-content-media" role="group">
-  <div class="ratio-{{ map.ratio }}">
+  <div class="ratio-{{ map.ratio_classes }}">
     <div class="ratio-content">
       <div class="leaflet-container">
         <div id="map-{{ map_id }}"></div>

--- a/envergo/templates/amenagement/moulinette/form.html
+++ b/envergo/templates/amenagement/moulinette/form.html
@@ -29,7 +29,7 @@
             </label>
             <figure class="fr-content-media">
               <div id="map-container"
-                   class="ratio-16x9 ratio-sm-2x3 fr-mt-1w fr-mb-2w fr-raw-link">
+                   class="ratio-16x9 ratio-sm-4x5 fr-mt-1w fr-mb-2w fr-raw-link">
                 <div class="ratio-content">
                   <div class="leaflet-container">
                     <div id="map"></div>

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -13,7 +13,8 @@
   {{ form.lng.as_hidden }}
   {{ form.lat.as_hidden }}
   <figure class="fr-content-media">
-    <div id="map-container" class="ratio-4x3 fr-mt-1w fr-mb-2w fr-raw-link">
+    <div id="map-container"
+         class="ratio-4x3 ratio-sm-2x3 fr-mt-1w fr-mb-2w fr-raw-link">
       <div class="ratio-content">
         <div class="leaflet-container">
           <div id="map">

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -14,7 +14,7 @@
   {{ form.lat.as_hidden }}
   <figure class="fr-content-media">
     <div id="map-container"
-         class="ratio-4x3 ratio-sm-2x3 fr-mt-1w fr-mb-2w fr-raw-link">
+         class="ratio-4x3 ratio-sm-4x5 fr-mt-1w fr-mb-2w fr-raw-link">
       <div class="ratio-content">
         <div class="leaflet-container">
           <div id="map">

--- a/envergo/templates/amenagement/moulinette/result_debug.html
+++ b/envergo/templates/amenagement/moulinette/result_debug.html
@@ -40,7 +40,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="perimeter-map-{{ forloop.counter0 }}"></div>
@@ -79,7 +79,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="criterion-map-{{ forloop.counter0 }}"></div>
@@ -120,7 +120,7 @@
     {% for map_type in map_list %}
       <h3>{{ map_type.list.0.map.get_map_type_display }} ({{ map_type.list.0.map.get_data_type_display }})</h3>
 
-      <div class="ratio-1x1 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="zone-map-{{ forloop.counter0 }}"></div>

--- a/envergo/templates/amenagement/moulinette/result_debug.html
+++ b/envergo/templates/amenagement/moulinette/result_debug.html
@@ -40,7 +40,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
+      <div class="ratio-4x3 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="perimeter-map-{{ forloop.counter0 }}"></div>
@@ -79,7 +79,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
+      <div class="ratio-4x3 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="criterion-map-{{ forloop.counter0 }}"></div>
@@ -120,7 +120,7 @@
     {% for map_type in map_list %}
       <h3>{{ map_type.list.0.map.get_map_type_display }} ({{ map_type.list.0.map.get_data_type_display }})</h3>
 
-      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
+      <div class="ratio-4x3 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="zone-map-{{ forloop.counter0 }}"></div>

--- a/envergo/templates/amenagement/moulinette/result_debug.html
+++ b/envergo/templates/amenagement/moulinette/result_debug.html
@@ -40,7 +40,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="perimeter-map-{{ forloop.counter0 }}"></div>
@@ -79,7 +79,7 @@
         <a href="{% url 'admin:geodata_map_change' map.grouper.id %}">{{ map.grouper.name }} (id={{ map.grouper.id }})</a>
       </h3>
 
-      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="criterion-map-{{ forloop.counter0 }}"></div>
@@ -120,7 +120,7 @@
     {% for map_type in map_list %}
       <h3>{{ map_type.list.0.map.get_map_type_display }} ({{ map_type.list.0.map.get_data_type_display }})</h3>
 
-      <div class="ratio-1x1 ratio-sm-2x3 fr-mt-1w fr-mb-3w">
+      <div class="ratio-1x1 ratio-sm-4x5 fr-mt-1w fr-mb-3w">
         <div class="ratio-content">
           <div class="leaflet-container">
             <div id="zone-map-{{ forloop.counter0 }}"></div>

--- a/envergo/templates/evaluations/_content.html
+++ b/envergo/templates/evaluations/_content.html
@@ -25,7 +25,7 @@
 
 <h2 class="fr-h3">Caractéristiques du projet</h2>
 
-<div class="ratio-16x9 ratio-sm-2x3 fr-mt-1w fr-mb-2w">
+<div class="ratio-16x9 ratio-sm-4x5 fr-mt-1w fr-mb-2w">
   <div class="ratio-content">
     <div class="leaflet-container">
       <div id="map"></div>

--- a/envergo/templates/geodata/2150_debug.html
+++ b/envergo/templates/geodata/2150_debug.html
@@ -19,7 +19,7 @@
             l'emplacement du projet.
           </label>
 
-          <div class="ratio-4x3 ratio-sm-2x3 fr-my-3w">
+          <div class="ratio-4x3 ratio-sm-4x5 fr-my-3w">
             <div class="ratio-content">
               <div id="map"></div>
             </div>

--- a/envergo/templates/geodata/admin/map_preview.html
+++ b/envergo/templates/geodata/admin/map_preview.html
@@ -16,7 +16,7 @@
   </div>
 
   <figure class="fr-content-media fr-mt-0" role="group">
-    <div class="ratio-16x9 ratio-sm-2x3">
+    <div class="ratio-16x9 ratio-sm-4x5">
       <div class="ratio-content">
         <div class="leaflet-container">
           <div id="map"></div>

--- a/envergo/templates/geodata/map.html
+++ b/envergo/templates/geodata/map.html
@@ -25,7 +25,7 @@
 {% block content %}
   <article>
     <h1>Carte</h1>
-    <div class="ratio-4x3 ratio-sm-2x3">
+    <div class="ratio-4x3 ratio-sm-4x5">
       <div class="ratio-content">{% leaflet_map 'map' callback="window.mapInit" %}</div>
     </div>
   </article>

--- a/envergo/templates/hedges/admin/hedge_map.html
+++ b/envergo/templates/hedges/admin/hedge_map.html
@@ -16,7 +16,7 @@
   </div>
 
   <figure class="fr-content-media fr-mt-0" role="group">
-    <div class="ratio-16x9 ratio-sm-2x3">
+    <div class="ratio-16x9 ratio-sm-4x5">
       <div class="ratio-content">
         <div class="leaflet-container">
           <div id="map"></div>

--- a/envergo/templates/pages/map.html
+++ b/envergo/templates/pages/map.html
@@ -38,7 +38,7 @@
       </div>
     </template>
 
-    <div class="ratio-4x3 ratio-sm-2x3">
+    <div class="ratio-4x3 ratio-sm-4x5">
       <div class="ratio-content">{% leaflet_map 'cadastre_map' callback="window.mapInit" %}</div>
     </div>
   </article>


### PR DESCRIPTION
- Ajout du ratio 4:5 dans la CSS
- Utilise le ratio 4:5 pour les cartes pour : width < 768px et ratio < 2/3