### PR TITLE
Haie / La liste des espèces protégées n'apparaît pas dans le template de la page /consultation

### DIFF
--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -399,6 +399,7 @@ class PetitionProjectDetail(DetailView):
 
         context["petition_project"] = self.object
         context["moulinette"] = moulinette
+        context.update(moulinette.catalog)
         context["base_result"] = moulinette.get_result_template()
         context["is_read_only"] = True
         context["plantation_evaluation"] = PlantationEvaluator(


### PR DESCRIPTION
https://trello.com/c/tzOHwepP/1516-haie-la-liste-des-esp%C3%A8ces-prot%C3%A9g%C3%A9es-nappara%C3%AEt-pas-dans-le-template-de-la-page-consultation