### PR TITLE
Ajoute un moyen de facilement désactiver la debug toolbar

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -52,21 +52,21 @@ INSTALLED_APPS = ["whitenoise.runserver_nostatic"] + INSTALLED_APPS  # noqa F405
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
-INSTALLED_APPS += ["debug_toolbar"]  # noqa F405
-# https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
-MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
-# https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
-DEBUG_TOOLBAR_CONFIG = {
-    "DISABLE_PANELS": [
-        "debug_toolbar.panels.redirects.RedirectsPanel",
-        # Disable profiling panel due to an issue with Python 3.12:
-        # https://github.com/jazzband/django-debug-toolbar/issues/1875
-        "debug_toolbar.panels.profiling.ProfilingPanel",
-        # We have too many static files, which makes this panel really slow
-        "debug_toolbar.panels.staticfiles.StaticFilesPanel",
-    ],
-    "SHOW_TEMPLATE_CONTEXT": True,
-}
+
+if env("USE_DEBUG_TOOLBAR", default="yes") == "yes":
+    INSTALLED_APPS += ["debug_toolbar"]  # noqa F405
+    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
+    DEBUG_TOOLBAR_CONFIG = {
+        "DISABLE_PANELS": [
+            "debug_toolbar.panels.redirects.RedirectsPanel",
+            # Disable profiling panel due to an issue with Python 3.12:
+            # https://github.com/jazzband/django-debug-toolbar/issues/1875
+            "debug_toolbar.panels.profiling.ProfilingPanel",
+            # We have too many static files, which makes this panel really slow
+            "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+        ],
+        "SHOW_TEMPLATE_CONTEXT": True,
+    }
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 if env("USE_DOCKER") == "yes":


### PR DESCRIPTION
J'ai trop de perfs avec la debug toolbar, j'ai ajouté un moyen de facilement la désactiver via le .env.