### PR TITLE
Corrige l'erreur Sentry "key error : additional_form_bounds"

### DIFF
--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -106,12 +106,7 @@ class MoulinetteMixin:
             # first appears, but the way this feature is designed, said forms
             # are always "bound" when they appear. So we have to check for the
             # presence of field keys in the GET parameters.
-            additional_forms_bound = False
-            field_keys = context["additional_fields"].keys()
-            for key in field_keys:
-                if key in self.request.GET:
-                    additional_forms_bound = True
-                    break
+            additional_forms_bound = any(key in self.request.GET for key in context["additional_fields"].keys())
             context["additional_forms_bound"] = additional_forms_bound
 
             moulinette_data = moulinette.summary()

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -105,7 +105,9 @@ class MoulinetteMixin:
             # first appears, but the way this feature is designed, said forms
             # are always "bound" when they appear. So we have to check for the
             # presence of field keys in the GET parameters.
-            additional_forms_bound = any(key in self.request.GET for key in context["additional_fields"].keys())
+            additional_forms_bound = any(
+                key in self.request.GET for key in context["additional_fields"].keys()
+            )
             context["additional_forms_bound"] = additional_forms_bound
 
             moulinette_data = moulinette.summary()

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -227,7 +227,7 @@ class MoulinetteMixin:
             for field in additional_form:
                 get.setlist(
                     field.html_name,
-                    [QueryDict(additional_form.data).getlist(field.html_name)],
+                    QueryDict(additional_form.data).getlist(field.html_name),
                 )
 
         if self.should_activate_optional_criteria():
@@ -236,7 +236,7 @@ class MoulinetteMixin:
                 for field in optional_form:
                     get.setlist(
                         field.html_name,
-                        [QueryDict(optional_form.data.get(field.html_name))],
+                        QueryDict(optional_form.data.get(field.html_name)),
                     )
 
         triage_params = moulinette.get_triage_params()
@@ -400,7 +400,6 @@ class MoulinetteResult(MoulinetteMixin, FormView):
 
         # We don't want to take analytics params into account, so they stay in the url
         current_params = set([p for p in current_params if not p.startswith("mtm_")])
-
         return expected_params == current_params
 
     def get_moulinette_data(self):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -1,5 +1,4 @@
 import json
-from collections import OrderedDict
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.conf import settings

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -230,7 +230,8 @@ class MoulinetteMixin:
         for additional_form in additional_forms:
             for field in additional_form:
                 get.setlist(
-                    field.html_name, additional_form.data.getlist(field.html_name)
+                    field.html_name,
+                    [QueryDict(additional_form.data).getlist(field.html_name)],
                 )
 
         if self.should_activate_optional_criteria():
@@ -238,7 +239,8 @@ class MoulinetteMixin:
             for optional_form in optional_forms:
                 for field in optional_form:
                     get.setlist(
-                        field.html_name, optional_form.data.getlist(field.html_name)
+                        field.html_name,
+                        [QueryDict(optional_form.data.get(field.html_name))],
                     )
 
         triage_params = moulinette.get_triage_params()

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -339,6 +339,8 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             template_name = moulinette.get_debug_result_template()
         elif is_edit:
             template_name = moulinette.get_home_template()
+        elif not moulinette.has_config():
+            template_name = moulinette.get_result_non_disponible_template()
         elif not (moulinette.is_evaluation_available() or is_admin):
             template_name = moulinette.get_result_available_soon_template()
         elif moulinette.has_missing_data():

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -329,6 +329,9 @@ class MoulinetteResult(MoulinetteMixin, FormView):
         is_edit = bool(self.request.GET.get("edit", False))
         is_admin = self.request.user.is_staff
 
+        # We want to display the moulinette result template, but must check all
+        # previous cases where we cannot do it
+
         if moulinette is None and triage_form is None:
             MoulinetteClass = get_moulinette_class_from_site(self.request.site)
             template_name = MoulinetteClass.get_home_template()
@@ -338,12 +341,10 @@ class MoulinetteResult(MoulinetteMixin, FormView):
             template_name = moulinette.get_debug_result_template()
         elif is_edit:
             template_name = moulinette.get_home_template()
-        elif moulinette.has_missing_data():
-            template_name = moulinette.get_home_template()
-        elif not moulinette.has_config():
-            template_name = moulinette.get_result_non_disponible_template()
         elif not (moulinette.is_evaluation_available() or is_admin):
             template_name = moulinette.get_result_available_soon_template()
+        elif moulinette.has_missing_data():
+            template_name = moulinette.get_home_template()
         else:
             template_name = moulinette.get_result_template()
 


### PR DESCRIPTION
Corrige cette erreur :

https://sentry.incubateur.net/organizations/betagouv/issues/138930/?environment=production&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=0

Le problème est que si le département n'étais pas encore ouvert, et que l'utilisateur n'était pas loggué, on essayait d'afficher le résultat avec des données qui n'étaient pas dans le contexte.