### PR TITLE
Corrige l'erreur sentry sur le geocodage

### DIFF
--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -242,7 +242,7 @@ def get_data_from_coords(lng, lat, timeout=0.5, index="address", limit=1):
         KeyError,
         IndexError,
     ) as e:
-        logger.error(
+        logger.warning(
             "An error occured during the request to ign geocodage api",
             extra={"exception": e},
         )


### PR DESCRIPTION
Corrige cette erreur :

https://sentry.incubateur.net/organizations/betagouv/issues/141538/?environment=production&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=1

Parfois en cas de requête sur le géocodage, l'api renvoie une erreur ou un timeout, ce qui loggue une erreur dans Sentry. Toutefois, le cas est toujours géré dans le code, donc je pense qu'on peut remplacer par un warning sans soucis.