### PR TITLE
Corrige l'erreur sentry "attribute error none"

### DIFF
--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -579,9 +579,10 @@ class MoulinetteResultPlantation(MoulinetteResult):
         moulinette = context.get("moulinette", None)
         context["is_result_plantation"] = True
 
-        context["plantation_evaluation"] = PlantationEvaluator(
-            moulinette, moulinette.catalog["haies"]
-        )
+        if moulinette:
+            context["plantation_evaluation"] = PlantationEvaluator(
+                moulinette, moulinette.catalog["haies"]
+            )
 
         result_d_url = update_qs(reverse("moulinette_result"), self.request.GET)
         context["edit_plantation_url"] = update_fragment(result_d_url, "plantation")


### PR DESCRIPTION
Cette erreur Sentry:

https://sentry.incubateur.net/organizations/betagouv/issues/142490/?environment=production&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=0

Une petite erreur ou l'on essaye d'accéder à une donnée alors que la moulinette n'est pas définie.

Cette erreur survient alors qu'on essaye d'accéder à des « résultat plantation » avec des données invalides.

https://haie.beta.gouv.fr/simulateur/resultat-plantation/?lineaire_total=10000%24&localisation_pac=oui&motif=amelioration_ecologique&reimplantation=replantation

J'ai l'impression que c'est la même erreur qui revient plusieurs fois dans sentry, quelqu'un qui a réalisé une simulation avec « 10000$ » pour le linéaire total. Un onglet ouvert qui se recharge ?