### PR TITLE
Corrige les erreurs d'arrondis dans les longueurs de haie

### DIFF
--- a/envergo/hedges/admin.py
+++ b/envergo/hedges/admin.py
@@ -64,13 +64,13 @@ class HedgeDataAdmin(admin.ModelAdmin):
         return len(obj.hedges_to_plant())
 
     def length_to_plant(self, obj):
-        return obj.length_to_plant()
+        return round(obj.length_to_plant())
 
     def hedges_to_remove(self, obj):
         return len(obj.hedges_to_remove())
 
     def length_to_remove(self, obj):
-        return obj.length_to_remove()
+        return round(obj.length_to_remove())
 
     def all_species(self, obj):
         """Display list of protected species related to this hedge set."""

--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -161,13 +161,13 @@ class HedgeData(models.Model):
         return [Hedge(**h) for h in self.data if h["type"] == TO_PLANT]
 
     def length_to_plant(self):
-        return round(sum(h.length for h in self.hedges_to_plant()))
+        return sum(h.length for h in self.hedges_to_plant())
 
     def hedges_to_remove(self):
         return [Hedge(**h) for h in self.data if h["type"] == TO_REMOVE]
 
     def length_to_remove(self):
-        return round(sum(h.length for h in self.hedges_to_remove()))
+        return sum(h.length for h in self.hedges_to_remove())
 
     def hedges_to_remove_pac(self):
         return [
@@ -177,18 +177,16 @@ class HedgeData(models.Model):
         ]
 
     def lineaire_detruit_pac(self):
-        return round(sum(h.length for h in self.hedges_to_remove_pac()))
+        return sum(h.length for h in self.hedges_to_remove_pac())
 
     def lineaire_detruit_pac_including_alignement(self):
-        return round(sum(h.length for h in self.hedges_to_remove() if h.is_on_pac))
+        return sum(h.length for h in self.hedges_to_remove() if h.is_on_pac)
 
     def lineaire_type_4_sur_parcelle_pac(self):
-        return round(
-            sum(
-                h.length
-                for h in self.hedges_to_remove()
-                if h.is_on_pac and h.hedge_type == "alignement"
-            )
+        return sum(
+            h.length
+            for h in self.hedges_to_remove()
+            if h.is_on_pac and h.hedge_type == "alignement"
         )
 
     def is_removing_near_pond(self):
@@ -202,7 +200,7 @@ class HedgeData(models.Model):
     def minimum_length_to_plant(self):
         """Returns the minimum length of hedges to plant, considering the length of hedges to remove and the
         replantation coefficient"""
-        return round(R * self.length_to_remove())
+        return R * self.length_to_remove()
 
     def get_minimum_lengths_to_plant(self):
         lengths_by_type = defaultdict(int)

--- a/envergo/hedges/static/hedge_input/app.js
+++ b/envergo/hedges/static/hedge_input/app.js
@@ -21,7 +21,7 @@ const styles = {
 const fitBoundsOptions = { padding: [10, 10] };
 
 const mode = document.getElementById('app').dataset.mode;
-const minimumLengthToPlant = document.getElementById('app').dataset.minimumLengthToPlant;
+const minimumLengthToPlant = parseFloat(document.getElementById('app').dataset.minimumLengthToPlant);
 const qualityUrl = document.getElementById('app').dataset.qualityUrl;
 
 // Show the "description de la haie" form modal

--- a/envergo/hedges/static/hedge_input/app.js
+++ b/envergo/hedges/static/hedge_input/app.js
@@ -1,4 +1,4 @@
-const {createApp, ref, onMounted, reactive, computed, watch, toRaw} = Vue
+const { createApp, ref, onMounted, reactive, computed, watch, toRaw } = Vue
 
 const TO_PLANT = 'TO_PLANT';
 const TO_REMOVE = 'TO_REMOVE';
@@ -28,7 +28,7 @@ const qualityUrl = document.getElementById('app').dataset.qualityUrl;
 const showHedgeModal = (hedge, hedgeType) => {
 
   const fillBooleanField = (fieldElement, fieldName, data) => {
-     if(fieldElement && data.hasOwnProperty(fieldName)) {
+    if (fieldElement && data.hasOwnProperty(fieldName)) {
       fieldElement.checked = data[fieldName];
     }
   }
@@ -36,7 +36,7 @@ const showHedgeModal = (hedge, hedgeType) => {
   const isReadonly = (hedgeType !== TO_PLANT || mode !== PLANTATION_MODE) && (hedgeType !== TO_REMOVE || mode !== REMOVAL_MODE);
   const dialogMode = hedgeType === TO_PLANT ? PLANTATION_MODE : REMOVAL_MODE;
 
-  const dialogId= `${dialogMode}-hedge-data-dialog`
+  const dialogId = `${dialogMode}-hedge-data-dialog`
   const dialog = document.getElementById(dialogId);
   const form = dialog.querySelector("form");
   const hedgeTypeField = document.getElementById(`id_${dialogMode}-hedge_type`);
@@ -120,7 +120,7 @@ const showHedgeModal = (hedge, hedgeType) => {
     dsfr(dialog).modal.conceal();
   };
 
-  if(isReadonly) {
+  if (isReadonly) {
     const inputs = form.querySelectorAll("input");
     const selects = form.querySelectorAll("select");
 
@@ -129,11 +129,11 @@ const showHedgeModal = (hedge, hedgeType) => {
     const submitButton = form.querySelector("button[type='submit']");
     submitButton.innerText = "Retour";
 
-    form.addEventListener("submit", closeModal, {once: true});
+    form.addEventListener("submit", closeModal, { once: true });
   }
   else {
     // Save data upon form submission
-    form.addEventListener("submit", saveModalData, {once: true});
+    form.addEventListener("submit", saveModalData, { once: true });
   }
 
   // If the modal is closed without saving, let's make sure to remove the
@@ -253,7 +253,7 @@ class Hedge {
       proximitePointEau,
       connexionBoisement,
       sousLigneElectrique,
-      proximiteVoirie  } = this.additionalData;
+      proximiteVoirie } = this.additionalData;
 
     const valid =
       typeHaie !== undefined
@@ -261,13 +261,13 @@ class Hedge {
       && proximitePointEau !== undefined
       && connexionBoisement !== undefined
       && proximiteMare !== undefined
-      &&(
+      && (
         (this.type === TO_REMOVE
-        && surParcellePac !== undefined
-        && vieilArbre !== undefined)
+          && surParcellePac !== undefined
+          && vieilArbre !== undefined)
         || (this.type === TO_PLANT
-        && sousLigneElectrique !== undefined
-        && proximiteVoirie !== undefined)
+          && sousLigneElectrique !== undefined
+          && proximiteVoirie !== undefined)
       );
 
     return valid;
@@ -393,11 +393,11 @@ createApp({
     const helpBubble = mode !== READ_ONLY_MODE ? ref("initialHelp") : ref(null);
     const hedgeBeingDrawn = ref(null);
 
-     // Reactive properties for quality conditions
+    // Reactive properties for quality conditions
     const quality = reactive({
-      "length_to_plant": {"result": false, "minimum_length_to_plant": minimumLengthToPlant, "left_to_plant": minimumLengthToPlant},
-      "quality": {"result": false, "missing_plantation": {"mixte": 0, "alignement": 0, "arbustive": 0, "buissonante": 0, "degradee":0}},
-      "do_not_plant_under_power_line": {"result": true}
+      "length_to_plant": { "result": false, "minimum_length_to_plant": minimumLengthToPlant, "left_to_plant": minimumLengthToPlant },
+      "quality": { "result": false, "missing_plantation": { "mixte": 0, "alignement": 0, "arbustive": 0, "buissonante": 0, "degradee": 0 } },
+      "do_not_plant_under_power_line": { "result": true }
     });
 
     // Computed property to track changes in the hedges array
@@ -442,7 +442,7 @@ createApp({
       return startDrawing(TO_REMOVE);
     };
 
-    const stopDrawing= () => {
+    const stopDrawing = () => {
       hedgeBeingDrawn.value = null;
       helpBubble.value = null;
       window.removeEventListener('keyup', cancelDrawingFromEscape);
@@ -453,17 +453,17 @@ createApp({
       stopDrawing();
     };
 
-    const cancelDrawing= () => {
-       if (hedgeBeingDrawn.value) {
-         hedgeBeingDrawn.value.polyline.off('editable:drawing:end', onDrawingEnd); // Remove the event listener
-         hedgeBeingDrawn.value.remove();
-         stopDrawing();
-       }
+    const cancelDrawing = () => {
+      if (hedgeBeingDrawn.value) {
+        hedgeBeingDrawn.value.polyline.off('editable:drawing:end', onDrawingEnd); // Remove the event listener
+        hedgeBeingDrawn.value.remove();
+        stopDrawing();
+      }
     };
 
     const cancelDrawingFromEscape = (event) => {
-      if (event.key === 'Escape'){
-          cancelDrawing();
+      if (event.key === 'Escape') {
+        cancelDrawing();
       }
     };
 
@@ -474,7 +474,7 @@ createApp({
       let allHedges = hedges[TO_REMOVE].hedges.concat(hedges[TO_PLANT].hedges);
       if (allHedges.length > 0) {
         const group = new L.featureGroup(allHedges.map(p => p.polyline));
-        map.fitBounds(group.getBounds(), {...fitBoundsOptions, animate: animate, padding: [50,50]});
+        map.fitBounds(group.getBounds(), { ...fitBoundsOptions, animate: animate, padding: [50, 50] });
       }
     };
 
@@ -486,7 +486,7 @@ createApp({
       return hedgesToPlant.concat(hedgesToRemove);
     }
 
-// We first check if all hedges are valid
+    // We first check if all hedges are valid
     const saveData = () => {
       const hedgesToValidate = mode === REMOVAL_MODE ? hedges[TO_REMOVE].hedges : hedges[TO_PLANT].hedges;
       const isValid = hedgesToValidate.every((hedge) => hedge.isValid());
@@ -536,8 +536,8 @@ createApp({
 
         const dismissHandler = () => {
           dsfr(dialog).modal.conceal();
-          if(event && event.type === 'popstate') {
-            history.pushState({modalOpen: true}, "", "#modal");
+          if (event && event.type === 'popstate') {
+            history.pushState({ modalOpen: true }, "", "#modal");
           }
         };
 
@@ -570,9 +570,9 @@ createApp({
         // We don't restore ids, but since we restore hedges in the same order
         // they were created, they should get the correct ids anyway.
         const hedge = addHedge(type, latLngs, additionalData, true);
-        if(type === TO_PLANT && mode === REMOVAL_MODE) {
+        if (type === TO_PLANT && mode === REMOVAL_MODE) {
           hedge.polyline.disableEdit();
-        }else if(type === TO_REMOVE && mode === PLANTATION_MODE) {
+        } else if (type === TO_REMOVE && mode === PLANTATION_MODE) {
           hedge.polyline.disableEdit();
         }
       });
@@ -586,8 +586,8 @@ createApp({
     });
 
     const onHedgesToPlantChange = () => {
-   // Prepare the hedge data to be sent in the request body
-    const hedgeData = serializeHedgesData();
+      // Prepare the hedge data to be sent in the request body
+      const hedgeData = serializeHedgesData();
 
       fetch(qualityUrl, {
         method: 'POST',

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -228,7 +228,9 @@ class HedgeDataChoiceField(forms.ModelChoiceField):
 
     def get_display_value(self, value):
         data = self.clean(value)
-        display_value = f"{data.length_to_remove()} m / {data.length_to_plant()} m"
+        display_value = (
+            f"{round(data.length_to_remove())} m / {round(data.length_to_plant())} m"
+        )
         return display_value
 
 

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1768,7 +1768,7 @@ class MoulinetteHaie(Moulinette):
         fields = super().summary_fields()
 
         # add an entry in the project summary
-        lineaire_detruit_pac = self.catalog.get("lineaire_detruit_pac", 0)
+        lineaire_detruit_pac = round(self.catalog.get("lineaire_detruit_pac", 0))
         localisation_pac = self.catalog.get("localisation_pac", False)
 
         if localisation_pac and lineaire_detruit_pac > 0:

--- a/envergo/moulinette/templatetags/moulinette.py
+++ b/envergo/moulinette/templatetags/moulinette.py
@@ -276,7 +276,7 @@ def show_haie_plantation_evaluation(context, plantation_evaluation):
         f"haie/moulinette/plantation_evaluation/{plantation_evaluation.result}.html"
     )
 
-    context_data["minimum_length_to_plant"] = (
+    context_data["minimum_length_to_plant"] = round(
         context_data["moulinette"].catalog["haies"].minimum_length_to_plant()
     )
 

--- a/envergo/templates/haie/moulinette/form.html
+++ b/envergo/templates/haie/moulinette/form.html
@@ -44,7 +44,7 @@
                       {# djlint:off #}{{ hedges_to_remove|length|intcomma }} tracé{% if hedges_to_remove|length > 1 %}s{% endif %}{# djlint:on #}
                     </p>
                     <p>
-                      Linéaire total : <span id="length-to-remove">{{ form.cleaned_data.haies.length_to_remove|intcomma }}</span> m
+                      Linéaire total : <span id="length-to-remove">{{ form.cleaned_data.haies.length_to_remove|floatformat:0 }}</span> m
                     </p>
                     {% if form.cleaned_data.haies.lineaire_detruit_pac_including_alignement > 0 %}
                       <p>

--- a/envergo/templates/haie/moulinette/form.html
+++ b/envergo/templates/haie/moulinette/form.html
@@ -147,8 +147,8 @@
           let lengthToRemove = statsContent.getElementById("length-to-remove");
           let lineaireDetruitPac = statsContent.getElementById("lineaire-detruit-pac");
           let hedgesToRemoveCount = statsContent.getElementById("hedges-to-remove-count");
-          lengthToRemove.textContent = event.data.length_to_remove.toLocaleString('fr-FR');
-          lineaireDetruitPac.textContent = event.data.lineaire_detruit_pac === 0 ? "Aucune haie située sur des parcelles PAC" : `dont ${event.data.lineaire_detruit_pac.toLocaleString('fr-FR')} m situés sur des parcelles PAC`;
+          lengthToRemove.textContent = Math.round(event.data.length_to_remove).toLocaleString('fr-FR');
+          lineaireDetruitPac.textContent = event.data.lineaire_detruit_pac === 0 ? "Aucune haie située sur des parcelles PAC" : `dont ${Math.round(event.data.lineaire_detruit_pac).toLocaleString('fr-FR')} m situés sur des parcelles PAC`;
           hedgesToRemoveCount.textContent = `${event.data.hedges_to_remove === 0 ? "Aucun" : event.data.hedges_to_remove.toLocaleString('fr-FR')} tracé${event.data.hedges_to_remove > 1 ? "s" : ""}`;
           statisticsContainer.innerHTML = "";
           statisticsContainer.appendChild(statsContent);

--- a/envergo/templates/haie/moulinette/result/soumis.html
+++ b/envergo/templates/haie/moulinette/result/soumis.html
@@ -10,11 +10,11 @@
 </p>
 
 <h6>
-  🌳 <strong>Plantation requise : {{ minimum_length_to_plant }} m</strong>
+  🌳 <strong>Plantation requise : {{ minimum_length_to_plant|floatformat:0 }} m</strong>
 </h6>
 <p>
   Au vu des caractéristiques des haies détruites, la plantation d’une longueur minimale de
-  {{ minimum_length_to_plant }} m sera exigée pour que le projet puisse être autorisé.
+  {{ minimum_length_to_plant|floatformat:0 }} m sera exigée pour que le projet puisse être autorisé.
 </p>
 <p>
   Prochaine étape :

--- a/envergo/templates/haie/petitions/mattermost_dossier_submission_notif.txt
+++ b/envergo/templates/haie/petitions/mattermost_dossier_submission_notif.txt
@@ -6,5 +6,5 @@ Un dossier a été soumis sur Démarches Simplifiées pour {{ demarche_label|saf
 [Admin django]({{ admin_url }})
 —
 Email de l'usager : {{ usager_email }}
-Linéaire détruit : {{ length_to_remove }} m
+Linéaire détruit : {{ length_to_remove|floatformat:0 }} m
 —

--- a/envergo/templates/hedges/input.html
+++ b/envergo/templates/hedges/input.html
@@ -180,9 +180,9 @@
                   <h6>Longueur de la haie plantée</h6>
                   <p v-if="quality.length_to_plant.result">Le linéaire total planté est suffisant.</p>
                   <p v-else>
-                    Le linéaire total planté doit être supérieur à {{ minimum_length_to_plant }} m.
+                    Le linéaire total planté doit être supérieur à {{ minimum_length_to_plant|floatformat:0 }} m.
                     <br />
-                    Il manque au moins [[ quality.length_to_plant.left_to_plant ]] m.
+                    Il manque au moins [[ Math.round(quality.length_to_plant.left_to_plant) ]] m.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
https://trello.com/c/MFsWtWQA/1465-haie-diff%C3%A9rence-entre-les-arrondis-selon-les-conditions

Beaucoup d'erreurs liées à des imprécisions d'arrondis qui se cumulent (ex : on arrondit la longueur de chaque haie, et on fait le total ensuite).

Je suis parti sur la solution qui consiste à manipuler toutes les longueurs en `float`, et n'arrondir qu'au dernier moment, lors de l'affichage. Je vous laisse me dire si cela vous convient.