### PR TITLE
Initialise la carte sans le tooltip d'aide en mode read_only

### DIFF
--- a/envergo/hedges/static/hedge_input/app.js
+++ b/envergo/hedges/static/hedge_input/app.js
@@ -376,6 +376,9 @@ class HedgeList {
 }
 
 createApp({
+  /**
+   * Create show and draw hedges app
+   */
 
   // Prevent conflict with django template delimiters
   delimiters: ["[[", "]]"],
@@ -386,7 +389,8 @@ createApp({
       TO_PLANT: new HedgeList(TO_PLANT),
       TO_REMOVE: new HedgeList(TO_REMOVE),
     };
-    const helpBubble = ref("initialHelp");
+
+    const helpBubble = mode !== READ_ONLY_MODE ? ref("initialHelp") : ref(null);
     const hedgeBeingDrawn = ref(null);
 
      // Reactive properties for quality conditions


### PR DESCRIPTION
https://trello.com/c/Sm9wnbIf/1496-le-tooltip-est-visible-depuis-la-consultation-instructeur

Cette modification sera effective sur les vues projet (template `petition_project`) et instruction (template `instructor_view`)