### PR TITLE
Reordonne les polygones des zones humides dans le résultat

### DIFF
--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -86,12 +86,6 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
     def get_map(self):
         map_polygons = []
 
-        wetlands_qs = [
-            zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
-        ]
-        if wetlands_qs:
-            map_polygons.append(MapPolygon(wetlands_qs, BLUE, "Zone humide"))
-
         potential_qs = [
             zone
             for zone in self.catalog["potential_wetlands"]
@@ -101,6 +95,12 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
             map_polygons.append(
                 MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
             )
+
+        wetlands_qs = [
+            zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
+        ]
+        if wetlands_qs:
+            map_polygons.append(MapPolygon(wetlands_qs, BLUE, "Zone humide"))
 
         if self.catalog["wetlands_within_25m"]:
             caption = "Le projet se situe dans une zone humide référencée."

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -189,12 +189,6 @@ class ZoneInondable(ZoneInondableMixin, CriterionEvaluator):
     def get_map(self):
         map_polygons = []
 
-        zone_qs = [
-            zone for zone in self.catalog["flood_zones"] if zone.map.display_for_user
-        ]
-        if zone_qs:
-            map_polygons.append(MapPolygon(zone_qs, "red", "Zone inondable"))
-
         potential_qs = [
             zone
             for zone in self.catalog["potential_flood_zones"]
@@ -204,6 +198,12 @@ class ZoneInondable(ZoneInondableMixin, CriterionEvaluator):
             map_polygons.append(
                 MapPolygon(potential_qs, PINK, "Zone inondable potentielle")
             )
+
+        zone_qs = [
+            zone for zone in self.catalog["flood_zones"] if zone.map.display_for_user
+        ]
+        if zone_qs:
+            map_polygons.append(MapPolygon(zone_qs, "red", "Zone inondable"))
 
         if self.catalog["flood_zones_within_12m"]:
             caption = "Le projet se situe dans une zone inondable."

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -81,12 +81,6 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
     def get_map(self):
         map_polygons = []
 
-        wetlands_qs = [
-            zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
-        ]
-        if wetlands_qs:
-            map_polygons.append(MapPolygon(wetlands_qs, BLUE, "Zone humide"))
-
         potential_qs = [
             zone
             for zone in self.catalog["potential_wetlands"]
@@ -96,6 +90,12 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
             map_polygons.append(
                 MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
             )
+
+        wetlands_qs = [
+            zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
+        ]
+        if wetlands_qs:
+            map_polygons.append(MapPolygon(wetlands_qs, BLUE, "Zone humide"))
 
         if self.catalog["wetlands_within_25m"]:
             caption = "Le projet se situe dans une zone humide référencée."

--- a/envergo/moulinette/regulations/sage.py
+++ b/envergo/moulinette/regulations/sage.py
@@ -108,6 +108,16 @@ class ImpactZoneHumide(ZoneHumideMixin, CriterionEvaluator):
     def get_map(self):
         map_polygons = []
 
+        potential_qs = [
+            zone
+            for zone in self.catalog["potential_wetlands"]
+            if zone.map.display_for_user
+        ]
+        if potential_qs:
+            map_polygons.append(
+                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
+            )
+
         wetlands_qs = [
             zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
         ]
@@ -121,16 +131,6 @@ class ImpactZoneHumide(ZoneHumideMixin, CriterionEvaluator):
         ]
         if forbidden_wetlands_qs:
             map_polygons.append(MapPolygon(forbidden_wetlands_qs, BLUE, "Zone humide"))
-
-        potential_qs = [
-            zone
-            for zone in self.catalog["potential_wetlands"]
-            if zone.map.display_for_user
-        ]
-        if potential_qs:
-            map_polygons.append(
-                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
-            )
 
         if (
             self.catalog["wetlands_within_25m"]
@@ -354,6 +354,16 @@ class ImpactZoneHumideIOTA(ZoneHumideMixin, CriterionEvaluator):
     def get_map(self):
         map_polygons = []
 
+        potential_qs = [
+            zone
+            for zone in self.catalog["potential_wetlands"]
+            if zone.map.display_for_user
+        ]
+        if potential_qs:
+            map_polygons.append(
+                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
+            )
+
         wetlands_qs = [
             zone for zone in self.catalog["wetlands"] if zone.map.display_for_user
         ]
@@ -367,16 +377,6 @@ class ImpactZoneHumideIOTA(ZoneHumideMixin, CriterionEvaluator):
         ]
         if forbidden_wetlands_qs:
             map_polygons.append(MapPolygon(forbidden_wetlands_qs, BLUE, "Zone humide"))
-
-        potential_qs = [
-            zone
-            for zone in self.catalog["potential_wetlands"]
-            if zone.map.display_for_user
-        ]
-        if potential_qs:
-            map_polygons.append(
-                MapPolygon(potential_qs, LIGHTBLUE, "Zone humide potentielle")
-            )
 
         if (
             self.catalog["wetlands_within_25m"]


### PR DESCRIPTION
https://trello.com/c/HlU6teRv/1416-envergo-positionner-les-polygones-zh-effectives-au-dessus-des-potentielles

Dans l'ordre
- zones humides interdites (remarques: elles ont la même couleur que les zones humides effectives)
- zones humides effectives
- zones humides potentielles