### PR TITLE
Optimise le calcul des géométries pour l'affichage des cartes

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -439,7 +439,7 @@ class Regulation(models.Model):
             ]
             map = Map(
                 type="regulation",
-                center=self.moulinette.catalog["coords"],
+                center=self.moulinette.catalog["lng_lat"],
                 entries=polygons,
                 truncate=False,
                 zoom=None,

--- a/envergo/moulinette/regulations/loisurleau.py
+++ b/envergo/moulinette/regulations/loisurleau.py
@@ -130,7 +130,7 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,
@@ -214,7 +214,7 @@ class ZoneInondable(ZoneInondableMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,

--- a/envergo/moulinette/regulations/natura2000.py
+++ b/envergo/moulinette/regulations/natura2000.py
@@ -118,7 +118,7 @@ class ZoneHumide(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,
@@ -168,7 +168,7 @@ class ZoneInondable(ZoneInondableMixin, CriterionEvaluator):
 
             map_polygons = [MapPolygon(zone_qs, "red", "Zone inondable")]
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,

--- a/envergo/moulinette/regulations/sage.py
+++ b/envergo/moulinette/regulations/sage.py
@@ -163,7 +163,7 @@ class ImpactZoneHumide(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,
@@ -259,7 +259,7 @@ class ImpactZoneHumideStrict(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,
@@ -409,7 +409,7 @@ class ImpactZoneHumideIOTA(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,
@@ -494,7 +494,7 @@ class ImpactZoneHumideIOTAStrict(ZoneHumideMixin, CriterionEvaluator):
 
         if map_polygons:
             criterion_map = Map(
-                center=self.catalog["coords"],
+                center=self.catalog["lng_lat"],
                 entries=map_polygons,
                 caption=caption,
                 truncate=False,


### PR DESCRIPTION
https://trello.com/c/gUWH0qNk/1564-minimiser-le-t%C3%A9l%C3%A9chargement-de-polygones-en-python

- `lng_lat`  avec srid 4326 pour la génération des cartes, pour éviter une étape de reprojection