### PR TITLE
Envergo / Pouvoir décocher la case "à" dans l'envoi d'email d'AR

### DIFF
--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -366,6 +366,11 @@ class EvaluationAdmin(admin.ModelAdmin):
                 )
                 return HttpResponseRedirect(url)
 
+            # our email provider cannot send email without "To" recipients.
+            if len(to) == 0:
+                to = cc
+                cc = list()
+
             eval_email.to = to
             eval_email.cc = cc
             eval_email.bcc = bcc

--- a/envergo/static/sass/project_admin.scss
+++ b/envergo/static/sass/project_admin.scss
@@ -59,3 +59,8 @@ form .aligned .hedge ul {
   margin-left: 1em;
   list-style-type: inherit;
 }
+
+fieldset.module.recipients:has(input[type="checkbox"]:checked)
+  #no-recipients-message {
+  display: none;
+}

--- a/envergo/templates/evaluations/admin/email_avis.html
+++ b/envergo/templates/evaluations/admin/email_avis.html
@@ -51,6 +51,11 @@
           </div>
         </div>
       {% endfor %}
+      <ul id="no-recipients-message" class="messagelist">
+        <li class="warning">
+          Si vous décochez tous les destinataires “à”, l’email sera envoyé directement aux destinataires “copie”
+        </li>
+      </ul>
     </fieldset>
 
     <fieldset class="module recipients">


### PR DESCRIPTION
https://trello.com/c/pnetMBaq/1491-envergo-pouvoir-d%C3%A9cocher-la-case-%C3%A0-dans-lenvoi-demail-dar