### PR TITLE
Utilise un dossier factice si l'API démarches simplifiées n'est pas activée dans les paramètres.

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -39,6 +39,8 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 CELERY_TASK_ALWAYS_EAGER = True
 
+MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
+
 
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/envergo/petitions/demarches_simplifiees/data/fake_dossier.json
+++ b/envergo/petitions/demarches_simplifiees/data/fake_dossier.json
@@ -1,0 +1,209 @@
+{
+  "data": {
+    "dossier": {
+      "id": "RG9zc2llci0yMzE3ODQ0Mw==",
+      "number": 23178443,
+      "state": "en_construction",
+      "dateDepot": "2025-03-21T11:08:34+01:00",
+      "usager": {
+        "email": "hedy.lamarr@exemple.com"
+      },
+      "demandeur": {
+        "civilite": "Mme",
+        "nom": "Hedy",
+        "prenom": "Lamarr",
+        "email": null
+      },
+      "champs": [
+        {
+          "id": "Q2hhbXAtNDUzNDEzNQ==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNTA5MzU0NA==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3MA==",
+          "stringValue": "Agriculteur, agricultrice"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3MQ==",
+          "stringValue": "GAEC Choupi"
+        },
+        {
+          "id": "Q2hhbXAtNDUzNDE0NA==",
+          "stringValue": "Laon (02000)"
+        },
+        {
+          "id": "Q2hhbXAtNDUzNDE0NQ==",
+          "stringValue": "hedy.lamarr@exemple.com"
+        },
+        {
+          "id": "Q2hhbXAtNDU0MzkzMg==",
+          "stringValue": "01 23 45 67 89"
+        },
+        {
+          "id": "Q2hhbXAtNDU0MzkzOA==",
+          "stringValue": "123456789"
+        },
+        {
+          "id": "Q2hhbXAtNDUzNDE1Ng==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDc0NDcyMQ==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDU0Mzk0Mw==",
+          "stringValue": "http://haie.local:8000/projet/AT9ZK7/consultation/"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE4Nw==",
+          "stringValue": "Laon (02000)"
+        },
+        {
+          "id": "Q2hhbXAtNDUzNDE0Ng==",
+          "stringValue": "La motivation"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3Ng==",
+          "stringValue": "Ouiiii j'ai cherché"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3NQ==",
+          "stringValue": "TINA"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3Nw==",
+          "stringValue": "Au max"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE4OA==",
+          "stringValue": null
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3OA==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTE3OQ==",
+          "stringValue": "true"
+        },
+        {
+          "id": "Q2hhbXAtNDU5NjU1Mw==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTI4NA==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTI4Ng==",
+          "stringValue": "Aucune haie sur parcelle déclarée à la PAC"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTI4NQ==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDU5NjU2NA==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDg3NjQ5Nw==",
+          "stringValue": "Dérogation"
+        },
+        {
+          "id": "Q2hhbXAtNDg3NjUxNQ==",
+          "stringValue": "Je n'ai pas consulté les structures"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIwMQ==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDU5Nzc0Mw==",
+          "stringValue": "Hêtre et chêne"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIwMg==",
+          "stringValue": "Moins de 25 ans"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIwMw==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTI4Mg==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIwNg==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIwOQ==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxMQ==",
+          "stringValue": "Plus rarement"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxMg==",
+          "stringValue": "élagage"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxMw==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxNA==",
+          "stringValue": "hêtre chêne fresne peuplier"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxNQ==",
+          "stringValue": "oui"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxNg==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxOA==",
+          "stringValue": "oui"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIxOQ==",
+          "stringValue": "oui"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIyMA==",
+          "stringValue": "élagage tous les ans"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIyMQ==",
+          "stringValue": "false"
+        },
+        {
+          "id": "Q2hhbXAtNDU1OTU0Nw==",
+          "stringValue": ""
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTIyNA==",
+          "stringValue": "true"
+        },
+        {
+          "id": "Q2hhbXAtNDcyOTI4Mw==",
+          "stringValue": "true"
+        }
+      ],
+      "demarche": {
+        "title": "Guichet unique de la haie – Aisne (02) / TEST",
+        "number": 115910
+      }
+    }
+  }
+}

--- a/envergo/petitions/demarches_simplifiees/queries/get_dossier.gql
+++ b/envergo/petitions/demarches_simplifiees/queries/get_dossier.gql
@@ -1,0 +1,27 @@
+query getDossier($dossierNumber: Int!) {
+  dossier(number: $dossierNumber) {
+    id
+    number
+    state
+    dateDepot
+    usager {
+      email
+    }
+    demandeur {
+      ... on PersonnePhysique {
+        civilite
+        nom
+        prenom
+        email
+      }
+    }
+    champs {
+      id
+      stringValue
+    }
+    demarche {
+      title
+      number
+    }
+  }
+}

--- a/envergo/petitions/tests/test_services.py
+++ b/envergo/petitions/tests/test_services.py
@@ -1,7 +1,10 @@
 import datetime
+import json
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from django.conf import settings
 from django.test import override_settings
 
 from envergo.moulinette.tests.factories import ConfigHaieFactory
@@ -15,104 +18,46 @@ from envergo.petitions.tests.factories import (
 pytestmark = pytest.mark.django_db
 
 
+with open(
+    Path(
+        settings.APPS_DIR
+        / "petitions"
+        / "demarches_simplifiees"
+        / "data"
+        / "fake_dossier.json"
+    ),
+    "r",
+) as file:
+    GET_DOSSIER_FAKE_RESPONSE = json.load(file)
+
+
 @override_settings(DEMARCHES_SIMPLIFIEES=DEMARCHES_SIMPLIFIEES_FAKE)
 @patch("requests.post")
 def test_fetch_project_details_from_demarches_simplifiees(mock_post, haie_user, site):
+    """Test fetch project details from démarches simplifiées"""
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": {
-            "dossier": {
-                "id": "RG9zc2llci0yMTY4MzczOQ==",
-                "number": 21683739,
-                "state": "en_construction",
-                "dateDepot": "2025-01-29T16:25:03+01:00",
-                "usager": {"email": "pierre-yves.dezaunay@beta.gouv.fr"},
-                "demandeur": {
-                    "civilite": "Mme",
-                    "nom": "dez",
-                    "prenom": "dez",
-                    "email": None,
-                },
-                "champs": [
-                    {"id": "Q2hhbXAtNDUzNDEzNQ==", "stringValue": ""},
-                    {
-                        "id": "Q2hhbXAtNDcyOTE3MA==",
-                        "stringValue": "Agriculteur, agricultrice",
-                    },
-                    {"id": "Q2hhbXAtNDcyOTE3MQ==", "stringValue": "terminator"},
-                    {
-                        "id": "Q2hhbXAtNDUzNDE0NA==",
-                        "stringValue": "27 Route de Cantois 33760 Ladaux",
-                    },
-                    {"id": "Q2hhbXAtNDUzNDE0NQ==", "stringValue": "test@test.fr"},
-                    {"id": "Q2hhbXAtNDU0MzkzMg==", "stringValue": "06 12 34 56 78"},
-                    {"id": "Q2hhbXAtNDU0MzkzOA==", "stringValue": "123456789"},
-                    {"id": "Q2hhbXAtNDUzNDE1Ng==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDc0NDcyMQ==", "stringValue": ""},
-                    {
-                        "id": "Q2hhbXAtNDU0Mzk0Mw==",
-                        "stringValue": "http://haie.local:3000/projet/E6Y6E9",
-                    },
-                    {"id": "Q2hhbXAtNDcyOTE4Nw==", "stringValue": "Ladaux (33760)"},
-                    {"id": "Q2hhbXAtNDUzNDE0Ng==", "stringValue": "sdf"},
-                    {"id": "Q2hhbXAtNDcyOTE3NQ==", "stringValue": "sdf"},
-                    {"id": "Q2hhbXAtNDcyOTE3Ng==", "stringValue": "dsf"},
-                    {"id": "Q2hhbXAtNDcyOTE3Nw==", "stringValue": "dsf"},
-                    {"id": "Q2hhbXAtNDcyOTE4OA==", "stringValue": None},
-                    {"id": "Q2hhbXAtNDcyOTE3OA==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDcyOTE3OQ==", "stringValue": "true"},
-                    {"id": "Q2hhbXAtNDU5NjU1Mw==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDcyOTI4NA==", "stringValue": "true"},
-                    {
-                        "id": "Q2hhbXAtNDU1OTU2Mw==",
-                        "stringValue": "Réhabilitation d’un fossé",
-                    },
-                    {"id": "Q2hhbXAtNDcyOTE4NQ==", "stringValue": "xcb"},
-                    {"id": "Q2hhbXAtNDcyOTE4Ng==", "stringValue": "xvcb"},
-                    {"id": "Q2hhbXAtNDU5NjU2NA==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDcyOTIwMQ==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDU5Nzc0Mw==", "stringValue": "xcvb"},
-                    {"id": "Q2hhbXAtNDcyOTIwMg==", "stringValue": "Moins de 25 ans"},
-                    {"id": "Q2hhbXAtNDcyOTIwMw==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDcyOTI4Mg==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDcyOTIwNg==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDcyOTIwOQ==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDcyOTIxMQ==", "stringValue": "Plus rarement"},
-                    {"id": "Q2hhbXAtNDcyOTIxMg==", "stringValue": "xcv"},
-                    {"id": "Q2hhbXAtNDcyOTIxMw==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDcyOTIxNA==", "stringValue": "xcv"},
-                    {"id": "Q2hhbXAtNDcyOTIxNQ==", "stringValue": "xcvb"},
-                    {"id": "Q2hhbXAtNDcyOTIxNg==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDcyOTIxOA==", "stringValue": "xcvb"},
-                    {"id": "Q2hhbXAtNDcyOTIxOQ==", "stringValue": "xcvb"},
-                    {"id": "Q2hhbXAtNDcyOTIyMA==", "stringValue": "xcvb"},
-                    {"id": "Q2hhbXAtNDcyOTIyMQ==", "stringValue": "false"},
-                    {"id": "Q2hhbXAtNDU1OTU0Nw==", "stringValue": ""},
-                    {"id": "Q2hhbXAtNDcyOTIyNA==", "stringValue": "true"},
-                    {"id": "Q2hhbXAtNDcyOTI4Mw==", "stringValue": "true"},
-                ],
-            }
-        }
-    }
-
+    mock_response.json.return_value = GET_DOSSIER_FAKE_RESPONSE
     mock_post.return_value = mock_response
+
+    config = ConfigHaieFactory(
+        demarches_simplifiees_city_id="Q2hhbXAtNDcyOTE4Nw==",
+        demarches_simplifiees_pacage_id="Q2hhbXAtNDU0MzkzOA==",
+    )
+
     petition_project = PetitionProjectFactory()
-    config = ConfigHaieFactory()
-    config.demarches_simplifiees_city_id = "Q2hhbXAtNDcyOTE4Nw=="
-    config.demarches_simplifiees_pacage_id = "Q2hhbXAtNDU0MzkzOA=="
 
     details = fetch_project_details_from_demarches_simplifiees(
         petition_project, config, site, "", haie_user
     )
 
-    assert details.applicant_name == "Mme dez dez"
-    assert details.city == "Ladaux (33760)"
+    assert details.applicant_name == "Mme Lamarr Hedy"
+    assert details.city == "Laon (02000)"
     assert details.pacage == "123456789"
 
     petition_project.refresh_from_db()
     assert petition_project.demarches_simplifiees_date_depot == datetime.datetime(
-        2025, 1, 29, 15, 25, 3, tzinfo=datetime.timezone.utc
+        2025, 3, 21, 10, 8, 34, tzinfo=datetime.timezone.utc
     )
     assert petition_project.demarches_simplifiees_last_sync is not None
 
@@ -141,7 +86,8 @@ def test_fetch_project_details_from_demarches_simplifiees_not_enabled(
         )
         > 0
     )
-    assert details is None
+    fake_dossier = GET_DOSSIER_FAKE_RESPONSE.get("data", {}).get("dossier")
+    assert details.usager == fake_dossier.get("usager").get("email")
 
 
 @patch("envergo.petitions.services.notify")

--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -107,6 +108,9 @@ def test_petition_project_instructor_view_requires_authentication(haie_user, sit
             "petition_project_instructor_view", kwargs={"reference": project.reference}
         )
     )
+
+    # Add support  django messaging framework
+    request._messages = messages.storage.default_storage(request)
 
     # Simulate an unauthenticated user
     request.user = AnonymousUser()

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse
 import fiona
 import requests
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.http import HttpResponse, JsonResponse
@@ -482,6 +483,14 @@ class PetitionProjectInstructorView(LoginRequiredMixin, UpdateView):
             self.request.COOKIES.get(settings.VISITOR_COOKIE_NAME, ""),
             self.request.user,
         )
+
+        # Send message if info from DS is not in project details
+        if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
+            messages.info(
+                self.request,
+                """L'accès à l'API démarches simplifiées n'est pas activée.
+                Les données proviennent d'un dossier factice.""",
+            )
 
         return context
 


### PR DESCRIPTION
Fait partie de https://trello.com/c/TI8rqG1y/1546-am%C3%A9liorer-la-synchronisation-%C3%A0-d%C3%A9marches-simplifi%C3%A9es

- utilise un dossier factice
- la query graphql ainsi que le dossier factice sont dans des fichiers dédiés

Pour l'instant ce dossier est dans l'app `petitions`, J'hésite à faire un dossier `demarches_simplifiees` dans `utils` comme pour `mattermost`, qu'en pensez-vous ?