### PR TITLE
Fix Matomo tracking on error page

### DIFF
--- a/standalone/page/response/unavailable/index.html
+++ b/standalone/page/response/unavailable/index.html
@@ -384,7 +384,7 @@
           IDSITE = "12";
         }
         else if (currentHost == ('envergo.beta.gouv.fr')) {
-          IDSITE = "186";
+          IDSITE = "46";
         }
         else if (currentHost == ('haie.incubateur.net')) {
           IDSITE = "141";

--- a/standalone/page/response/unavailable/index.html
+++ b/standalone/page/response/unavailable/index.html
@@ -397,9 +397,7 @@
         var _paq = window._paq = window._paq || [];
         _paq.push(['setCustomUrl', customUrl]);
         _paq.push(['trackEvent', 'Error', '500', getCookieValue('visitorid')]);
-        _paq.push(['disableErrorTracking']); // avoid sending a duplicated error event with less data
 
-        _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {
           var u="//stats.beta.gouv.fr/";

--- a/standalone/page/response/unavailable/index.html
+++ b/standalone/page/response/unavailable/index.html
@@ -398,6 +398,7 @@
         _paq.push(['setCustomUrl', customUrl]);
         _paq.push(['trackEvent', 'Error', '500', getCookieValue('visitorid')]);
 
+        _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         (function() {
           var u="//stats.beta.gouv.fr/";


### PR DESCRIPTION
On utilisait le site id de l'ancien Matomo (stats.data et non stats.beta)
et le disableErrorTracking ne servait à rien et faisait planter le script...