### PR TITLE
Envergo / Ajouter le département aux metadonnées des événements SQL des AR

### DIFF
--- a/envergo/evaluations/tests/test_utils.py
+++ b/envergo/evaluations/tests/test_utils.py
@@ -1,0 +1,29 @@
+from envergo.evaluations.utils import extract_department_from_address_or_city_string
+
+
+def test_extract_department_from_address_or_city_string():
+    assert extract_department_from_address_or_city_string("Paris (75)") == "75"
+    assert extract_department_from_address_or_city_string("Ajaccio (2A)") == "2A"
+    assert (
+        extract_department_from_address_or_city_string("Pointe-à-Pitre (971)") == "971"
+    )
+    assert (
+        extract_department_from_address_or_city_string(
+            "Rue des Grands Chênes 42600 Montbrison"
+        )
+        == "42"
+    )
+    assert (
+        extract_department_from_address_or_city_string(
+            "Appt B 15451 Rue des Grands Chênes 42600 Montbrison"
+        )
+        == "42"
+    )
+    assert extract_department_from_address_or_city_string("Tagata tsoin tsoin") is None
+    assert extract_department_from_address_or_city_string("Paris (1234)") is None
+    assert (
+        extract_department_from_address_or_city_string(
+            "Rue des Grands Chênes Montbrison"
+        )
+        is None
+    )

--- a/envergo/evaluations/utils.py
+++ b/envergo/evaluations/utils.py
@@ -22,6 +22,17 @@ def extract_department_from_address(address):
     return extract_department_from_postal_code(postal_code)
 
 
+def extract_department_from_address_or_city_string(address_or_city):
+    """Extract the department number from a complete address or a city + department string.
+    Return None if no department number is found.
+    """
+    # Regular expression to match the format "CityName (DepartmentNumber)"
+    match = re.match(r".*\(([0-9AB]{2,3})\)$", address_or_city)
+    if match:
+        return match.group(1)  # Extract the department number
+    return extract_department_from_address(address_or_city)
+
+
 def extract_department_from_postal_code(postal_code):
     department = None
     if postal_code:

--- a/envergo/evaluations/views.py
+++ b/envergo/evaluations/views.py
@@ -43,6 +43,7 @@ from envergo.evaluations.tasks import (
     confirm_request_to_requester,
     post_evalreq_to_automation,
 )
+from envergo.evaluations.utils import extract_department_from_address_or_city_string
 from envergo.geodata.models import Department
 from envergo.moulinette.views import MoulinetteMixin
 from envergo.utils.urls import update_qs
@@ -458,6 +459,9 @@ class RequestEvalWizardStep3(WizardStepMixin, UpdateView):
                 request_reference=request.reference,
                 request_url=reverse(
                     "admin:evaluations_request_change", args=[request.id]
+                ),
+                department=extract_department_from_address_or_city_string(
+                    request.address
                 ),
                 **mtm_keys,
             )


### PR DESCRIPTION
https://trello.com/c/VdKNJSda/1324-envergo-ajouter-le-d%C3%A9partement-aux-metadonn%C3%A9es-des-%C3%A9v%C3%A9nements-sql-des-ar

A faire tourner en prod pour mettre à jour l'existant via la commande shell_plus

```
from tqdm import tqdm
from envergo.analytics.models import Event
from envergo.evaluations.models import Request
from envergo.evaluations.utils import extract_department_from_address_or_city_string
def enrich_evaluation_request_events():
    qs = Event.objects.filter(category="evaluation", event="request").exclude(metadata__has_key="department")
    total = qs.count()
    batch_size = 1000
    i = 0
    with tqdm(total=total) as pbar:
        while i < total:
            models = qs[i: i + batch_size].iterator()  # noqa
            to_update = []
            for model in models:
                reference = model.metadata.get("request_reference", None)
                if reference:
                    request = Request.objects.filter(reference=reference).first()
                    if request:
                        model.metadata["department"] = extract_department_from_address_or_city_string(request.address)
                        to_update.append(model)
            Event.objects.bulk_update(to_update, ["metadata"])
            i += batch_size
            pbar.update(batch_size)
```

