### PR TITLE
Feature/ecran instruction

### DIFF
--- a/envergo/petitions/demarches_simplifiees/data/fake_dossier.json
+++ b/envergo/petitions/demarches_simplifiees/data/fake_dossier.json
@@ -22,7 +22,7 @@
         "createdAt": "2025-03-31T19:47:22+02:00"
       },
       "usager": {
-        "email": "emmanuelle.helly@beta.gouv.fr"
+        "email": "hedy.lamarr@example.com"
       },
       "prenomMandataire": null,
       "nomMandataire": null,

--- a/envergo/petitions/forms.py
+++ b/envergo/petitions/forms.py
@@ -31,7 +31,7 @@ class PetitionProjectInstructorForm(forms.ModelForm):
                 attrs={"placeholder": "AAAA-MM-XXX-NNNNN"}
             ),
             "instructor_free_mention": forms.Textarea(
-                attrs={"rows": 3, "placeholder": "Ajoutez vos notes ici…"},
+                attrs={"rows": 10, "placeholder": "Ajoutez vos notes ici…"},
             ),
         }
-        labels = {"instructor_free_mention": "Notes libres"}
+        labels = {"instructor_free_mention": "Notes libres pour l'instructeur"}

--- a/envergo/petitions/forms.py
+++ b/envergo/petitions/forms.py
@@ -31,7 +31,15 @@ class PetitionProjectInstructorForm(forms.ModelForm):
                 attrs={"placeholder": "AAAA-MM-XXX-NNNNN"}
             ),
             "instructor_free_mention": forms.Textarea(
-                attrs={"rows": 10, "placeholder": "Ajoutez vos notes ici…"},
+                attrs={
+                    "rows": 10,
+                    "placeholder": "Ajoutez vos notes ici…",
+                },
             ),
         }
         labels = {"instructor_free_mention": "Notes libres pour l'instructeur"}
+        help_texts = {
+            "instructor_free_mention": "Partagez ici tout ce qui est utile à votre suivi de la demande, "
+            "ou à la collaboration entre services instructeurs. "
+            "Cliquer sur « Enregistrer » pour sauvegarder."
+        }

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -86,7 +86,7 @@ class ProjectDetails:
     demarches_simplifiees_dossier_number: int
     demarche_simplifiee_number: int
     usager: str
-    summary: InstructorInformation
+    summary: InstructorInformation | None
     details: list[InstructorInformation]
     ds_data: DemarchesSimplifieesDetails | None
 
@@ -538,6 +538,7 @@ def compute_instructor_informations_ds(
         demarches_simplifiees_dossier_number=petition_project.demarches_simplifiees_dossier_number,
         demarche_simplifiee_number=config.demarche_simplifiee_number,
         usager=ds_details.usager if ds_details else "",
+        summary=None,
         details=[project_details],
         ds_data=ds_details,
     )

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -396,7 +396,7 @@ def compute_instructor_informations(
     # Build notes instruction
     notes_instruction = InstructorInformation(
         slug=None,
-        label="Notes instruction",
+        label=None,
         items=[
             "instructor_free_mention",
         ],

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -11,7 +11,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 
 from envergo.moulinette.forms import MOTIF_CHOICES
-from envergo.petitions.models import DOSSIER_STATES
 from envergo.utils.mattermost import notify
 from envergo.utils.tools import display_form_details
 
@@ -601,20 +600,18 @@ def fetch_project_details_from_demarches_simplifiees(
             f"\nrequest.url: {api_url}"
             f"\nrequest.body: {body}"
         )
-        if petition_project.demarches_simplifiees_state != DOSSIER_STATES.draft:
-            with open(
-                Path(
-                    settings.APPS_DIR
-                    / "petitions"
-                    / "demarches_simplifiees"
-                    / "data"
-                    / "fake_dossier.json"
-                ),
-                "r",
-            ) as file:
-                response = json.load(file)
-                dossier = response.get("data", {}).get("dossier") or {}
-
+        with open(
+            Path(
+                settings.APPS_DIR
+                / "petitions"
+                / "demarches_simplifiees"
+                / "data"
+                / "fake_dossier.json"
+            ),
+            "r",
+        ) as file:
+            response = json.load(file)
+            dossier = response.get("data", {}).get("dossier") or {}
     else:
         response = requests.post(
             api_url,

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -307,24 +307,12 @@ def build_project_details(petition_project) -> InstructorInformation:
             InstructorInformationDetails(
                 label="Destruction",
                 items=[
-                    Item(
-                        "Nombre de tracés",
-                        len(hedge_data.hedges_to_remove()),
-                        None,
-                        None,
-                    ),
                     Item("Total linéaire détruit", round(length_to_remove), "m", None),
                 ],
             ),
             InstructorInformationDetails(
                 label="Plantation",
                 items=[
-                    Item(
-                        "Nombre de tracés",
-                        len(hedge_data.hedges_to_plant()),
-                        None,
-                        None,
-                    ),
                     Item("Total linéaire planté", round(length_to_plant), "m", None),
                     Item(
                         "Ratio en longueur",

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -300,7 +300,7 @@ def build_project_details(petition_project) -> InstructorInformation:
         slug=None,
         label=None,
         items=[
-            Item("Référence", petition_project.reference, None, None),
+            Item("Référence interne", petition_project.reference, None, None),
             "instructor_free_mention",
         ],
         details=[
@@ -380,6 +380,7 @@ def compute_instructor_informations(
     )
     if city_field:
         city = city_field.get("stringValue", None)
+
     pacage_field = next(
         (
             champ

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -98,8 +98,7 @@ def build_instructor_informations_bcae8(
 
     hedge_data = petition_project.hedge_data
     lineaire_detruit_pac = hedge_data.lineaire_detruit_pac()
-    lineaire_total = float(moulinette.catalog.get("lineaire_total", ""))
-    ratio_detruit = round(lineaire_detruit_pac / lineaire_total * 100, 2)
+    lineaire_total = moulinette.catalog.get("lineaire_total", "")
     motif = moulinette.catalog.get("motif", "")
 
     bcae8 = InstructorInformation(
@@ -134,7 +133,11 @@ def build_instructor_informations_bcae8(
                     ),
                     Item(
                         "Pourcentage détruit / total linéaire",
-                        (ratio_detruit if lineaire_total else ""),
+                        (
+                            round(lineaire_detruit_pac / lineaire_total * 100, 2)
+                            if lineaire_total
+                            else ""
+                        ),
                         "%",
                         None,
                     ),

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -104,7 +104,8 @@ def build_instructor_informations_bcae8(
 
     bcae8 = InstructorInformation(
         slug="bcae8",
-        comment="Seuls les tracés sur parcelle PAC et hors alignement d’arbres sont pris en compte",
+        comment="Les décomptes de cette section n'incluent que les haies déclarées "
+        "sur parcelle PAC. Les alignements d’arbres sont également exclus.",
         label="BCAE 8",
         items=[
             Item("Total linéaire exploitation déclaré", lineaire_total, "m", None),

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -119,19 +119,28 @@ def build_instructor_informations_bcae8(
                 label="Destruction",
                 items=[
                     Item(
-                        "Nombre de tracés",
-                        len(hedge_data.hedges_to_remove_pac()),
-                        None,
-                        None,
-                    ),
-                    Item(
-                        "Total linéaire détruit",
+                        "Total linéaire détruit sur parcelle PAC",
                         round(hedge_data.lineaire_detruit_pac()),
                         "m",
                         None,
                     ),
                     Item(
-                        "Pourcentage détruit / total linéaire",
+                        "Détail",
+                        (
+                            ", ".join(
+                                [
+                                    f"{round(h.length)} ⋅ {h.id}"
+                                    for h in hedge_data.hedges_to_remove_pac()
+                                ]
+                            )
+                            if hedge_data.hedges_to_remove_pac
+                            else ""
+                        ),
+                        None,
+                        None,
+                    ),
+                    Item(
+                        "Pourcentage linéaire à détruire / total linéaire exploitation",
                         (
                             round(lineaire_detruit_pac / lineaire_total * 100, 2)
                             if lineaire_total
@@ -146,19 +155,28 @@ def build_instructor_informations_bcae8(
                 label="Plantation",
                 items=[
                     Item(
-                        "Nombre de tracés plantés",
-                        len(hedge_data.hedges_to_plant_pac()),
-                        None,
-                        None,
-                    ),
-                    Item(
-                        "Total linéaire planté",
+                        "Total linéaire à planter sur parcelle PAC",
                         round(hedge_data.length_to_plant_pac()),
                         "m",
                         None,
                     ),
                     Item(
-                        "Ratio en longueur",
+                        "Détail",
+                        (
+                            ", ".join(
+                                [
+                                    f"{round(h.length)} ⋅ {h.id}"
+                                    for h in hedge_data.hedges_to_plant_pac()
+                                ]
+                            )
+                            if hedge_data.hedges_to_plant_pac
+                            else ""
+                        ),
+                        None,
+                        None,
+                    ),
+                    Item(
+                        "Ratio de replantation",
                         (
                             round(
                                 hedge_data.length_to_plant_pac() / lineaire_detruit_pac,
@@ -168,7 +186,7 @@ def build_instructor_informations_bcae8(
                             else ""
                         ),
                         None,
-                        "Longueur plantée / longueur détruite",
+                        "Linéaire à planter / linéaire à détruire, sur parcelle PAC",
                     ),
                 ],
             ),
@@ -305,18 +323,12 @@ def build_project_details(petition_project) -> InstructorInformation:
         label=None,
         items=[
             Item("Référence interne", petition_project.reference, None, None),
-            "instructor_free_mention",
         ],
         details=[
             InstructorInformationDetails(
-                label="Destruction",
+                label="Résumé du projet",
                 items=[
                     Item("Total linéaire détruit", round(length_to_remove), "m", None),
-                ],
-            ),
-            InstructorInformationDetails(
-                label="Plantation",
-                items=[
                     Item("Total linéaire planté", round(length_to_plant), "m", None),
                     Item(
                         "Ratio en longueur",
@@ -402,6 +414,7 @@ def compute_instructor_informations(
             project_details.items.append(
                 Item("Nom du demandeur", ds_details.applicant_name, None, None)
             )
+    project_details.items.append("instructor_free_mention")
 
     # Build BCAE8
     bcae8 = build_instructor_informations_bcae8(petition_project, moulinette)

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -97,7 +97,8 @@ def build_instructor_informations_bcae8(
 
     hedge_data = petition_project.hedge_data
     lineaire_detruit_pac = hedge_data.lineaire_detruit_pac()
-    lineaire_total = moulinette.catalog.get("lineaire_total", "")
+    lineaire_total = float(moulinette.catalog.get("lineaire_total", ""))
+    ratio_detruit = round(lineaire_detruit_pac / lineaire_total * 100, 2)
     motif = moulinette.catalog.get("motif", "")
 
     bcae8 = InstructorInformation(
@@ -131,11 +132,7 @@ def build_instructor_informations_bcae8(
                     ),
                     Item(
                         "Pourcentage détruit / total linéaire",
-                        (
-                            round(lineaire_detruit_pac / lineaire_total * 100, 2)
-                            if lineaire_total
-                            else ""
-                        ),
+                        (ratio_detruit if lineaire_total else ""),
                         "%",
                         None,
                     ),

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -11,6 +11,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 
 from envergo.moulinette.forms import MOTIF_CHOICES
+from envergo.petitions.models import DOSSIER_STATES
 from envergo.utils.mattermost import notify
 from envergo.utils.tools import display_form_details
 
@@ -591,23 +592,24 @@ def fetch_project_details_from_demarches_simplifiees(
 
     if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
         logger.warning(
-            f"Demarches Simplifiees is not enabled. Doing nothing. Use fake dossier."
+            f"Demarches Simplifiees is not enabled. Doing nothing."
+            f"Use fake dossier if dossier is not draft."
             f"\nrequest.url: {api_url}"
             f"\nrequest.body: {body}"
         )
-
-        with open(
-            Path(
-                settings.APPS_DIR
-                / "petitions"
-                / "demarches_simplifiees"
-                / "data"
-                / "fake_dossier.json"
-            ),
-            "r",
-        ) as file:
-            response = json.load(file)
-            dossier = response.get("data", {}).get("dossier") or {}
+        if petition_project.demarches_simplifiees_state != DOSSIER_STATES.draft:
+            with open(
+                Path(
+                    settings.APPS_DIR
+                    / "petitions"
+                    / "demarches_simplifiees"
+                    / "data"
+                    / "fake_dossier.json"
+                ),
+                "r",
+            ) as file:
+                response = json.load(file)
+                dossier = response.get("data", {}).get("dossier") or {}
 
     else:
         response = requests.post(

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -312,7 +312,7 @@ def build_instructor_informations_ep(petition_project) -> InstructorInformation:
     return ep
 
 
-def build_project_details(petition_project) -> InstructorInformation:
+def build_project_summary(petition_project) -> InstructorInformation:
     """Build project details from petition project data"""
 
     hedge_data = petition_project.hedge_data
@@ -402,19 +402,28 @@ def compute_instructor_informations(
         applicant_name, city, pacage, usager, None, None
     )
 
-    # Build project details
-    project_details = build_project_details(petition_project)
+    # Build project summary
+    project_summary = build_project_summary(petition_project)
 
     if ds_details:
         if ds_details.city:
-            project_details.items.append(
+            project_summary.items.append(
                 Item("Commune principale", ds_details.city, None, None)
             )
         if ds_details.applicant_name:
-            project_details.items.append(
+            project_summary.items.append(
                 Item("Nom du demandeur", ds_details.applicant_name, None, None)
             )
-    project_details.items.append("instructor_free_mention")
+
+    # Build notes instruction
+    notes_instruction = InstructorInformation(
+        slug=None,
+        label="Notes instruction",
+        items=[
+            "instructor_free_mention",
+        ],
+        details=None,
+    )
 
     # Build BCAE8
     bcae8 = build_instructor_informations_bcae8(petition_project, moulinette)
@@ -430,7 +439,7 @@ def compute_instructor_informations(
         demarches_simplifiees_dossier_number=petition_project.demarches_simplifiees_dossier_number,
         demarche_simplifiee_number=config.demarche_simplifiee_number,
         usager=ds_details.usager if ds_details else "",
-        details=[project_details, bcae8, ep],
+        details=[project_summary, notes_instruction, bcae8, ep],
         ds_data=ds_details,
     )
 
@@ -441,7 +450,7 @@ def compute_instructor_informations_ds(
     """Compute ProjectDetails with instructor informations"""
 
     # Build project details
-    project_details = build_project_details(petition_project)
+    project_details = build_project_summary(petition_project)
 
     # Get ds details
     config = moulinette.config

--- a/envergo/static/sass/project_haie.scss
+++ b/envergo/static/sass/project_haie.scss
@@ -497,6 +497,12 @@ div#project-specifications-instructor {
   max-width: 42em;
 }
 
+#form-group-instructor_free_mention .label-content {
+  font-weight: bold;
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .ds-item > .fr-sidemenu__link::after {
   content: "";
   background-image: url("/static/images/logo_demarches_simplifiees.png");

--- a/envergo/static/sass/project_haie.scss
+++ b/envergo/static/sass/project_haie.scss
@@ -493,6 +493,10 @@ div#project-specifications-instructor {
  * Page instructor
  */
 
+.project-inner-content {
+  max-width: 42em;
+}
+
 .ds-item > .fr-sidemenu__link::after {
   content: "";
   background-image: url("/static/images/logo_demarches_simplifiees.png");

--- a/envergo/templates/haie/petitions/_items.html
+++ b/envergo/templates/haie/petitions/_items.html
@@ -32,7 +32,11 @@
       {% endif %}
     {% else %}
       <span>
-        {{ item.value }}
+        {% if item.value|is_type:"int" or item.value|is_type:"float" %}
+          {{ item.value|floatformat:"g" }}
+        {% else %}
+          {{ item.value }}
+        {% endif %}
         {% if item.unit and item.value is not None and item.value != "" %}{{ item.unit }}{% endif %}
       </span>
     {% endif %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -34,22 +34,39 @@
 {% block project_content %}
 
   <h2>Informations générales</h2>
-  <div class="fr-mb-2w">
-    <a title="Consulter les résultats de la simulation - ouvre une nouvelle fenêtre"
-       href="{{ project_url }}"
-       target="_blank"
-       class="fr-btn"
-       rel="noopener external">Voir le résultat de la simulation</a>
+
+  <section class="fr-py-3w"
+           {% if project_details.summary.slug %}id="{{ project_details.summary.slug }}"{% endif %}>
+    {% with summary=project_details.summary %}
+      {% if summary.label %}<h2>{{ summary.label }}</h2>{% endif %}
+      {% if summary.comment %}<p class="fr-callout fr-icon-information-line">{{ summary.comment }}</p>{% endif %}
+
+      {% include "haie/petitions/_items.html" with items=summary.items %}
+
+      {% if summary.details %}
+        {% for summary_details in summary.details %}
+          <h3 class="fr-h4 fr-mt-4w fr-mb-2w">{{ summary_details.label }}</h3>
+
+          {% include "haie/petitions/_items.html" with items=summary_details.items %}
+
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+  </section>
+
+  <div class="fr-my-2w">
+    <button class="hedge-input-open-btn fr-btn fr-btn--icon-right fr-icon-arrow-right-line"
+            type="button"
+            data-fr-opened="false"
+            aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
   </div>
 
-  {% if project_details.details %}
-    <div>
-      <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line"
-              type="button"
-              data-fr-opened="false"
-              aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
-    </div>
-  {% endif %}
+  <a title="Consulter les résultats de la simulation - ouvre une nouvelle fenêtre"
+     href="{{ project_url }}"
+     target="_blank"
+     class="fr-btn fr-btn--secondary"
+     rel="noopener external">Voir le résultat de la simulation</a>
+
   <div class="project-inner-content">
 
     <form method="post"

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -41,6 +41,12 @@
      class="fr-btn  fr-btn--secondary"
      rel="noopener external">Voir le résultat de la simulation</a>
 
+  {% if project_details.details %}
+    <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line fr-mt-2w"
+            type="button"
+            data-fr-opened="false"
+            aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
+  {% endif %}
   <div class="project-inner-content">
 
     <form method="post"
@@ -61,12 +67,6 @@
               {% include "haie/petitions/_items.html" with items=information_details.items %}
 
             {% endfor %}
-          {% endif %}
-          {% if forloop.first %}
-            <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line fr-mt-2w"
-                    type="button"
-                    data-fr-opened="false"
-                    aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
           {% endif %}
         </section>
       {% endfor %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -38,36 +38,41 @@
   <a title="Consulter les résultats de la simulation - ouvre une nouvelle fenêtre"
      href="{{ project_url }}"
      target="_blank"
-     rel="noopener external">Consulter les résultats de la simulation</a>
-  <form method="post"
-        action="{% url 'petition_project_instructor_view' petition_project.reference %}">
-    {% csrf_token %}
-    {% for information in project_details.details %}
-      <section class="fr-py-3w"
-               {% if information.slug %}id="{{ information.slug }}"{% endif %}>
-        {% if information.label %}<h2 class="fr-mb-0">{{ information.label }}</h2>{% endif %}
-        <p class="fr-hint-text">
-          {% if information.comment %}{{ information.comment }}{% endif %}
-        </p>
-        {% include "haie/petitions/_items.html" with items=information.items %}
-        {% if information.details %}
-          {% for information_details in information.details %}
-            <h3 class="fr-mt-4w">{{ information_details.label }}</h3>
+     class="fr-btn  fr-btn--secondary"
+     rel="noopener external">Voir le résultat de la simulation</a>
 
-            {% include "haie/petitions/_items.html" with items=information_details.items %}
+  <div class="project-inner-content">
 
-          {% endfor %}
-        {% endif %}
-        {% if forloop.first %}
-          <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line fr-mt-2w"
-                  type="button"
-                  data-fr-opened="false"
-                  aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
-        {% endif %}
-      </section>
-    {% endfor %}
-  </form>
+    <form method="post"
+          action="{% url 'petition_project_instructor_view' petition_project.reference %}">
+      {% csrf_token %}
+      {% for information in project_details.details %}
+        <section class="fr-py-3w"
+                 {% if information.slug %}id="{{ information.slug }}"{% endif %}>
+          {% if information.label %}<h2 class="fr-mb-0">{{ information.label }}</h2>{% endif %}
+          <p class="fr-hint-text">
+            {% if information.comment %}{{ information.comment }}{% endif %}
+          </p>
+          {% include "haie/petitions/_items.html" with items=information.items %}
+          {% if information.details %}
+            {% for information_details in information.details %}
+              <h3 class="fr-h4 fr-mt-4w fr-mb-2w">{{ information_details.label }}</h3>
 
+              {% include "haie/petitions/_items.html" with items=information_details.items %}
+
+            {% endfor %}
+          {% endif %}
+          {% if forloop.first %}
+            <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line fr-mt-2w"
+                    type="button"
+                    data-fr-opened="false"
+                    aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
+          {% endif %}
+        </section>
+      {% endfor %}
+    </form>
+
+  </div>
 {% endblock %}
 
 {% block extra_body %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -34,18 +34,21 @@
 {% block project_content %}
 
   <h2>Informations générales</h2>
-
-  <a title="Consulter les résultats de la simulation - ouvre une nouvelle fenêtre"
-     href="{{ project_url }}"
-     target="_blank"
-     class="fr-btn  fr-btn--secondary"
-     rel="noopener external">Voir le résultat de la simulation</a>
+  <div class="fr-mb-2w">
+    <a title="Consulter les résultats de la simulation - ouvre une nouvelle fenêtre"
+       href="{{ project_url }}"
+       target="_blank"
+       class="fr-btn"
+       rel="noopener external">Voir le résultat de la simulation</a>
+  </div>
 
   {% if project_details.details %}
-    <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line fr-mt-2w"
-            type="button"
-            data-fr-opened="false"
-            aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
+    <div>
+      <button class="hedge-input-open-btn fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line"
+              type="button"
+              data-fr-opened="false"
+              aria-controls="hedge-input-modal">Voir le tracé des haies sur la carte</button>
+    </div>
   {% endif %}
   <div class="project-inner-content">
 
@@ -57,7 +60,7 @@
         <section class="fr-py-3w"
                  {% if information.slug %}id="{{ information.slug }}"{% endif %}>
 
-          {% if information.label %}<h2 class="fr-mb-0">{{ information.label }}</h2>{% endif %}
+          {% if information.label %}<h2>{{ information.label }}</h2>{% endif %}
           {% if information.comment %}<p class="fr-callout fr-icon-information-line">{{ information.comment }}</p>{% endif %}
 
           {% include "haie/petitions/_items.html" with items=information.items %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -53,13 +53,15 @@
           action="{% url 'petition_project_instructor_view' petition_project.reference %}">
       {% csrf_token %}
       {% for information in project_details.details %}
+
         <section class="fr-py-3w"
                  {% if information.slug %}id="{{ information.slug }}"{% endif %}>
+
           {% if information.label %}<h2 class="fr-mb-0">{{ information.label }}</h2>{% endif %}
-          <p class="fr-hint-text">
-            {% if information.comment %}{{ information.comment }}{% endif %}
-          </p>
+          {% if information.comment %}<p class="fr-callout fr-icon-information-line">{{ information.comment }}</p>{% endif %}
+
           {% include "haie/petitions/_items.html" with items=information.items %}
+
           {% if information.details %}
             {% for information_details in information.details %}
               <h3 class="fr-h4 fr-mt-4w fr-mb-2w">{{ information_details.label }}</h3>


### PR DESCRIPTION
(j'ai dû refaire une PR, mais c'est la même que vous avez déjà lue ici #636 )

https://trello.com/c/ZpdUzTPU/1576-haie-it%C3%A9ration-%C3%A9cran-dinstruction

### Couplage avec DS

- _plus tard_ Champs vide : indiqué "Non renseigné (formulaire pas encore déposé par le pétitionnaire)"

### Section “Caractéristiques du projet”

- [x] Renommer “Référence” (suivie du code à 6 lettres) en “Référence interne"
- [x] Pour les sous-rubriques, plutôt que du `<h3>`, réduire taille et marge bottom : <h4 class="fr-mt-4w fr-mb-2w" → j'ai mis `<h3 class="fr-h4 fr-mt-4w fr-mb-2w">`
- [x] contenu dans un container de largeur 42 rem
- [x] Renommer le lien “Consulter…” en “Voir le résultat de la simulation” et en bouton secondaire plutôt qu’en lien `<a>`
- [x] section “Caractéristiques du projet” : enlever “Nombre de tracés” sous Destruction et Plantation

#### Champs de formulaire

- [x] Renommer “Notes libres” en “Notes libres pour l’instruction”, sous-titre “Partagez ici tout ce qui est utile à votre suivi de la demande, ou à la collaboration entre services instructeurs. Cliquer sur « Enregistrer » pour sauvegarder.”
- [x] Augmenter la hauteur de ce champ d’input à 10 lignes
- [x] séparateur espace entre les milliers pour toutes les longueurs affichées
-  _plus tard_ Réduire l’espace vertical à 12 px entre les champs et les boutons “Enregistrer” 
- _plus tard_  scinder en 2 formulaire : champs note libre et champs onagre

### **Section BCAE8**

- [x] Changer la mise en forme et le contenu du texte de précaution
- [x] Résumé du détail des longueurs
- _plus tard_  Affichage des réponses aux questions complémentaires

## plus applicable je pense

- Remettre le `<h1>` "Caractéristiques du projet" dans la balise `<section>` sinon ça crée un trop grand espace vertical
‌‌