### PR TITLE
Envergo / manque le cas "soumis_ou_pac" dans les emails d'avis

### DIFF
--- a/envergo/evaluations/models.py
+++ b/envergo/evaluations/models.py
@@ -574,7 +574,10 @@ class EvaluationEmail:
                 evaluation.send_eval_to_project_owner,
             )
         ):
-            if moulinette.loi_sur_leau and moulinette.loi_sur_leau.result == "soumis":
+            if moulinette.loi_sur_leau and moulinette.loi_sur_leau.result in [
+                "soumis",
+                "soumis_ou_pac",
+            ]:
                 if config.ddtm_water_police_email:
                     bcc_recipients.append(config.ddtm_water_police_email)
                 else:

--- a/envergo/evaluations/tests/test_eval_emails.py
+++ b/envergo/evaluations/tests/test_eval_emails.py
@@ -401,6 +401,22 @@ def test_lse_soumis_content(rf, moulinette_url):
 
 
 @pytest.mark.parametrize("footprint", [1200])
+def test_lse_soumis_ou_pac_content(rf, moulinette_url):
+    eval, moulinette = fake_moulinette(
+        moulinette_url, "soumis_ou_pac", "non_soumis", "non_soumis", "non_soumis"
+    )
+    req = rf.get("/")
+    eval_email = eval.get_evaluation_email()
+    email = eval_email.get_email(req)
+    body = email.alternatives[0][0]
+    assert "Le projet est soumis à la Loi sur l'eau" in body
+    assert "Le projet est soumis à Natura 2000" not in body
+    assert "Le projet est soumis à examen au cas par cas" not in body
+    assert "Le projet est soumis à évaluation environnementale" not in body
+    assert "ddtm_email_test@example.org" in email.bcc
+
+
+@pytest.mark.parametrize("footprint", [1200])
 def test_n2000_soumis_content(rf, moulinette_url):
     eval, moulinette = fake_moulinette(
         moulinette_url, "non_soumis", "soumis", "non_soumis", "non_soumis"

--- a/envergo/templates/evaluations/admin/eval_email_soumis.html
+++ b/envergo/templates/evaluations/admin/eval_email_soumis.html
@@ -19,7 +19,7 @@
       </li>
     {% endif %}
 
-    {% if moulinette.loi_sur_leau.result == "soumis" %}
+    {% if moulinette.loi_sur_leau.result == "soumis" or moulinette.loi_sur_leau.result == "soumis_ou_pac" %}
       <li>
         <strong style="background-color: #ffb7a5;">Le projet est soumis à la Loi sur l'eau</strong>.
         <br />


### PR DESCRIPTION
https://trello.com/c/kLXS0Krp/1644-envergo-manque-le-cas-soumisoupac-dans-les-emails-davis