### PR TITLE
Haie / l'onglet ouvrant DS est parfois bloqué par le navigateur

### DIFF
--- a/envergo/static/js/libs/haie_result_actions_banner.js
+++ b/envergo/static/js/libs/haie_result_actions_banner.js
@@ -13,13 +13,6 @@ function displayMessage(title, message, type) {
   projectResult.scrollIntoView({behavior: 'smooth'});
 }
 
-
-function openDemarchesSimplifeesModal(event) {
-  if (event.type === 'click' || event.key === 'Enter' || event.key === ' ') {
-    event.preventDefault();
-    event.target.setAttribute('data-fr-opened', true);
-  }
-}
 // a script to add actions on the moulinette result banner
 window.addEventListener('load', function () {
   (function (exports) {
@@ -47,6 +40,7 @@ window.addEventListener('load', function () {
         }
         const form = event.target;
         const formData = new FormData(form);
+        const newTab = window.open("", '_blank');
 
         fetch(form.action, {
           method: 'POST',
@@ -59,13 +53,13 @@ window.addEventListener('load', function () {
           .then(data => {
             if (data.demarche_simplifiee_url && data.read_only_url) {
               // open démarche simplifiée in a new tab and display the read only version of the simuation result
-              const newTab = window.open(data.demarche_simplifiee_url, '_blank');
               if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
                 // if the new tab was blocked by the browser, display the link in the current tab
                 displayMessage("Votre navigateur empêche l'ouverture d'un nouvel onglet.",
                   `Veuillez cliquer sur <a href="${data.demarche_simplifiee_url}">ce lien</a> pour commencer votre démarche.`,
                   "info");
               } else {
+                newTab.location = data.demarche_simplifiee_url;
                 window.location.href = data.read_only_url;
               }
             } else {
@@ -84,22 +78,6 @@ window.addEventListener('load', function () {
             }
           });
       });
-
-      // There is multiples buttons that can submit the form across the result page
-      const submitButtons = document.querySelectorAll('.demarche-simplifiee-btn');
-      submitButtons.forEach(function (button) {
-        button.addEventListener('click', function (event) {
-          event.preventDefault();
-          var submitEvent = new Event('submit', { bubbles: true, cancelable: true });
-          demarcheForm.dispatchEvent(submitEvent);
-        });
-      });
     }
-
-    const inlineButton = document.querySelector('.demarches-simplifiees-modal-btn');
-    if (inlineButton) {
-      inlineButton.addEventListener('keydown', openDemarchesSimplifeesModal);
-    }
-
   })(this);
 });

--- a/envergo/static/js/libs/haie_result_actions_banner.js
+++ b/envergo/static/js/libs/haie_result_actions_banner.js
@@ -1,3 +1,134 @@
+(function (exports) {
+  'use strict';
+
+  const DemarchesSimplifieesModal = function (modalElt) {
+    this.modalElt = modalElt;
+    this.formElt =  modalElt.querySelector("#demarche-simplifiee-form");
+    this.submitElt = modalElt.querySelector('input[type=submit]');
+    this.buttonElts = modalElt.querySelectorAll('input[type="button"], input[type="submit"]');
+    this.closeElt = modalElt.querySelector('.fr-link--close');
+  };
+  exports.DemarchesSimplifieesModal = DemarchesSimplifieesModal;
+
+  DemarchesSimplifieesModal.prototype.init = function () {
+    this.formElt.addEventListener('submit', this.deactivate.bind(this));
+    this.formElt.addEventListener('submit', this.submit.bind(this));
+  };
+
+  DemarchesSimplifieesModal.prototype.deactivate = function () {
+    this.buttonElts.forEach(button => {
+      button.disabled = true;
+    });
+
+    if (this.closeElt) {
+      this.closeElt.disabled = true; // Disable the close button to prevent closing while submitting
+    }
+
+    // Escape key prevention
+    this.boundPreventEscape = this.preventEscape.bind(this);
+    document.addEventListener('keydown', this.boundPreventEscape, true);
+
+    // Prevent clicks outside the modal from closing it
+    this.boundPreventClickOutside = this.preventClickOutside.bind(this);
+    this.modalElt.addEventListener('click', this.boundPreventClickOutside, true);
+  };
+
+  DemarchesSimplifieesModal.prototype.activate = function () {
+    this.buttonElts.forEach(button => {
+      button.removeAttribute('disabled');
+    });
+
+    if (this.closeElt) {
+      this.closeElt.removeAttribute('disabled');
+    }
+
+    document.removeEventListener('keydown', this.boundPreventEscape, true);
+    this.modalElt.removeEventListener('click', this.boundPreventClickOutside, true);
+  };
+
+  DemarchesSimplifieesModal.prototype.submit = function (event) {
+    event.preventDefault();
+
+    let textElt = document.createElement('span');
+    textElt.innerHTML = 'Création en cours…';
+    textElt.id = 'demarche-simplifiee-submit-hint';
+    textElt.classList.add("fr-hint-text");
+    this.submitElt.insertAdjacentElement("afterend", textElt);
+
+    // remove error message if exists
+    const errorDiv = document.getElementById('demarche_simplifiee_message');
+    if (errorDiv) {
+      errorDiv.remove();
+    }
+    const form = event.target;
+    const formData = new FormData(form);
+    const newTab = window.open("", '_blank');
+
+    fetch(form.action, {
+      method: 'POST',
+      body: formData,
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data.demarche_simplifiee_url && data.read_only_url) {
+          // open démarche simplifiée in a new tab and display the read only version of the simuation result
+          if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
+            // if the new tab was blocked by the browser, display the link in the current tab
+            displayMessage("Votre navigateur empêche l'ouverture d'un nouvel onglet.",
+              `Veuillez cliquer sur <a href="${data.demarche_simplifiee_url}">ce lien</a> pour commencer votre démarche.`,
+              "info");
+          } else {
+            newTab.location = data.demarche_simplifiee_url;
+            window.location.href = data.read_only_url;
+          }
+        } else {
+          throw data;
+        }
+      })
+      .catch(error => {
+        if (newTab) {
+          // close the new tab if it was opened
+          newTab.close();
+        }
+
+        displayMessage(error.error_title || 'Nous avons rencontré un problème',
+          error.error_body || "Merci de réessayer ultérieurement.",
+          "error");
+      })
+      .finally(() => {
+        this.activate();
+        let textElt = document.getElementById('demarche-simplifiee-submit-hint');
+        if (textElt) {
+          textElt.remove();
+        }
+        // close the modal
+        if (this.modalElt) {
+          dsfr(this.modalElt).modal.conceal();
+        }
+      });
+  };
+
+  DemarchesSimplifieesModal.prototype.preventEscape = function (event) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  DemarchesSimplifieesModal.prototype.preventClickOutside = function (event) {
+    const body = this.modalElt.querySelector('.fr-modal__body');
+      if (!body.contains(event.target)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+  }
+
+})(this);
+
+
 function displayMessage(title, message, type) {
   const projectResult = document.getElementById('project-result');
   const notification = `
@@ -13,71 +144,11 @@ function displayMessage(title, message, type) {
   projectResult.scrollIntoView({behavior: 'smooth'});
 }
 
+(function () {
 // a script to add actions on the moulinette result banner
-window.addEventListener('load', function () {
-  (function (exports) {
-    'use strict';
-
-    var demarcheForm = document.getElementById("demarche-simplifiee-form");
-    if (demarcheForm) {
-
-      demarcheForm.addEventListener("submit", function (event) {
-        event.preventDefault();
-
-        // Replace form button by a loader
-        const submitButton = document.getElementById("demarche-simplifiee-banner-btn");
-        let originalButton = null;
-        const textNode = document.createTextNode('Redirection vers Démarches simplifiées…');
-        if (submitButton) {
-          originalButton = submitButton.cloneNode(true);
-          submitButton.parentNode.replaceChild(textNode, submitButton);
-        }
-
-        // remove error message if exists
-        const errorDiv = document.getElementById('demarche_simplifiee_message');
-        if (errorDiv) {
-          errorDiv.remove();
-        }
-        const form = event.target;
-        const formData = new FormData(form);
-        const newTab = window.open("", '_blank');
-
-        fetch(form.action, {
-          method: 'POST',
-          body: formData,
-          headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-          },
-        })
-          .then(response => response.json())
-          .then(data => {
-            if (data.demarche_simplifiee_url && data.read_only_url) {
-              // open démarche simplifiée in a new tab and display the read only version of the simuation result
-              if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
-                // if the new tab was blocked by the browser, display the link in the current tab
-                displayMessage("Votre navigateur empêche l'ouverture d'un nouvel onglet.",
-                  `Veuillez cliquer sur <a href="${data.demarche_simplifiee_url}">ce lien</a> pour commencer votre démarche.`,
-                  "info");
-              } else {
-                newTab.location = data.demarche_simplifiee_url;
-                window.location.href = data.read_only_url;
-              }
-            } else {
-              throw data;
-            }
-          })
-          .catch(error => {
-            displayMessage(error.error_title || 'Nous avons rencontré un problème',
-                  error.error_body || "Merci de réessayer ultérieurement.",
-                  "error");
-          })
-          .finally(() => {
-            // Replace loader by original button
-            if (originalButton) {
-              textNode.parentNode.replaceChild(originalButton, textNode);
-            }
-          });
-      });
-    }
-  })(this);
-});
+  window.addEventListener('load', function () {
+    const modal = document.getElementById('demarches-simplifiees-modal');
+    const demarchesSimplifieesModal = new DemarchesSimplifieesModal(modal);
+    demarchesSimplifieesModal.init();
+  });
+})();

--- a/envergo/templates/haie/moulinette/_demarches_simplifiees_form.html
+++ b/envergo/templates/haie/moulinette/_demarches_simplifiees_form.html
@@ -1,8 +1,0 @@
-<form id="demarche-simplifiee-form"
-      action="{% url 'petition_project_create' %}"
-      method="post">
-  {% csrf_token %}
-  <input type="hidden"
-         name="moulinette_url"
-         value="{{ request.build_absolute_uri }}" />
-</form>

--- a/envergo/templates/haie/moulinette/_init_dossier_on_demarches_simplifees.html
+++ b/envergo/templates/haie/moulinette/_init_dossier_on_demarches_simplifees.html
@@ -35,11 +35,17 @@
                      name="moulinette_url"
                      value="{{ request.build_absolute_uri }}" />
               <div id="demarches-simplifiees-modal-btns">
-                <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-                        aria-controls="demarches-simplifiees-modal">Revenir à ma simulation</button>
-                <input type="submit"
-                       class=" fr-ml-2w fr-btn demarche-simplifiee-btn fr-btn--icon-right  fr-icon-external-link-line"
-                       value="Poursuivre vers la demande" />
+                <div>
+                  <input type="button"
+                         class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+                         aria-controls="demarches-simplifiees-modal"
+                         value="Revenir à ma simulation" />
+                </div>
+                <div class="fr-ml-2w">
+                  <input type="submit"
+                         class="fr-btn demarche-simplifiee-btn fr-btn--icon-right  fr-icon-external-link-line"
+                         value="Poursuivre vers la demande" />
+                </div>
               </div>
             </form>
           </div>

--- a/envergo/templates/haie/moulinette/_init_dossier_on_demarches_simplifees.html
+++ b/envergo/templates/haie/moulinette/_init_dossier_on_demarches_simplifees.html
@@ -27,14 +27,21 @@
 
             </p>
             <p>Souhaitez-vous continuer ?</p>
-            <div id="demarches-simplifiees-modal-btns">
-              <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-                      aria-controls="demarches-simplifiees-modal">Revenir à ma simulation</button>
-              <button class=" fr-ml-2w fr-btn demarche-simplifiee-btn fr-btn--icon-right  fr-icon-external-link-line">
-                Poursuivre vers la demande
-              </button>
-            </div>
-
+            <form id="demarche-simplifiee-form"
+                  action="{% url 'petition_project_create' %}"
+                  method="post">
+              {% csrf_token %}
+              <input type="hidden"
+                     name="moulinette_url"
+                     value="{{ request.build_absolute_uri }}" />
+              <div id="demarches-simplifiees-modal-btns">
+                <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+                        aria-controls="demarches-simplifiees-modal">Revenir à ma simulation</button>
+                <input type="submit"
+                       class=" fr-ml-2w fr-btn demarche-simplifiee-btn fr-btn--icon-right  fr-icon-external-link-line"
+                       value="Poursuivre vers la demande" />
+              </div>
+            </form>
           </div>
         </div>
       </div>

--- a/envergo/templates/haie/moulinette/plantation_liability_info/_not_suitable.html
+++ b/envergo/templates/haie/moulinette/plantation_liability_info/_not_suitable.html
@@ -10,7 +10,7 @@
       Vous pouvez donc
       <span role="button"
             tabindex="0"
-            class="inline-button demarches-simplifiees-modal-btn"
+            class="inline-button"
             aria-controls="demarches-simplifiees-modal"
             data-fr-opened="false">déposer une demande d’autorisation.</span>
       Elle sera examinée, mais il est probable qu’un refus soit prononcé.

--- a/envergo/templates/haie/moulinette/plantation_result/inadequate.html
+++ b/envergo/templates/haie/moulinette/plantation_result/inadequate.html
@@ -18,7 +18,7 @@
     Vous pouvez tout de même choisir de
     <span role="button"
           tabindex="0"
-          class="inline-button demarches-simplifiees-modal-btn"
+          class="inline-button"
           aria-controls="demarches-simplifiees-modal"
           data-fr-opened="false">déposer votre demande d’autorisation.</span>
     Elle sera examinée, mais il est probable qu’un refus soit prononcé.

--- a/envergo/templates/haie/moulinette/result_base.html
+++ b/envergo/templates/haie/moulinette/result_base.html
@@ -56,7 +56,6 @@
       {% block liability_info %}{% endblock %}
     {% endif %}
   {% endfor %}
-  {% include 'haie/moulinette/_demarches_simplifiees_form.html' %}
 
   {% include 'haie/moulinette/_hedge_input_modal.html' %}
 {% endblock %}

--- a/envergo/templates/moulinette/base_result.html
+++ b/envergo/templates/moulinette/base_result.html
@@ -10,6 +10,9 @@
 
   <div id="project-result" class="fr-col">
     <section class="fr-py-4w fr-px-2w">
+      {% block messages_in_result %}
+        {% include '_messages.html' %}
+      {% endblock %}
       {% block result %}{% endblock %}
     </section>
   </div>

--- a/envergo/templates/moulinette/result.html
+++ b/envergo/templates/moulinette/result.html
@@ -6,7 +6,6 @@
 
 {% block messages %}{# messages are displayed in the result container #}{% endblock %}
 {% block result %}
-  {% include '_messages.html' %}
   {% if config and not config.is_activated %}
     <div class="fr-alert fr-alert--info fr-alert--small fr-mb-3w">
       Le simulateur n'est pas activé dans ce département ({{ moulinette.department.department }}). Vous voyez


### PR DESCRIPTION
https://trello.com/c/fHvsNy8f/1670-haie-longlet-ouvrant-ds-est-parfois-bloqu%C3%A9-par-le-navigateur


Solution implementée : 
1. au click : on ouvre un nouvel onglet vierge (a priori autorisé par les navigateurs car déclenché par une actions utilisateur et sans délais)
2. on désactive les boutons et on empêche la fermeture de la modale. 
3. à la réponse :
        en cas d'erreur : on ferme l'onglet nouvellement ouvert, on ferme la modale, on affiche un message
        en cas de succés : on redirige l'onglet nouvellement ouvert vers DS et la page vers le projet ; si l'onglet n'as pas été ouvert (peu probable) on ferme la modale et on affiche un message avec un lien
