### PR TITLE
Admin / config critère : référer au nom admin du périmètre

### DIFF
--- a/envergo/moulinette/admin.py
+++ b/envergo/moulinette/admin.py
@@ -142,7 +142,7 @@ class CriterionAdmin(admin.ModelAdmin):
         "backend_title",
         "is_optional",
         "regulation",
-        "perimeter",
+        "perimeter_list",
         "activation_map_column",
         "activation_distance_column",
         "evaluator_column",
@@ -221,6 +221,12 @@ class CriterionAdmin(admin.ModelAdmin):
             }
         )
         return super().render_delete_form(request, context)
+
+    def perimeter_list(self, obj):
+        perimeter = obj.perimeter
+        return perimeter.backend_name if perimeter else ""
+
+    perimeter_list.short_description = _("Perimeter")
 
 
 class PerimeterAdminForm(forms.ModelForm):

--- a/envergo/moulinette/admin.py
+++ b/envergo/moulinette/admin.py
@@ -73,12 +73,18 @@ class RegulationAdmin(admin.ModelAdmin):
         return obj.regulation
 
 
+class PerimeterChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.backend_name
+
+
 class CriterionAdminForm(forms.ModelForm):
     header = forms.CharField(
         label=_("Header"),
         required=False,
         widget=admin.widgets.AdminTextareaWidget(attrs={"rows": 3}),
     )
+    perimeter = PerimeterChoiceField(queryset=Perimeter.objects.all())
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
https://trello.com/c/Ekzhh99N/1669-admin-config-crit%C3%A8re-r%C3%A9f%C3%A9rer-au-nom-admin-du-p%C3%A9rim%C3%A8tre

J'ai fait le choix de n'appliquer cette modification que pour l'admin, et pas pour l'ensemble de l'affichage des perimetres.
C'est plus verbeux en terme de code (l'autre option aurait été de simplement modifier la méthode  `__str__` de perimeter), mais ca évite de casser l'affichage dans les templates.