### PR TITLE
Persistence des données du formulaire

### DIFF
--- a/config/tests/test_urls.py
+++ b/config/tests/test_urls.py
@@ -22,7 +22,7 @@ COMMON_URLS = [
     "accessibility",
     "stats",
     "legal_mentions",
-    "moulinette_home",
+    "moulinette_form",
     "moulinette_result",
     "demo_catchment_area",
     "demo_density",

--- a/envergo/analytics/views.py
+++ b/envergo/analytics/views.py
@@ -107,7 +107,7 @@ class FeedbackSubmit(SuccessMessageMixin, ParseAddressMixin, FormView):
         return prefix
 
     def get(self, request, *args, **kwargs):
-        return HttpResponseRedirect(reverse("moulinette_home"))
+        return HttpResponseRedirect(reverse("moulinette_form"))
 
     def form_valid(self, form):
         """Send the feedback as a Mattermost notification."""

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1966,7 +1966,7 @@ class MoulinetteHaie(Moulinette):
         return set(TriageFormHaie.base_fields.keys())
 
     @classmethod
-    def get_triage_template(cls, triage_form):
+    def get_triage_result_template(cls, triage_form):
         """Return the template to display the triage out of scope result."""
         if (
             triage_form["element"].value() == "haie"

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1451,6 +1451,9 @@ class Moulinette(ABC):
 
         return form_errors
 
+    def is_valid(self):
+        return not bool(self.form_errors())
+
     def has_missing_data(self):
         """Make sure all the data required to compute the result is provided."""
 

--- a/envergo/moulinette/tests/test_evalenv.py
+++ b/envergo/moulinette/tests/test_evalenv.py
@@ -293,8 +293,8 @@ def test_evalenv_non_soumis_missing_optional_criteria(admin_client):
     full_url = f"{url}?{params}"
     res = admin_client.get(full_url)
 
-    assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/home.html")
+    assert res.status_code == 302
+    assert res["Location"].startswith("/simulateur/formulaire/")
 
 
 def test_evalenv_non_soumis_optional_criteria(admin_client):

--- a/envergo/moulinette/tests/test_optional_criteria.py
+++ b/envergo/moulinette/tests/test_optional_criteria.py
@@ -54,7 +54,7 @@ def moulinette_data(footprint):
 def test_edition_redirection_from_result_admin_see_optional_criterion_additional_question(
     admin_client,
 ):
-    url = reverse("moulinette_result")
+    url = reverse("moulinette_form")
     params = "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381&edit=true"
     full_url = f"{url}?{params}"
     res = admin_client.get(full_url)

--- a/envergo/moulinette/tests/test_optional_criteria.py
+++ b/envergo/moulinette/tests/test_optional_criteria.py
@@ -70,8 +70,8 @@ def test_edition_redirection_from_result_admin_see_optional_criterion_additional
 
 
 # ETQ admin, je peux voir les questions optionnelles dès l'accueil du simulateur
-def test_optional_questions_appear_on_moulinette_home(admin_client):
-    url = reverse("moulinette_home")
+def test_optional_questions_appear_on_moulinette_form(admin_client):
+    url = reverse("moulinette_form")
     res = admin_client.get(url)
 
     assert res.status_code == 200

--- a/envergo/moulinette/tests/test_optional_criteria.py
+++ b/envergo/moulinette/tests/test_optional_criteria.py
@@ -128,5 +128,5 @@ def test_optional_criterion_activation(admin_client):
     full_url = f"{url}?{params}"
     res = admin_client.get(full_url)
 
-    assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/home.html")
+    assert res.status_code == 302
+    assert res["Location"].startswith("/simulateur/formulaire/")

--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -22,7 +22,7 @@ ADMIN_MSG = "Le simulateur n'est pas activé dans ce département"
 
 
 def test_moulinette_home(client):
-    url = reverse("moulinette_home")
+    url = reverse("moulinette_form")
     res = client.get(url)
 
     assert res.status_code == 200
@@ -32,7 +32,7 @@ def test_moulinette_home(client):
 
 
 def test_moulinette_home_with_params_redirects_to_results_page(client):
-    url = reverse("moulinette_home")
+    url = reverse("moulinette_form")
     params = "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381"
     full_url = f"{url}?{params}"
     res = client.get(full_url)
@@ -175,7 +175,7 @@ def test_moulinette_result_custom_matomo_tracking_url(client):
 
 
 def test_moulinette_home_form_error(client):
-    url = reverse("moulinette_home")
+    url = reverse("moulinette_form")
     params = "bad_param=true"
     full_url = f"{url}?{params}"
     res = client.get(full_url)
@@ -187,7 +187,7 @@ def test_moulinette_home_form_error(client):
 
 
 def test_moulinette_utm_param(client):
-    url = reverse("moulinette_home")
+    url = reverse("moulinette_form")
     params = "utm_campaign=test"
     full_url = f"{url}?{params}"
     res = client.get(full_url)

--- a/envergo/moulinette/urls.py
+++ b/envergo/moulinette/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import RedirectView
 
-from envergo.moulinette.views import MoulinetteHome
+from envergo.moulinette.views import MoulinetteForm
 
 urlpatterns = [
     # Redirections history
@@ -17,7 +17,7 @@ urlpatterns = [
     path(
         "",
         RedirectView.as_view(pattern_name="home", query_string=True),
-        name="moulinette_home_redirect",
+        name="moulinette_form_redirect",
     ),
     # This is another "fake" url, only for matomo tracking
     path(
@@ -29,7 +29,7 @@ urlpatterns = [
         _("form/"),
         include(
             [
-                path("", MoulinetteHome.as_view(), name="moulinette_home"),
+                path("", MoulinetteForm.as_view(), name="moulinette_form"),
                 # We need this url to exist, but it's a "fake" url, it's only
                 # used to be logged in matomo, so we can correctry track the funnel
                 # moulinette home > missing data > final result

--- a/envergo/moulinette/urls_haie.py
+++ b/envergo/moulinette/urls_haie.py
@@ -18,7 +18,7 @@ urlpatterns = [
                 # This is another "fake" url, only for matomo tracking
                 path(
                     "saisie-destruction/",
-                    RedirectView.as_view(pattern_name="moulinette_home"),
+                    RedirectView.as_view(pattern_name="moulinette_form"),
                     name="moulinette_saisie_d",
                 ),
                 # This is another "fake" url, only for matomo tracking

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -202,7 +202,7 @@ class MoulinetteMixin:
         by the moulinette forms.
         """
 
-        get = QueryDict("", mutable=True)
+        get = self.request.GET.copy()
         form_data = form.cleaned_data
         get_data = form_data.copy()  # keep the computed values in the catalog
         get_data.pop("address", None)

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -52,9 +52,10 @@ class MoulinetteMixin:
         if self.request.method in ("POST", "PUT"):
             moulinette_data.update(self.request.POST)
 
-        mutable_data = moulinette_data.copy()
-        mutable_data.update(compute_surfaces(moulinette_data))
-        kwargs.update({"data": mutable_data})
+        if moulinette_data:
+            mutable_data = moulinette_data.copy()
+            mutable_data.update(compute_surfaces(moulinette_data))
+            kwargs.update({"data": mutable_data})
 
         return kwargs
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -694,6 +694,8 @@ class Triage(FormView):
         else:
             url = reverse("moulinette_result")
 
-        query_string = urlencode(query_params)
-        url_with_params = f"{url}?{query_string}"
+        # We want to preserve existing querystring params when validating the form
+        qs = self.request.GET.urlencode()
+        qs = update_qs(qs, query_params)
+        url_with_params = f"{url}?{qs}"
         return HttpResponseRedirect(url_with_params)

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -47,10 +47,12 @@ class MoulinetteMixin:
             "prefix": self.get_prefix(),
         }
 
-        moulinette_data = None
-        GET = self.clean_request_get_parameters()
-        moulinette_data = GET
-
+        # We always want to submit data present in url, event if they don't belong
+        # to an actual form.
+        # This is because sometimes, when the form value change, we can add or remove
+        # some additional questions, and we don't want the user to lose those values
+        # in between submissions
+        moulinette_data = self.clean_request_get_parameters()
         if self.request.method in ("POST", "PUT"):
             moulinette_data.update(self.request.POST)
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -1,5 +1,5 @@
 import json
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
 from django.http import HttpResponseRedirect, QueryDict
@@ -689,7 +689,7 @@ class Triage(FormView):
         if (
             query_params["element"] == "haie"
             and query_params["travaux"] == "destruction"
-        ):
+        ) and not "edit" in self.request.GET:
             url = reverse("moulinette_home")
         else:
             url = reverse("moulinette_result")

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -271,7 +271,7 @@ class MoulinetteMixin:
 
 
 @method_decorator(xframe_options_sameorigin, name="dispatch")
-class MoulinetteHome(MoulinetteMixin, FormView):
+class MoulinetteForm(MoulinetteMixin, FormView):
     def get_template_names(self):
         MoulinetteClass = get_moulinette_class_from_site(self.request.site)
         return MoulinetteClass.get_home_template()
@@ -397,7 +397,7 @@ class MoulinetteResultMixin:
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")
         )
-        form_url = self.request.build_absolute_uri(reverse("moulinette_home"))
+        form_url = self.request.build_absolute_uri(reverse("moulinette_form"))
         form_url_with_edit = update_qs(form_url, {"edit": "true"})
         matomo_missing_data_url = update_qs(missing_data_url, mtm_params)
         out_of_scope_result_url = self.request.build_absolute_uri(
@@ -530,7 +530,7 @@ class BaseMoulinetteResult(FormView):
             )
             return res
         else:
-            return HttpResponseRedirect(reverse("moulinette_home"))
+            return HttpResponseRedirect(reverse("moulinette_form"))
 
 
 class MoulinetteAmenagementResult(
@@ -689,8 +689,8 @@ class Triage(FormView):
         if (
             query_params["element"] == "haie"
             and query_params["travaux"] == "destruction"
-        ) and not "edit" in self.request.GET:
-            url = reverse("moulinette_home")
+        ) and "edit" not in self.request.GET:
+            url = reverse("moulinette_form")
         else:
             url = reverse("moulinette_result")
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -26,7 +26,7 @@ from envergo.moulinette.models import (
     get_moulinette_class_from_site,
 )
 from envergo.moulinette.utils import compute_surfaces
-from envergo.utils.urls import extract_mtm_params, remove_from_qs, update_qs
+from envergo.utils.urls import copy_qs, extract_mtm_params, remove_from_qs, update_qs
 
 
 class MoulinetteMixin:
@@ -282,7 +282,7 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
         if "redirect_url" in context:
             return HttpResponseRedirect(context["redirect_url"])
-        elif self.moulinette:
+        elif self.moulinette and "edit" not in request.GET:
             return HttpResponseRedirect(self.get_results_url(context["form"]))
         else:
             return res
@@ -315,7 +315,6 @@ class MoulinetteResultMixin:
         moulinette = self.moulinette
         triage_form = self.triage_form
         is_debug = bool(self.request.GET.get("debug", False))
-        is_edit = bool(self.request.GET.get("edit", False))
         is_admin = self.request.user.is_staff
 
         # We want to display the moulinette result template, but must check all
@@ -328,8 +327,6 @@ class MoulinetteResultMixin:
             template_name = MoulinetteHaie.get_triage_template(triage_form)
         elif is_debug:
             template_name = moulinette.get_debug_result_template()
-        elif is_edit:
-            template_name = moulinette.get_home_template()
         elif not moulinette.has_config():
             template_name = moulinette.get_result_non_disponible_template()
         elif not (moulinette.is_evaluation_available() or is_admin):
@@ -375,7 +372,6 @@ class MoulinetteResultMixin:
         data = {}
         moulinette = context.get("moulinette", None)
         is_debug = bool(self.request.GET.get("debug", False))
-        is_edit = bool(self.request.GET.get("edit", False))
 
         # Let's build custom uris for better matomo tracking
         # Depending on the moulinette result, we want to track different uris
@@ -397,8 +393,6 @@ class MoulinetteResultMixin:
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")
         )
-        form_url = self.request.build_absolute_uri(reverse("moulinette_form"))
-        form_url_with_edit = update_qs(form_url, {"edit": "true"})
         matomo_missing_data_url = update_qs(missing_data_url, mtm_params)
         out_of_scope_result_url = self.request.build_absolute_uri(
             reverse("moulinette_result_out_of_scope")
@@ -411,10 +405,7 @@ class MoulinetteResultMixin:
 
         data["matomo_custom_url"] = matomo_bare_url
 
-        if moulinette and is_edit:
-            data["matomo_custom_url"] = form_url_with_edit
-
-        elif moulinette and is_debug:
+        if moulinette and is_debug:
             data["matomo_custom_url"] = matomo_debug_url
 
         elif moulinette and moulinette.has_missing_data():
@@ -444,8 +435,10 @@ class MoulinetteResultMixin:
         share_print_url = update_qs(current_url, {"mtm_campaign": "print-simu"})
         result_url = remove_from_qs(current_url, "debug")
         debug_result_url = update_qs(current_url, {"debug": "true"})
+        form_url = reverse("moulinette_form")
+        form_url = copy_qs(form_url, current_url)
         edit_url = (
-            update_qs(result_url, {"edit": "true"})
+            update_qs(form_url, {"edit": "true"})
             if moulinette
             else context.get("triage_url", None)
         )
@@ -494,7 +487,6 @@ class MoulinetteResultMixin:
 
 class BaseMoulinetteResult(FormView):
     def get(self, request, *args, **kwargs):
-        is_edit = bool(self.request.GET.get("edit", False))
         context = self.get_context_data(**kwargs)
         res = self.render_to_response(context)
         moulinette = self.moulinette
@@ -504,18 +496,12 @@ class BaseMoulinetteResult(FormView):
             return HttpResponseRedirect(context["redirect_url"])
 
         elif moulinette:
-            if (
-                "debug" not in self.request.GET
-                and not is_edit
-                and not self.validate_results_url(request, context)
+            if "debug" not in self.request.GET and not self.validate_results_url(
+                request, context
             ):
                 return HttpResponseRedirect(self.get_results_url(context["form"]))
 
-            if not (
-                moulinette.has_missing_data()
-                or is_request_from_a_bot(request)
-                or is_edit
-            ):
+            if not (moulinette.has_missing_data() or is_request_from_a_bot(request)):
                 self.log_moulinette_event(moulinette, context)
 
             return res
@@ -597,16 +583,13 @@ class MoulinetteResultPlantation(MoulinetteHaieResult):
         """Check which template to use depending on the moulinette result."""
 
         moulinette = self.moulinette
-        is_edit = bool(self.request.GET.get("edit", False))
 
         # Moulinette result template for plantation is not the moulinette ABC class result template
         # So we get the template name super and check specific cases
 
         template_name = super().get_template_names()[0]
 
-        if is_edit:
-            template_name = "TODO"  # TODO
-        elif moulinette.has_missing_data():  # TODO missing only hedges to plant
+        if moulinette.has_missing_data():  # TODO missing only hedges to plant
             template_name = moulinette.get_result_template()
         elif template_name == "haie/moulinette/result.html":
             template_name = "haie/moulinette/result_plantation.html"
@@ -631,8 +614,8 @@ class MoulinetteResultPlantation(MoulinetteHaieResult):
             plantation_url = update_qs(plantation_url, self.request.GET)
             context["plantation_url"] = plantation_url
 
-        result_d_url = update_qs(reverse("moulinette_result"), self.request.GET)
-        context["edit_url"] = update_qs(result_d_url, {"edit": "true"})
+        form_url = update_qs(reverse("moulinette_form"), self.request.GET)
+        context["edit_url"] = update_qs(form_url, {"edit": "true"})
         return context
 
     def log_moulinette_event(self, moulinette, context, **kwargs):
@@ -689,7 +672,7 @@ class Triage(FormView):
         if (
             query_params["element"] == "haie"
             and query_params["travaux"] == "destruction"
-        ) and "edit" not in self.request.GET:
+        ):
             url = reverse("moulinette_form")
         else:
             url = reverse("moulinette_result")

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -288,6 +288,18 @@ class MoulinetteForm(MoulinetteMixin, FormView):
         else:
             return res
 
+    def post(self, request, *args, **kwargs):
+        form = self.get_form()
+        context = self.get_context_data(form=form)
+        moulinette = context.get("moulinette", None)
+
+        # We don't want to redirect to the result url if the form is not
+        # absolutely valid, i.e we can actually display the result
+        if moulinette and not moulinette.has_missing_data():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
     def form_valid(self, form):
         return HttpResponseRedirect(self.get_results_url(form))
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -20,7 +20,11 @@ from envergo.geodata.models import Department
 from envergo.geodata.utils import get_address_from_coords
 from envergo.hedges.services import PlantationEvaluator
 from envergo.moulinette.forms import TriageFormHaie
-from envergo.moulinette.models import ConfigHaie, get_moulinette_class_from_site
+from envergo.moulinette.models import (
+    ConfigHaie,
+    MoulinetteHaie,
+    get_moulinette_class_from_site,
+)
 from envergo.moulinette.utils import compute_surfaces
 from envergo.utils.urls import copy_qs, extract_mtm_params, remove_from_qs, update_qs
 
@@ -324,12 +328,15 @@ class MoulinetteResultMixin:
         """Check which template to use depending on the moulinette result."""
 
         moulinette = self.moulinette
+        triage_form = self.triage_form
         is_debug = bool(self.request.GET.get("debug", False))
         is_admin = self.request.user.is_staff
 
         # We want to display the moulinette result template, but must check all
         # previous cases where we cannot do it
-        if is_debug:
+        if moulinette is None and triage_form is not None:
+            template_name = MoulinetteHaie.get_triage_result_template(triage_form)
+        elif is_debug:
             template_name = moulinette.get_debug_result_template()
         elif not moulinette.has_config():
             template_name = moulinette.get_result_non_disponible_template()
@@ -511,7 +518,11 @@ class BaseMoulinetteResult(FormView):
 
         # Moulinette is invalid and a triage form exists (haie), redirects to the
         # first step
-        elif moulinette is None and triage_form is not None:
+        elif (
+            moulinette is None
+            and triage_form is not None
+            and not triage_form.is_valid()
+        ):
             redirect_url = reverse("triage")
             redirect_url = update_qs(redirect_url, request.GET)
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -696,6 +696,6 @@ class Triage(FormView):
 
         # We want to preserve existing querystring params when validating the form
         qs = self.request.GET.urlencode()
-        qs = update_qs(qs, query_params)
         url_with_params = f"{url}?{qs}"
+        url_with_params = update_qs(url_with_params, query_params)
         return HttpResponseRedirect(url_with_params)

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -49,15 +49,14 @@ class MoulinetteMixin:
 
         moulinette_data = None
         GET = self.clean_request_get_parameters()
-        if self.request.method == "GET" and GET:
-            moulinette_data = GET
-        elif self.request.method in ("POST", "PUT"):
-            moulinette_data = self.request.POST
+        moulinette_data = GET
 
-        if moulinette_data:
-            mutable_data = moulinette_data.copy()
-            mutable_data.update(compute_surfaces(moulinette_data))
-            kwargs.update({"data": mutable_data})
+        if self.request.method in ("POST", "PUT"):
+            moulinette_data.update(self.request.POST)
+
+        mutable_data = moulinette_data.copy()
+        mutable_data.update(compute_surfaces(moulinette_data))
+        kwargs.update({"data": mutable_data})
 
         return kwargs
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -53,9 +53,8 @@ class MoulinetteMixin:
             moulinette_data.update(self.request.POST)
 
         if moulinette_data:
-            mutable_data = moulinette_data.copy()
-            mutable_data.update(compute_surfaces(moulinette_data))
-            kwargs.update({"data": mutable_data})
+            moulinette_data.update(compute_surfaces(moulinette_data))
+            kwargs.update({"data": moulinette_data})
 
         return kwargs
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -20,11 +20,7 @@ from envergo.geodata.models import Department
 from envergo.geodata.utils import get_address_from_coords
 from envergo.hedges.services import PlantationEvaluator
 from envergo.moulinette.forms import TriageFormHaie
-from envergo.moulinette.models import (
-    ConfigHaie,
-    MoulinetteHaie,
-    get_moulinette_class_from_site,
-)
+from envergo.moulinette.models import ConfigHaie, get_moulinette_class_from_site
 from envergo.moulinette.utils import compute_surfaces
 from envergo.utils.urls import copy_qs, extract_mtm_params, remove_from_qs, update_qs
 
@@ -283,7 +279,9 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
         if "redirect_url" in context:
             return HttpResponseRedirect(context["redirect_url"])
-        elif self.moulinette and "edit" not in request.GET:
+        elif (
+            self.moulinette and self.moulinette.is_valid() and "edit" not in request.GET
+        ):
             return HttpResponseRedirect(self.get_results_url(context["form"]))
         else:
             return res
@@ -295,7 +293,7 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
         # We don't want to redirect to the result url if the form is not
         # absolutely valid, i.e we can actually display the result
-        if moulinette and not moulinette.has_missing_data():
+        if moulinette and moulinette.is_valid():
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
@@ -326,25 +324,20 @@ class MoulinetteResultMixin:
         """Check which template to use depending on the moulinette result."""
 
         moulinette = self.moulinette
-        triage_form = self.triage_form
         is_debug = bool(self.request.GET.get("debug", False))
         is_admin = self.request.user.is_staff
 
         # We want to display the moulinette result template, but must check all
         # previous cases where we cannot do it
-
-        if moulinette is None and triage_form is None:
-            MoulinetteClass = get_moulinette_class_from_site(self.request.site)
-            template_name = MoulinetteClass.get_home_template()
-        elif moulinette is None:
-            template_name = MoulinetteHaie.get_triage_template(triage_form)
-        elif is_debug:
+        if is_debug:
             template_name = moulinette.get_debug_result_template()
         elif not moulinette.has_config():
             template_name = moulinette.get_result_non_disponible_template()
         elif not (moulinette.is_evaluation_available() or is_admin):
             template_name = moulinette.get_result_available_soon_template()
         elif moulinette.has_missing_data():
+            # This case should not happen, because we redirect to the form view
+            # earlier
             template_name = moulinette.get_home_template()
         else:
             template_name = moulinette.get_result_template()
@@ -501,14 +494,33 @@ class MoulinetteResultMixin:
 class BaseMoulinetteResult(FormView):
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
+        moulinette = context.get("moulinette", None)
+        triage_form = context.get("triage_form", None)
+        redirect_url = context.get("redirect_url", None)
+
+        # Moulinette is invalid and there is no triage to do (amenagement)
+        # so just redirect to the form
+        if moulinette is None and triage_form is None:
+            redirect_url = reverse("moulinette_form")
+            redirect_url = update_qs(redirect_url, request.GET)
+
+        # Moulinette form is invalid
+        elif moulinette is not None and moulinette.has_missing_data():
+            redirect_url = reverse("moulinette_form")
+            redirect_url = update_qs(redirect_url, request.GET)
+
+        # Moulinette is invalid and a triage form exists (haie), redirects to the
+        # first step
+        elif moulinette is None and triage_form is not None:
+            redirect_url = reverse("triage")
+            redirect_url = update_qs(redirect_url, request.GET)
+
+        if redirect_url:
+            return HttpResponseRedirect(redirect_url)
+
         res = self.render_to_response(context)
-        moulinette = self.moulinette
-        triage_form = self.triage_form
 
-        if "redirect_url" in context:
-            return HttpResponseRedirect(context["redirect_url"])
-
-        elif moulinette:
+        if moulinette:
             if "debug" not in self.request.GET and not self.validate_results_url(
                 request, context
             ):

--- a/envergo/templates/amenagement/_header.html
+++ b/envergo/templates/amenagement/_header.html
@@ -56,7 +56,7 @@
         {% block menu_items %}
           <li class="fr-nav__item">{% menu_item 'home' "Accueil" %}</li>
           <li class="fr-nav__item">
-            {% menu_item 'moulinette_home' "Simulateur" tracking_name 'SimulationClick' 'Nav' data_testid="simulateur_nav_btn" %}
+            {% menu_item 'moulinette_form' "Simulateur" tracking_name 'SimulationClick' 'Nav' data_testid="simulateur_nav_btn" %}
           </li>
           <li class="fr-nav__item">{% evalreq_menu tracking_name 'RequestClick' 'Nav' %}</li>
           <li class="fr-nav__item">{% faq_menu %}</li>

--- a/envergo/templates/amenagement/_slim_header.html
+++ b/envergo/templates/amenagement/_slim_header.html
@@ -28,7 +28,7 @@
           <ul class="fr-btns-group">
             <li>
               <a class="fr-btn"
-                 href="{% url 'moulinette_home' %}"
+                 href="{% url 'moulinette_form' %}"
                  data-event-category="{{ tracking_name }}"
                  data-event-action="SimulationClick"
                  data-event-name="Nav">Simulateur</a>

--- a/envergo/templates/amenagement/moulinette/form.html
+++ b/envergo/templates/amenagement/moulinette/form.html
@@ -9,7 +9,7 @@
             method="post"
             novalidate
             autocomplete="off"
-            action="{% url "moulinette_home" %}"
+            action="{% url "moulinette_form" %}"
             id="moulinette-form">
         {% csrf_token %}
 

--- a/envergo/templates/amenagement/moulinette/form.html
+++ b/envergo/templates/amenagement/moulinette/form.html
@@ -9,7 +9,7 @@
             method="post"
             novalidate
             autocomplete="off"
-            action="{% url "moulinette_form" %}"
+            action="{% url 'moulinette_form' %}?{{ request.GET.urlencode|safe }}"
             id="moulinette-form">
         {% csrf_token %}
 

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -15,7 +15,7 @@
   <form method="post"
         novalidate
         autocomplete="off"
-        action="{% url "moulinette_home" %}"
+        action="{% url "moulinette_form" %}"
         id="moulinette-form">
     {% csrf_token %}
     {% for field in form %}{{ field|as_hidden }}{% endfor %}

--- a/envergo/templates/amenagement/moulinette/result_available_soon.html
+++ b/envergo/templates/amenagement/moulinette/result_available_soon.html
@@ -10,7 +10,7 @@
   </div>
 
   <p>
-    👉 Testez le simulateur avec <a href="{% url 'moulinette_home' %}?created_surface=1250&final_surface=2250&lng=-1.83425&lat=47.20490&autorisation_urba=pc">
+    👉 Testez le simulateur avec <a href="{% url 'moulinette_form' %}?created_surface=1250&final_surface=2250&lng=-1.83425&lat=47.20490&autorisation_urba=pc">
     cet exemple de projet : une extension de
     1250 m² d'un bâtiment près des rives de la Loire, soumise à
     la Loi sur l'eau</a>.

--- a/envergo/templates/amenagement/moulinette/result_non_disponible.html
+++ b/envergo/templates/amenagement/moulinette/result_non_disponible.html
@@ -14,7 +14,7 @@
   </div>
 
   <p>
-    👉 Testez le simulateur avec <a href="{% url 'moulinette_home' %}?created_surface=1250&final_surface=2250&lng=-1.83425&lat=47.20490&autorisation_urba=pc">
+    👉 Testez le simulateur avec <a href="{% url 'moulinette_form' %}?created_surface=1250&final_surface=2250&lng=-1.83425&lat=47.20490&autorisation_urba=pc">
     cet exemple de projet : une extension de 1250 m² d'un bâtiment près des rives de la Loire, soumise à la Loi sur l'eau</a>.
   </p>
 

--- a/envergo/templates/haie/moulinette/form.html
+++ b/envergo/templates/haie/moulinette/form.html
@@ -10,7 +10,7 @@
             method="post"
             novalidate
             autocomplete="off"
-            action="{% url 'moulinette_home' %}?{{ request.GET.urlencode }}"
+            action="{% url 'moulinette_form' %}?{{ request.GET.urlencode }}"
             id="moulinette-form">
         {% csrf_token %}
 

--- a/envergo/templates/haie/moulinette/form.html
+++ b/envergo/templates/haie/moulinette/form.html
@@ -10,7 +10,7 @@
             method="post"
             novalidate
             autocomplete="off"
-            action="{% url 'moulinette_form' %}?{{ request.GET.urlencode }}"
+            action="{% url 'moulinette_form' %}?{{ request.GET.urlencode|safe }}"
             id="moulinette-form">
         {% csrf_token %}
 

--- a/envergo/templates/pages/faq/loi_sur_leau.html
+++ b/envergo/templates/pages/faq/loi_sur_leau.html
@@ -63,7 +63,7 @@
       </h3>
       <div class="fr-collapse" id="accordion-savoir_si_mon_projet_est_soumis">
         <p>
-          S’il s’agit d’un projet d’aménagement ou de construction, le <a href="{% url 'moulinette_home' %}">simulateur EnvErgo</a> vous permet en quelques clics de vérifier si le projet est soumis à la Loi sur l'eau — ainsi qu’aux autres réglementations environnementales (Natura 2000, évaluation environnementale…).
+          S’il s’agit d’un projet d’aménagement ou de construction, le <a href="{% url 'moulinette_form' %}">simulateur EnvErgo</a> vous permet en quelques clics de vérifier si le projet est soumis à la Loi sur l'eau — ainsi qu’aux autres réglementations environnementales (Natura 2000, évaluation environnementale…).
           C'est un service public numérique gratuit, fourni par le Ministère de la Transition Écologique.
           Il fonctionne pour l'instant dans <a href="{% url 'faq_availability_info' %}">{% nb_available_depts %} départements</a>, et sera progressivement étendu à l'ensemble du territoire national.
         </p>

--- a/envergo/templates/pages/faq/natura_2000.html
+++ b/envergo/templates/pages/faq/natura_2000.html
@@ -103,7 +103,7 @@
       </h3>
       <div class="fr-collapse" id="accordion-savoir_si_mon_projet_est_soumis">
         <p>
-          S’il s’agit d’un projet d’aménagement ou de construction, le <a href="{% url 'moulinette_home' %}">simulateur EnvErgo</a> vous permet en quelques clics de vérifier si le projet est soumis à Natura 2000 — ainsi qu’aux autres réglementations environnementales (Loi sur l’eau, évaluation environnementale…).
+          S’il s’agit d’un projet d’aménagement ou de construction, le <a href="{% url 'moulinette_form' %}">simulateur EnvErgo</a> vous permet en quelques clics de vérifier si le projet est soumis à Natura 2000 — ainsi qu’aux autres réglementations environnementales (Loi sur l’eau, évaluation environnementale…).
           C'est un service public numérique gratuit, fourni par le Ministère de la Transition Écologique.
           Il fonctionne pour l'instant dans <a href="{% url 'faq_availability_info' %}">{% nb_available_depts %} départements</a>, et sera prochainement étendu à un territoire plus large.
         </p>
@@ -186,7 +186,7 @@
           En effet, des impacts sur un site protégé peuvent être induits par le projet (bruit, effluents, activité humaine…), même s’il n’est pas strictement dans le périmètre.
         </p>
         <p>
-          Le <a href="{% url 'moulinette_home' %}">simulateur EnvErgo</a>, pour déterminer si un projet de construction ou d’aménagement est soumis à Natura 2000,
+          Le <a href="{% url 'moulinette_form' %}">simulateur EnvErgo</a>, pour déterminer si un projet de construction ou d’aménagement est soumis à Natura 2000,
           prend en compte les listes locales et la doctrine DDT(M) de chaque département.
         </p>
       </div>
@@ -214,7 +214,7 @@
           <li>autorisation environnementale, etc.</li>
         </ul>
         <p>
-          Le <a href="{% url 'moulinette_home' %}">simulateur EnvErgo</a> permet de déterminer à la fois si un projet est soumis à EIN,
+          Le <a href="{% url 'moulinette_form' %}">simulateur EnvErgo</a> permet de déterminer à la fois si un projet est soumis à EIN,
           et la procédure associée pour déposer le dossier.
         </p>
       </div>

--- a/envergo/utils/urls.py
+++ b/envergo/utils/urls.py
@@ -12,6 +12,15 @@ def update_qs(url, params):
     return urlunsplit(new_bits)
 
 
+def copy_qs(url, from_url):
+    """Replace url querystring with querystring from `from_url`."""
+
+    bits = urlsplit(url)
+    from_bits = urlsplit(from_url)
+    new_bits = bits._replace(query=from_bits.query)
+    return urlunsplit(new_bits)
+
+
 def remove_from_qs(url, key):
     """Remove a parameter from an url query string."""
 


### PR DESCRIPTION
https://trello.com/c/8zrs9jmO/1231-haie-garder-la-persistance-du-remplissage-du-formulaire-au-fl%C3%A9chage

https://trello.com/c/4Q4BAcNL/1260-haie-et-envergo-persistance-des-questions-compl%C3%A9mentaires

Un refactoring qui permet de corriger plusieurs problèmes.

J'ai refondu la manière dont le formulaire est affiché. Avant, pour éditer une simulation, on restait sur l'url de résultat mais on affichait le template « formulaire ». J'ai tout mis en cohérence pour que le formulaire soit toujours affiché avec l'url « formulaire ».

J'ai aussi renommé l'url `moulinette_home` en `moulinette_form` ce qui me semble plus significatif.