### PR TITLE
Conditions d'acceptabilité : On affiche les conditions d'acceptabilité des critères même s'ils appartiennent à une réglementation non activée

### DIFF
--- a/envergo/hedges/services.py
+++ b/envergo/hedges/services.py
@@ -214,6 +214,17 @@ class PlantationEvaluator:
         R = self.replantation_coefficient
         conditions = []
         for regulation in self.moulinette.regulations:
+            if not regulation.is_activated():
+                continue
+
+            if regulation.has_perimeters:
+                all_perimeters = regulation.perimeters.all()
+                activated_perimeters = [p for p in all_perimeters if p.is_activated]
+                if all_perimeters and not any(activated_perimeters):
+                    continue
+                if not all_perimeters:
+                    continue
+
             for criterion in regulation.criteria.all():
                 if hasattr(criterion._evaluator, "plantation_evaluate"):
                     conditions.extend(

--- a/envergo/hedges/services.py
+++ b/envergo/hedges/services.py
@@ -220,9 +220,7 @@ class PlantationEvaluator:
             if regulation.has_perimeters:
                 all_perimeters = regulation.perimeters.all()
                 activated_perimeters = [p for p in all_perimeters if p.is_activated]
-                if all_perimeters and not any(activated_perimeters):
-                    continue
-                if not all_perimeters:
+                if not all_perimeters or not any(activated_perimeters):
                     continue
 
             for criterion in regulation.criteria.all():

--- a/envergo/hedges/tests/test_services.py
+++ b/envergo/hedges/tests/test_services.py
@@ -1,0 +1,122 @@
+import pytest
+
+from envergo.geodata.conftest import bizous_town_center, france_map  # noqa
+from envergo.hedges.services import PlantationEvaluator
+from envergo.hedges.tests.factories import HedgeDataFactory
+from envergo.moulinette.models import MoulinetteHaie
+from envergo.moulinette.tests.factories import (
+    ConfigHaieFactory,
+    CriterionFactory,
+    PerimeterFactory,
+    RegulationFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def alignementarbres_criteria(france_map):  # noqa
+    regulation = RegulationFactory(regulation="alignement_arbres")
+
+    criteria = [
+        CriterionFactory(
+            title="Alignement arbres > L350-3",
+            regulation=regulation,
+            evaluator="envergo.moulinette.regulations.alignementarbres.AlignementsArbres",
+            activation_map=france_map,
+            activation_mode="department_centroid",
+        ),
+    ]
+    return criteria
+
+
+@pytest.fixture
+def ep_criteria(france_map):  # noqa
+    regulation = RegulationFactory(regulation="ep")
+    criteria = [
+        CriterionFactory(
+            title="Espèces protégées",
+            regulation=regulation,
+            evaluator="envergo.moulinette.regulations.ep.EspecesProtegeesSimple",
+            activation_map=france_map,
+            activation_mode="department_centroid",
+        ),
+    ]
+    return criteria
+
+
+@pytest.fixture
+def n2000_criteria(france_map, bizous_town_center):  # noqa
+    regulation = RegulationFactory(regulation="natura2000_haie", has_perimeters=True)
+
+    perimeter = PerimeterFactory(
+        name="N2000 Bizous", activation_map=bizous_town_center, regulations=[regulation]
+    )
+
+    criteria = [
+        CriterionFactory(
+            title="Natura 2000 Haie > Haie Bizous",
+            regulation=regulation,
+            perimeter=perimeter,
+            evaluator="envergo.moulinette.regulations.natura2000_haie.Natura2000Haie",
+            activation_map=france_map,
+            activation_mode="hedges_intersection",
+            evaluator_settings={"result": "soumis"},
+        ),
+    ]
+    return criteria
+
+
+def test_plantation_evaluator_should_evaluate_only_activated_regulations(
+    ep_criteria, alignementarbres_criteria, n2000_criteria
+):
+    # GIVEN two regulations, one activated, one not activated, and one without activated perimeter on a department
+    ConfigHaieFactory(regulations_available=["alignement_arbres", "natura2000_haie"])
+    hedges = HedgeDataFactory(
+        data=[
+            {
+                "id": "D1",
+                "type": "TO_REMOVE",
+                "latLngs": [
+                    {"lat": 43.0693, "lng": 0.4421},
+                    {"lat": 43.0695, "lng": 0.4420},
+                ],
+                "additionalData": {
+                    "type_haie": "alignement",
+                    "vieil_arbre": False,
+                    "proximite_mare": False,
+                    "sur_parcelle_pac": False,
+                    "proximite_point_eau": False,
+                    "connexion_boisement": False,
+                    "bord_voie": True,
+                },
+            }
+        ]
+    )
+    moulinette_data = {
+        "motif": "securite",
+        "reimplantation": "replantation",
+        "localisation_pac": "non",
+        "haies": hedges,
+        "travaux": "destruction",
+        "element": "haie",
+        "department": 44,
+    }
+    moulinette = MoulinetteHaie(moulinette_data, moulinette_data)
+
+    # WHEN the plantation evaluator is created with these regulations
+    evaluator = PlantationEvaluator(moulinette, moulinette_data["haies"])
+    evaluator.evaluate()
+
+    # THEN the plantation evaluator should only evaluate the activated regulation
+    assert len(evaluator.conditions) == 2
+    assert any(
+        condition
+        for condition in evaluator.conditions
+        if condition.label == "Alignements d’arbres (L350-3)"
+    )
+    assert any(
+        condition
+        for condition in evaluator.conditions
+        if condition.label == "Longueur de la haie plantée"
+    )


### PR DESCRIPTION
https://trello.com/c/BKj1GjgL/1784-conditions-dacceptabilit%C3%A9-on-affiche-les-conditions-dacceptabilit%C3%A9-des-crit%C3%A8res-m%C3%AAme-sils-appartiennent-%C3%A0-une-r%C3%A9glementation-non