### PR TITLE
Haie / Les instructeurs peuvent visualiser les pièces-jointes liées à un message (Messagerie 3/5)

### DIFF
--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -493,6 +493,7 @@ def test_petition_project_instructor_messagerie_ds(
     assert "Il manque les infos de la PAC" in content
     assert "2 avril 2025 à 11:01" in content
     assert "8 messages" in content
+    assert "Coriandrum_sativum" in content
 
     # Test if dossier has zero messages
     mock_post.return_value = GET_DOSSIER_MESSAGES_0_FAKE_RESPONSE["data"]

--- a/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
+++ b/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
@@ -40,7 +40,7 @@
           <div class="fr-mt-2w">
           {% for pj in message.attachments %}
             <div class="fr-download">
-              <a class="fr-download__link" target="_blank" href="{{ pj.url }}">
+              <a class="fr-link" target="_blank" href="{{ pj.url }}">
                 <span class="fr-sr-only">Télécharger le fichier</span>
                 {{ pj.filename }}
                 <span class="fr-download__detail">{{ pj.contentType }} – {{ pj.byteSize|filesizeformat }}</span>

--- a/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
+++ b/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
@@ -41,7 +41,7 @@
           {% for pj in message.attachments %}
             <div class="fr-download">
               <a class="fr-download__link" target="_blank" href="{{ pj.url }}">
-                <span class="sr-only">Télécharger le fichier</span>
+                <span class="fr-sr-only">Télécharger le fichier</span>
                 {{ pj.filename }}
                 <span class="fr-download__detail">{{ pj.contentType }} – {{ pj.byteSize|filesizeformat }}</span>
               </a>

--- a/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
+++ b/envergo/templates/haie/petitions/instructor_view_dossier_messagerie.html
@@ -36,7 +36,20 @@
             {% endwith %}
           </div>
           <div class="ds-message__content">{{ message.body|safe|linebreaksbr }}</div>
+
+          <div class="fr-mt-2w">
+          {% for pj in message.attachments %}
+            <div class="fr-download">
+              <a class="fr-download__link" target="_blank" href="{{ pj.url }}">
+                <span class="sr-only">Télécharger le fichier</span>
+                {{ pj.filename }}
+                <span class="fr-download__detail">{{ pj.contentType }} – {{ pj.byteSize|filesizeformat }}</span>
+              </a>
+            </div>
+          {% endfor %}
+
         </div>
+      </div>
       {% endfor %}
     </section>
   {% endif %}


### PR DESCRIPTION
https://trello.com/c/bTB7ZxCD/1765-haie-les-instructeurs-peuvent-visualiser-les-pi%C3%A8ces-jointes-li%C3%A9es-%C3%A0-un-message-messagerie-3-5

J'ai copié l'affichage de démarches simplifiées.

Suite de #740 