### PR TITLE
Envergo / la standardisation des url Matomo incluant une réf d'avis efface les mtm_

### DIFF
--- a/envergo/analytics/utils.py
+++ b/envergo/analytics/utils.py
@@ -87,15 +87,20 @@ def set_visitor_id_cookie(response, value):
 
 def extract_matomo_url_from_request(request):
     """Extract bare urls with matomo params from request."""
+    bare_url = request.build_absolute_uri(request.path)
+    return update_url_with_matomo_params(bare_url, request)
+
+
+def update_url_with_matomo_params(url, request):
+    """Add matomo params from request querystring to a given url."""
 
     current_url = request.build_absolute_uri()
     params = extract_mtm_params(current_url)
     is_edit = bool(request.GET.get("edit", False))
     if is_edit:
         params["edit"] = "true"
-    bare_url = request.build_absolute_uri(request.path)
 
-    return update_qs(bare_url, params)
+    return update_qs(url, params)
 
 
 def get_matomo_tags(request):

--- a/envergo/evaluations/views.py
+++ b/envergo/evaluations/views.py
@@ -24,7 +24,11 @@ from django.views.generic import (
 )
 from django.views.generic.edit import BaseFormView
 
-from envergo.analytics.utils import is_request_from_a_bot, log_event
+from envergo.analytics.utils import (
+    is_request_from_a_bot,
+    log_event,
+    update_url_with_matomo_params,
+)
 from envergo.evaluations.forms import (
     EvaluationSearchForm,
     RequestForm,
@@ -149,7 +153,9 @@ class EvaluationDetail(
         context["current_url"] = current_url
         context["share_btn_url"] = share_btn_url
         context["share_print_url"] = share_print_url
-        context["matomo_custom_url"] = "/avis/+ref_ar+/"
+        context["matomo_custom_url"] = update_url_with_matomo_params(
+            "/avis/+ref_ar+/", self.request
+        )
         context["evaluation_content"] = self.get_evaluation_content()
         return context
 
@@ -318,7 +324,9 @@ class WizardStepMixin:
         form = self.get_form(self.get_form_class())
         if form.is_bound and not form.is_valid():
             # as it is not a complete url, Matomo concatenate it to the current url, which is OK for us
-            context["matomo_custom_url"] = "erreur-validation/"
+            context["matomo_custom_url"] = update_url_with_matomo_params(
+                "erreur-validation/", self.request
+            )
         return context
 
 
@@ -486,7 +494,9 @@ class RequestEvalWizardStep3(WizardStepMixin, UpdateView):
         context["max_files"] = settings.MAX_EVALREQ_FILES
         context["uploaded_files"] = files
         context["request_submitted"] = self.object.submitted
-        context["matomo_custom_url"] = "/avis/formulaire/etape-3/+ref_ar+/"
+        context["matomo_custom_url"] = update_url_with_matomo_params(
+            "/avis/formulaire/etape-3/+ref_ar+/", self.request
+        )
 
         return context
 
@@ -577,7 +587,9 @@ class RequestSuccess(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["matomo_custom_url"] = "/avis/formulaire/succès/+ref_ar+/"
+        context["matomo_custom_url"] = update_url_with_matomo_params(
+            "/avis/formulaire/succès/+ref_ar+/", self.request
+        )
         return context
 
 
@@ -601,6 +613,8 @@ class SelfDeclaration(EvaluationDetailMixin, DetailView):
         context["address"] = quote_plus(self.object.address, safe="")
         context["application_number"] = self.object.application_number
         context["redirect_url"] = f"{self.object.get_absolute_url()}?tally=ok"
-        context["matomo_custom_url"] = "/avis/+ref_ar+/conformite/"
+        context["matomo_custom_url"] = update_url_with_matomo_params(
+            "/avis/+ref_ar+/conformite/", self.request
+        )
 
         return context

--- a/envergo/hedges/views.py
+++ b/envergo/hedges/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView
 from django.views.generic.edit import FormMixin, FormView
 
+from envergo.analytics.utils import update_url_with_matomo_params
 from envergo.hedges.forms import HedgeToPlantPropertiesForm, HedgeToRemovePropertiesForm
 from envergo.hedges.models import HedgeData
 from envergo.hedges.services import PlantationEvaluator
@@ -127,7 +128,9 @@ class HedgeInput(MoulinetteMixin, FormMixin, DetailView):
 
         mode = self.kwargs.get("mode", "removal")
         context["mode"] = mode
-        context["matomo_custom_url"] = self.get_matomo_custom_url(mode)
+        context["matomo_custom_url"] = update_url_with_matomo_params(
+            self.get_matomo_custom_url(mode), self.request
+        )
         context["hedge_conditions_url"] = self.get_conditions_url(mode)
 
         return context

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -14,6 +14,7 @@ from envergo.analytics.utils import (
     get_matomo_tags,
     is_request_from_a_bot,
     log_event,
+    update_url_with_matomo_params,
 )
 from envergo.evaluations.models import TagStyleEnum
 from envergo.geodata.models import Department
@@ -26,7 +27,7 @@ from envergo.moulinette.models import (
     get_moulinette_class_from_site,
 )
 from envergo.moulinette.utils import compute_surfaces
-from envergo.utils.urls import extract_mtm_params, remove_from_qs, update_qs
+from envergo.utils.urls import remove_from_qs, update_qs
 
 
 class MoulinetteMixin:
@@ -294,12 +295,12 @@ class MoulinetteHome(MoulinetteMixin, FormView):
 
         form = context["form"]
         if form.is_bound and not form.is_valid():
-            mtm_params = extract_mtm_params(self.request.build_absolute_uri())
             invalid_form_url = self.request.build_absolute_uri(
                 reverse("moulinette_invalid_form")
             )
-            matomo_invalid_form_url = update_qs(invalid_form_url, mtm_params)
-            context["matomo_custom_url"] = matomo_invalid_form_url
+            context["matomo_custom_url"] = update_url_with_matomo_params(
+                invalid_form_url, self.request
+            )
 
         return context
 
@@ -378,51 +379,56 @@ class MoulinetteResultMixin:
         # Let's build custom uris for better matomo tracking
         # Depending on the moulinette result, we want to track different uris
         # as if they were distinct pages.
-        current_url = self.request.build_absolute_uri()
 
         # Url without any query parameters
         # We want to build "fake" urls for matomo tracking
         # For example, if the current url is /simulateur/resultat/?debug=true,
         # We want to track this as a custom url /simulateur/debug/
-        mtm_params = extract_mtm_params(current_url)
 
         # We want to log the current simulation url stripped from any query parameters
         # except for mtm_ ones
         bare_url = self.request.build_absolute_uri(self.request.path)
-        matomo_bare_url = update_qs(bare_url, mtm_params)
         debug_url = self.request.build_absolute_uri(reverse("moulinette_result_debug"))
-        matomo_debug_url = update_qs(debug_url, mtm_params)
         missing_data_url = self.request.build_absolute_uri(
             reverse("moulinette_missing_data")
         )
         form_url = self.request.build_absolute_uri(reverse("moulinette_home"))
         form_url_with_edit = update_qs(form_url, {"edit": "true"})
-        matomo_missing_data_url = update_qs(missing_data_url, mtm_params)
         out_of_scope_result_url = self.request.build_absolute_uri(
             reverse("moulinette_result_out_of_scope")
         )
-        matomo_out_of_scope_result_url = update_qs(out_of_scope_result_url, mtm_params)
         invalid_form_url = self.request.build_absolute_uri(
             reverse("moulinette_invalid_form")
         )
-        matomo_invalid_form_url = update_qs(invalid_form_url, mtm_params)
 
-        data["matomo_custom_url"] = matomo_bare_url
+        data["matomo_custom_url"] = update_url_with_matomo_params(
+            bare_url, self.request
+        )
 
         if moulinette and is_edit:
-            data["matomo_custom_url"] = form_url_with_edit
+            data["matomo_custom_url"] = update_url_with_matomo_params(
+                form_url_with_edit, self.request
+            )
 
         elif moulinette and is_debug:
-            data["matomo_custom_url"] = matomo_debug_url
+            data["matomo_custom_url"] = update_url_with_matomo_params(
+                debug_url, self.request
+            )
 
         elif moulinette and moulinette.has_missing_data():
             if context["additional_forms_bound"]:
-                context["matomo_custom_url"] = matomo_invalid_form_url
+                context["matomo_custom_url"] = update_url_with_matomo_params(
+                    invalid_form_url, self.request
+                )
             else:
-                context["matomo_custom_url"] = matomo_missing_data_url
+                context["matomo_custom_url"] = update_url_with_matomo_params(
+                    missing_data_url, self.request
+                )
 
         elif context.get("triage_form", None):
-            context["matomo_custom_url"] = matomo_out_of_scope_result_url
+            context["matomo_custom_url"] = update_url_with_matomo_params(
+                out_of_scope_result_url, self.request
+            )
 
         return data
 


### PR DESCRIPTION
https://trello.com/c/FTNjHrm0/1825-envergo-la-standardisation-des-url-matomo-incluant-une-r%C3%A9f-davis-efface-les-mtm