### PR TITLE
Corige la config de django debug toolbar

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -55,7 +55,10 @@ INSTALLED_APPS = ["whitenoise.runserver_nostatic"] + INSTALLED_APPS  # noqa F405
 
 if env("USE_DEBUG_TOOLBAR", default="yes") == "yes":
     INSTALLED_APPS += ["debug_toolbar"]  # noqa F405
-    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
+    MIDDLEWARE = [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+        *MIDDLEWARE,  # noqa F405
+    ]
     DEBUG_TOOLBAR_CONFIG = {
         "DISABLE_PANELS": [
             "debug_toolbar.panels.redirects.RedirectsPanel",
@@ -66,6 +69,7 @@ if env("USE_DEBUG_TOOLBAR", default="yes") == "yes":
             "debug_toolbar.panels.staticfiles.StaticFilesPanel",
         ],
         "SHOW_TEMPLATE_CONTEXT": True,
+        "RESULTS_CACHE_SIZE": 50,
     }
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
 INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]


### PR DESCRIPTION
Dans la configuration actuelle, le middleware pour la ddt se trouve en dernier. Le résultat est que les requêtes effectuées dans les middleware ne sont pas détectées et passent inaperçues.

En passant la ddt en tout premier, on obtient des infos de debug plus pertinentes.