### PR TITLE
Haie / supprimer le bandeau "Pour en savoir plus" en bas des pages instructeur

### DIFF
--- a/envergo/templates/haie/moulinette/confighaie_settings.html
+++ b/envergo/templates/haie/moulinette/confighaie_settings.html
@@ -32,3 +32,5 @@
     </div>
   </div>
 {% endblock %}
+
+{% block after-content %}{% endblock %}

--- a/envergo/templates/haie/petitions/instructor_dossier_list.html
+++ b/envergo/templates/haie/petitions/instructor_dossier_list.html
@@ -109,6 +109,9 @@
   {% endwith %}
 
 {% endblock %}
+
+{% block after-content %}{% endblock %}
+
 {% block extra_js %}
   <script defer src="{% static 'js/libs/follow_up_form.js' %}"></script>
   <script>


### PR DESCRIPTION
https://trello.com/c/aA2GUsb3/1972-haie-supprimer-le-bandeau-pour-en-savoir-plus-en-bas-des-pages-instructeur