### PR TITLE
Corrige le zoom sur vue d'ensemble des haies

### DIFF
--- a/envergo/hedges/static/hedge_input/app.js
+++ b/envergo/hedges/static/hedge_input/app.js
@@ -514,8 +514,11 @@ createApp({
 
     // Center the map around all existing hedges
     const zoomOut = (animate = true) => {
+      let allHedges = hedges[TO_REMOVE].hedges;
+      if (mode !== REMOVAL_MODE) {
+        allHedges = allHedges.concat(hedges[TO_PLANT].hedges);
+      }
       // The concat method does not modify the original arrays
-      let allHedges = hedges[TO_REMOVE].hedges.concat(hedges[TO_PLANT].hedges);
       if (allHedges.length > 0) {
         const group = new L.featureGroup(allHedges.map(p => p.polyline));
         map.fitBounds(group.getBounds(), { ...fitBoundsOptions, animate: animate, padding: [50, 50] });


### PR DESCRIPTION
https://trello.com/c/rpktVcjp/1276-haie-la-vue-densemble-est-erronn%C3%A9e-si-jai-d%C3%A9plac%C3%A9-une-haie

 - une fois qu'on modifiait une haie en déplaçant des points, le zoom devenait erroné
 - sur un projet complet, quand on revenait sur la vue « détruire des haies », le zoom prenait en compte les haies masquées