### PR TITLE
Corrige une url de redirection

### DIFF
--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -1684,7 +1684,7 @@ class PetitionProjectAcceptInvitation(RedirectView):
         if not token or not self.TOKEN_PATTERN.match(token):
             raise SuspiciousOperation("Invalid invitation token format")
 
-        url = reverse("petition_project", args=[reference])
+        url = reverse("petition_project_instructor_view", args=[reference])
         url_with_token = f"{url}?{settings.INVITATION_TOKEN_COOKIE_NAME}={token}"
         return url_with_token
 


### PR DESCRIPTION
Hotfix: change l'url de redirection pour les anciennes vues d'acceptation de token d'invitation.