### PR TITLE
On perimeter maps, place To plant hedges behind To remove hedges (lik…

### DIFF
--- a/envergo/moulinette/regulations/__init__.py
+++ b/envergo/moulinette/regulations/__init__.py
@@ -267,15 +267,6 @@ class HedgesCentricMapFactory(MapFactory):
                     for hedge in haies.hedges_to_plant()
                 ]
 
-                if hedges_to_remove_geometries:
-                    hedges_to_remove = MapPolygon(
-                        hedges_to_remove_geometries,
-                        "#f00",
-                        "Haies à détruire",
-                        class_name="hedge to-remove",
-                    )
-                    polygons.append(hedges_to_remove)
-
                 if hedges_to_plant_geometries:
                     hedges_to_plant = MapPolygon(
                         hedges_to_plant_geometries,
@@ -284,6 +275,15 @@ class HedgesCentricMapFactory(MapFactory):
                         class_name="hedge to-plant",
                     )
                     polygons.append(hedges_to_plant)
+
+                if hedges_to_remove_geometries:
+                    hedges_to_remove = MapPolygon(
+                        hedges_to_remove_geometries,
+                        "#f00",
+                        "Haies à détruire",
+                        class_name="hedge to-remove",
+                    )
+                    polygons.append(hedges_to_remove)
 
                 hedges = MapPolygon(
                     hedges_to_remove_geometries + hedges_to_plant_geometries,


### PR DESCRIPTION
https://trello.com/c/RC6w35TA
Pas sûr de mon coup, mais l’idée c’est que sur une page du type :

https://haie.beta.gouv.fr/projet/XZS6LL/instruction/sites_proteges_haie/#regulation_sites_proteges_haie

On ait bien les haies D qui soit devant les haies P.

Objectif = harmoniser avec l'éditeur de haies, même si c’est pas l’idéal puisque dans ce cas aussi on cache les haies qui se superposent.