### PR TITLE
Analytics/remove consultation tokens

### DIFF
--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -1128,7 +1128,6 @@ class PetitionProjectInstructorConsultationsView(
     """View for managing invitation tokens (consultations)"""
 
     template_name = "haie/petitions/instructor_view_consultations.html"
-    event_action = "consultation_tokens"
 
     def has_view_permission(self, request, object):
         """Only department administratons can see this page"""
@@ -1404,9 +1403,9 @@ class PetitionProjectInstructorProcedureView(
                 form.add_error(
                     None,
                     mark_safe(
-                        f"Impossible de mettre à jour le dossier dans Démarches Simplifiées. Si le problème persiste, "
-                        f"<a href='{reverse("contact_us")}'>contactez l'équipe du Guichet Unique de la Haie</a> en "
-                        f"indiquant l'identifiant du dossier."
+                        f"""Impossible de mettre à jour le dossier dans Démarches Simplifiées. Si le problème persiste,
+                        <a href='{reverse("contact_us")}'>contactez l'équipe du Guichet Unique de la Haie</a> en
+                        indiquant l'identifiant du dossier."""
                     ),
                 )
                 return self.form_invalid(form)


### PR DESCRIPTION
https://trello.com/c/NPlVmACD

L’event `consultation_tokens` n’est pas dans le référentiel SQL, on peut donc le supprimer.