### PR TITLE
remove consulation_tokens analytics event

### DIFF
--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -1133,6 +1133,7 @@ class PetitionProjectInstructorConsultationsView(
     """View for managing invitation tokens (consultations)"""
 
     template_name = "haie/petitions/instructor_view_consultations.html"
+    event_action = None  # do not log event
 
     def has_view_permission(self, request, object):
         """Only department administratons can see this page"""


### PR DESCRIPTION
https://trello.com/c/NPlVmACD

L’event `consultation_tokens` n’est pas dans le référentiel SQL, on peut donc le supprimer

Je pourrai supprimer les events erronés dans la base de prod sans souci