### PR TITLE
Désactive le middleware de rate limiting dans les tests

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -47,3 +47,5 @@ MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
 
 ENV_NAME = "test"
 ENVERGO_AMENAGEMENT_DOMAIN = "testserver"
+
+RATELIMIT_ENABLE = False

--- a/envergo/middleware/tests.py
+++ b/envergo/middleware/tests.py
@@ -10,6 +10,7 @@ def autouse_site(site):
 
 
 @override_settings(RATELIMIT_RATE="0/s")
+@override_settings(RATELIMIT_ENABLE=True)
 def test_ratelimit(client):
     # GIVEN a 0/s rate limit setting (to avoid flakyness)
     url = "/simulateur/formulaire/"


### PR DESCRIPTION
Je suis très étonné qu'on n'en ait pas eu besoin jusque là.