### PR TITLE
Bug / TypeError sur la page département indisponible (Sentry)

### DIFF
--- a/envergo/templates/evaluations/eval_request_wizard_address_unavailable_department.html
+++ b/envergo/templates/evaluations/eval_request_wizard_address_unavailable_department.html
@@ -1,6 +1,6 @@
 {% extends 'evaluations/eval_request_wizard_address.html' %}
 
-{% load pages %}
+{% load pages static %}
 
 {% block form %}
   <div id="unavailable-department-alert"
@@ -20,7 +20,4 @@
 </div>
 {% endblock %}
 
-{% block extra_js %}
-  <script>DEPARTMENT_FIELD_NAME = 'department';</script>
-  <script defer src="{% static 'js/libs/eval_request_department.js' %}"></script>
-{% endblock %}
+{% block extra_js %}{% endblock %}


### PR DESCRIPTION
Correction des bugs remontés sur sentry

https://sentry.incubateur.net/organizations/betagouv/issues/173785/

Explication de l'erreur : dans le formulaire pour demander un avis, il n'y a pas de champs adresse sur le template qui indique que le département n'est pas encore disponible.