### PR TITLE
Bug / Erreur 500 pour l'url /projet

### DIFF
--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -97,6 +97,19 @@ def ep_criteria(france_map):  # noqa
     return criteria
 
 
+def test_petition_projet_create_view_dispatch(client, site, haie_user):
+    """Test request GET on url "/project" """
+    project_url = reverse("petition_project_create")
+    response = client.get(project_url)
+    assert response.status_code == 302
+    assert response.url == "/"
+
+    client.force_login(haie_user)
+    response = client.get(project_url)
+    assert response.status_code == 302
+    assert response.url == "/projet/liste"
+
+
 @override_settings(DEMARCHES_SIMPLIFIEES=DEMARCHES_SIMPLIFIEES_FAKE)
 @patch("requests.post")
 @patch("envergo.petitions.views.reverse")

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -217,6 +217,14 @@ class PetitionProjectCreate(FormView):
 
     def dispatch(self, request, *args, **kwargs):
         # store alerts in the request object to notify admins if needed
+        if request.method == "GET":
+            if request.user.is_authenticated:
+                url = reverse("petition_project_list")
+            else:
+                url = reverse("home")
+
+            return HttpResponseRedirect(url)
+
         request.alerts = PetitionProjectCreationAlert(request)
         res = super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
https://trello.com/c/nyLj4uN4/2068-erreur-500-pour-lurl-projet

https://sentry.incubateur.net/organizations/betagouv/issues/235872

Cette vue n'est utilisée que pour soumettre un dossier après une simulation sur le GUH, il n'y a aucune raison pour que la vue soit appelée en GET. On pourrait restreindre les méthodes pour cette vue à POST, mais j'ai choisi de rediriger soit vers la page d'accueil si on n'est pas connecté, soit vers la liste des dossiers quand on est connecté.