### PR TITLE
Mise à jour de l'url pour l'autocomplétion d'adresse

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -271,6 +271,7 @@ SECURE_CSP_REPORT_ONLY = {
     ],
     "connect-src": [
         CSP.SELF,
+        "https://data.geopf.fr",  # New address autocomplete api
         "https://*.data.gouv.fr",  # Address autocomplete api
         "https://*.beta.gouv.fr",  # Stats
         "https://sentry.incubateur.net",

--- a/envergo/static/js/libs/address_autocomplete.js
+++ b/envergo/static/js/libs/address_autocomplete.js
@@ -123,7 +123,7 @@
       source: function (query, populateResults) {
         const event = new CustomEvent('Envergo:address_autocomplete_input', { detail: query });
         window.dispatchEvent(event);
-        return debouncedFetch(`https://api-adresse.data.gouv.fr/search/?autocomplete=1&q=${query}`)
+        return debouncedFetch(`https://data.geopf.fr/geocodage/search/?autocomplete=1&q=${query}`)
           .then((response) => response.json())
           .then(({ features }) => {
             populateResults(features);
@@ -147,7 +147,7 @@
       }
     });
 
-    observer.observe(this.inputElement, {attributes: true, attributeFilter: ['disabled']});
+    observer.observe(this.inputElement, { attributes: true, attributeFilter: ['disabled'] });
   };
 
 })(this, accessibleAutocomplete);


### PR DESCRIPTION
Grosse sueur froide. Il s'agit d'un hotfix, le code est déjà en prod.

https://adresse.data.gouv.fr/blog/lapi-adresse-de-la-base-adresse-nationale-est-transferee-a-lign