### PR TITLE
Retirer les blocs auto-m.e.c. de tous les avis

### DIFF
--- a/envergo/templates/evaluations/_content.html
+++ b/envergo/templates/evaluations/_content.html
@@ -80,10 +80,6 @@
 
 {% for regulation in moulinette.regulations %}
   {% include 'amenagement/moulinette/_result_regulation.html' with regulation=regulation %}
-
-  {% if evaluation.is_eligible_to_self_declaration %}
-    {% include 'evaluations/_self_declaration_cta.html' %}
-  {% endif %}
 {% endfor %}
 
 {% include 'moulinette/_additional_regulations.html' with moulinette=moulinette %}


### PR DESCRIPTION
https://trello.com/c/JrQT4oEM/2140-retirer-les-blocs-auto-mec-de-tous-les-avis