### PR TITLE
Empêche le doublonnage des paramètre "alternative=True" en créant des simus alternatives

### DIFF
--- a/envergo/petitions/models.py
+++ b/envergo/petitions/models.py
@@ -543,7 +543,10 @@ class Simulation(models.Model):
 
         m_url = MoulinetteUrl(self.moulinette_url)
         qt = m_url.querydict
-        qt.update(kwargs)
+        # Use iteration instead of `qt.update` because qt is a MultiValueDict and
+        # update just adds more values instead of just updating them
+        for key, value in kwargs.items():
+            qt[key] = value
         f_url = reverse(view_name)
         url = f"{f_url}?{qt.urlencode()}"
         return url
@@ -551,7 +554,7 @@ class Simulation(models.Model):
     @property
     def form_url(self):
         """Return the moulinette form url with the simulation parameters."""
-        return self.custom_url("moulinette_form", alternative=True)
+        return self.custom_url("moulinette_form", alternative="true")
 
     @property
     def result_url(self):
@@ -560,7 +563,7 @@ class Simulation(models.Model):
         if self.is_active:
             url = reverse("petition_project", args=[self.project.reference])
         else:
-            url = self.custom_url("moulinette_result_plantation", alternative=True)
+            url = self.custom_url("moulinette_result_plantation", alternative="true")
         return url
 
 

--- a/envergo/petitions/tests/test_models.py
+++ b/envergo/petitions/tests/test_models.py
@@ -1,7 +1,9 @@
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
 from envergo.moulinette.tests.factories import DCConfigHaieFactory
-from envergo.petitions.tests.factories import PetitionProjectFactory
+from envergo.petitions.tests.factories import PetitionProjectFactory, SimulationFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -10,3 +12,62 @@ def test_set_department_on_save():
     DCConfigHaieFactory()
     petition_project = PetitionProjectFactory()
     assert petition_project.department.department == "44"
+
+
+def test_form_url_adds_alternative_param():
+    """form_url appends alternative=true to the query string."""
+    DCConfigHaieFactory()
+    project = PetitionProjectFactory()
+    simulation = SimulationFactory(project=project)
+
+    # Check that "alternative" is not already in the initial url
+    url = simulation.moulinette_url
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    assert "alternative" not in params
+
+    url = simulation.form_url
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    assert params["alternative"] == ["true"]
+
+
+def test_form_url_does_not_duplicate_alternative_param():
+    """form_url replaces an existing alternative param instead of appending a second one."""
+    DCConfigHaieFactory()
+    project = PetitionProjectFactory()
+    # Create a simulation whose moulinette_url already contains alternative=true
+    moulinette_url = project.moulinette_url + "&alternative=true"
+    simulation = SimulationFactory(project=project, moulinette_url=moulinette_url)
+    url = simulation.form_url
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    # Should have exactly one value, not two
+    assert params["alternative"] == ["true"]
+
+
+@pytest.mark.urls("config.urls_haie")
+def test_result_url_adds_alternative_param():
+    """result_url appends alternative=true for new simulations."""
+    DCConfigHaieFactory()
+    project = PetitionProjectFactory()
+    simulation = SimulationFactory(project=project, is_active=False)
+    url = simulation.result_url
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    assert params["alternative"] == ["true"]
+
+
+@pytest.mark.urls("config.urls_haie")
+def test_result_url_active_returns_project_url():
+    """result_url points to the project page (without alternative param) for active simulations."""
+    DCConfigHaieFactory()
+    project = PetitionProjectFactory()
+    # Deactivate the initial simulation created by the factory
+    project.simulations.update(is_active=False)
+    simulation = SimulationFactory(project=project, is_active=True)
+    url = simulation.result_url
+    assert f"/projet/{project.reference}/" in url
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    assert "alternative" not in params

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -664,7 +664,7 @@ class PetitionProjectDetail(DetailView):
         moulinette_params = parse_qs(parsed_moulinette_url.query)
         form_url = reverse("moulinette_form")
 
-        moulinette_params["alternative"] = True
+        moulinette_params["alternative"] = "true"
         edit_url = update_qs(form_url, moulinette_params)
 
         context["share_btn_url"] = share_btn_url


### PR DESCRIPTION
https://trello.com/c/wdwIIkN2/2161-enregistrement-simu-alter-doublon-alternativetrue