### PR TITLE
[hotfix] Corrige un crash sur le critère réserves naturelles

### DIFF
--- a/envergo/moulinette/tests/test_reserves_naturelles.py
+++ b/envergo/moulinette/tests/test_reserves_naturelles.py
@@ -120,3 +120,67 @@ def test_moulinette_evaluation(
             moulinette.reserves_naturelles.reserves_naturelles.result == expected_result
         )
         assert moulinette.catalog["l_resnat"] == expected_lenght_resnat
+
+
+def test_hedges_to_plant_inside_zone_but_removal_outside(bizous_town_center):  # noqa
+    """Criterion activates when any hedge intersects the zone, but only
+    hedges_to_remove are used in get_catalog_data. When a hedge to plant
+    is inside the zone but the hedge to remove is outside, the zone
+    aggregation returns None and must not crash.
+
+    Regression test for ENVERGO-15B.
+    """
+
+    # Hedge to plant inside the bizous zone (activates the criterion)
+    # Hedge to remove well outside the zone (no zone intersection)
+    hedges = HedgeDataFactory(
+        data=[
+            {
+                "id": "P1",
+                "type": "TO_PLANT",
+                "latLngs": [
+                    {"lat": 43.06930871579473, "lng": 0.4421436860179369},
+                    {"lat": 43.069162248282396, "lng": 0.44236765047068033},
+                ],
+                "additionalData": {
+                    "type_haie": "degradee",
+                },
+            },
+            {
+                "id": "D1",
+                "type": "TO_REMOVE",
+                "latLngs": [
+                    {"lat": 43.10, "lng": 0.50},
+                    {"lat": 43.11, "lng": 0.51},
+                ],
+                "additionalData": {
+                    "type_haie": "degradee",
+                    "vieil_arbre": False,
+                    "proximite_mare": False,
+                    "sur_parcelle_pac": False,
+                    "proximite_point_eau": False,
+                    "connexion_boisement": False,
+                },
+            },
+        ]
+    )
+    data = {
+        "motif": "chemin_acces",
+        "reimplantation": "replantation",
+        "localisation_pac": "non",
+        "haies": hedges,
+        "travaux": "destruction",
+        "element": "haie",
+        "department": "44",
+        "plan_gestion": "non",
+    }
+    moulinette_data = {"initial": data, "data": data}
+
+    DCConfigHaieFactory()
+    moulinette = MoulinetteHaie(moulinette_data)
+
+    # The criterion should activate (hedge to plant intersects the zone)
+    # but no hedges_to_remove intersect any zone, so resnat/l_resnat
+    # should be empty defaults.
+    assert moulinette.catalog["resnat"] == {}
+    assert moulinette.catalog["l_resnat"] == 0


### PR DESCRIPTION
When the reserves naturelle criterion is triggered because hedges to plant intersect the activation map BUT no hedges to remove are not intersecting it, there is a 500 error.

Note : Hotfix déjà en prod.