### PR TITLE
Grosse amélioration des perfs sur le calcul de densité

### DIFF
--- a/envergo/demos/tests/test_views.py
+++ b/envergo/demos/tests/test_views.py
@@ -79,10 +79,7 @@ def test_hedges_density_around_point_demo_off_land(client):
     1. Off-land density is the sentinel `1.0` and `truncated_circle` is
        `None`.
     2. The display geometry is STILL populated — clicking outside any land
-       zone must not strip nearby hedges from the map. This is critical
-       once the display fetch is folded into the same SQL query as the
-       length aggregation: the bundle function must use the largest
-       *untruncated* circle for the WHERE clause.
+       zone must not strip nearby hedges from the map.
     """
     LineFactory()
     TerresEmergeesZoneFactory(geometry=herault_multipolygon)

--- a/envergo/demos/tests/test_views.py
+++ b/envergo/demos/tests/test_views.py
@@ -4,7 +4,11 @@ import uuid
 import pytest
 from django.urls import reverse
 
-from envergo.geodata.tests.factories import LineFactory
+from envergo.geodata.tests.factories import (
+    LineFactory,
+    TerresEmergeesZoneFactory,
+    herault_multipolygon,
+)
 from envergo.hedges.tests.factories import HedgeDataFactory
 
 pytestmark = [pytest.mark.django_db, pytest.mark.haie]
@@ -24,8 +28,83 @@ def test_hedges_density_around_point_demo(client):
     assert "mtm_campaign=share-demo-densite-haie" in response.context["share_btn_url"]
     # AND haies inside circle is in context
     haies_polygon = json.loads(response.context["polygons"])[0]
+    # The display geometry must be a MultiLineString. Without an explicit
+    # ST_Multi wrap, ST_Collect over MultiLineString rows can yield a
+    # GeometryCollection, which has `geometries` instead of `coordinates`
+    # and breaks Leaflet rendering — assert the type explicitly.
+    assert haies_polygon["polygon"]["type"] == "MultiLineString"
     assert len(haies_polygon["polygon"]["coordinates"]) > 0
     assert haies_polygon["legend"] == "Haies"
+
+
+def test_hedges_density_around_point_demo_on_land(client):
+    """Density demo with a point inside a `terres_emergees` zone.
+
+    The default `LineFactory` setup creates no `terres_emergees` zones, so
+    the on-land check returns False and the view silently exercises the
+    off-land sentinel branch (density=1.0). This test seeds a real
+    terres_emergees zone covering France so the on-land branch is actually
+    hit, and asserts the resulting context contains real (non-sentinel)
+    density values and a non-null truncated 5 km circle.
+    """
+    LineFactory()
+    TerresEmergeesZoneFactory()
+    url = reverse("demo_density")
+    # WHEN I get demo page with lat/lng on land
+    params = "lng=3.58123&lat=49.32252"
+    full_url = f"{url}?{params}"
+    response = client.get(full_url)
+    # THEN the page is displayed with no error
+    assert response.status_code == 200
+    # AND the on-land branch is exercised: truncated 5 km circle is computed,
+    # area is positive, and density is the real ratio (not the sentinel 1.0)
+    assert response.context["truncated_circle_5000"] is not None
+    assert response.context["area_5000_ha"] > 0
+    assert response.context["density_5000"] != 1.0
+    # AND the display geometry is a stable MultiLineString
+    haies_polygon = json.loads(response.context["polygons"])[0]
+    assert haies_polygon["polygon"]["type"] == "MultiLineString"
+    assert len(haies_polygon["polygon"]["coordinates"]) > 0
+
+
+def test_hedges_density_around_point_demo_off_land(client):
+    """Density demo with a point outside any `terres_emergees` zone.
+
+    Sets up a real terres_emergees zone (Hérault, in southern France) plus
+    haies in northern France, then queries with a point in the north — the
+    point is well outside the only land zone, so the on-land check returns
+    False and the off-land sentinel branch runs. This locks in two
+    contracts:
+
+    1. Off-land density is the sentinel `1.0` and `truncated_circle` is
+       `None`.
+    2. The display geometry is STILL populated — clicking outside any land
+       zone must not strip nearby hedges from the map. This is critical
+       once the display fetch is folded into the same SQL query as the
+       length aggregation: the bundle function must use the largest
+       *untruncated* circle for the WHERE clause.
+    """
+    LineFactory()
+    TerresEmergeesZoneFactory(geometry=herault_multipolygon)
+    url = reverse("demo_density")
+    # WHEN I get the demo page with a point in northern France (lines area),
+    # which is far from the only terres_emergees zone (Hérault, in the south)
+    params = "lng=3.58123&lat=49.32252"
+    full_url = f"{url}?{params}"
+    response = client.get(full_url)
+    # THEN the page is displayed with no error
+    assert response.status_code == 200
+    # AND the off-land sentinel is in effect for both exposed radii
+    assert response.context["truncated_circle_400"] is None
+    assert response.context["truncated_circle_5000"] is None
+    assert response.context["density_400"] == 1.0
+    assert response.context["density_5000"] == 1.0
+    assert response.context["area_400_ha"] == 0.0
+    assert response.context["area_5000_ha"] == 0.0
+    # AND the display geometry is still populated despite the off-land branch
+    haies_polygon = json.loads(response.context["polygons"])[0]
+    assert haies_polygon["polygon"]["type"] == "MultiLineString"
+    assert len(haies_polygon["polygon"]["coordinates"]) > 0
 
 
 def test_hedges_density_in_buffer_demo(client):

--- a/envergo/demos/views.py
+++ b/envergo/demos/views.py
@@ -10,8 +10,8 @@ from scipy.interpolate import griddata
 from envergo.geodata.forms import LatLngForm
 from envergo.geodata.models import MAP_TYPES, Line
 from envergo.geodata.utils import (
+    compute_hedge_densities_around_point,
     compute_hedge_density_around_lines,
-    compute_hedge_density_around_point,
     get_catchment_area_pixel_values,
     to_geojson,
 )
@@ -89,37 +89,25 @@ class HedgeDensity(LatLngDemoMixin, FormView):
     def get_result_data(self, lng, lat):
         """Return context with data to display map"""
         lng_lat = Point(float(lng), float(lat), srid=EPSG_WGS84)
-        density_400 = compute_hedge_density_around_point(lng_lat, 400)
-        density_5000 = compute_hedge_density_around_point(lng_lat, 5000)
-
-        circle = (
-            density_5000["artifacts"]["truncated_circle"]
-            or density_5000["artifacts"]["circle"]
+        # Get the density data for different circles around the point.
+        # For display purpose, we fetch hedges with a simplified geometry.
+        # Tolerance ~5 m at French latitudes is well below pixel resolution
+        # at the demo's 5 km zoom.
+        bundle = compute_hedge_densities_around_point(
+            lng_lat,
+            radii=[400, 5000],
+            display_simplify_tolerance=0.00005,
         )
+        density_400 = bundle[400]
+        density_5000 = bundle[5000]
 
-        hedges_5000 = Line.objects.filter(
-            map__map_type=MAP_TYPES.haies,
-            geometry__intersects=circle,
-        )
-
-        hedges_5000_mls = []
-        for hedge in hedges_5000:
-            geom = hedge.geometry
-            if geom:
-                hedges_5000_mls.extend(geom)
-
-        polygons = []
-        polygons.append(
+        polygons = [
             {
-                "polygon": to_geojson(
-                    MultiLineString(hedges_5000_mls, srid=EPSG_WGS84)
-                ),
+                "polygon": bundle["display_geojson"],
                 "color": "#f0f921",
                 "legend": "Haies",
                 "opacity": 1.0,
-            }
-        )
-        polygons.append(
+            },
             {
                 "polygon": to_geojson(
                     density_400["artifacts"]["truncated_circle"]
@@ -128,9 +116,7 @@ class HedgeDensity(LatLngDemoMixin, FormView):
                 "color": "#cc4778",
                 "legend": "400m",
                 "opacity": 1.0,
-            }
-        )
-        polygons.append(
+            },
             {
                 "polygon": to_geojson(
                     density_5000["artifacts"]["truncated_circle"]
@@ -139,8 +125,8 @@ class HedgeDensity(LatLngDemoMixin, FormView):
                 "color": "#7e03a8",
                 "legend": "5km",
                 "opacity": 1.0,
-            }
-        )
+            },
+        ]
         context = {
             "result_available": True,
             "length_400": density_400["artifacts"]["length"],

--- a/envergo/demos/views.py
+++ b/envergo/demos/views.py
@@ -2,13 +2,12 @@ import json
 from math import sqrt
 
 import numpy as np
-from django.contrib.gis.geos import MultiLineString, Point
+from django.contrib.gis.geos import Point
 from django.db import connection
 from django.views.generic import FormView
 from scipy.interpolate import griddata
 
 from envergo.geodata.forms import LatLngForm
-from envergo.geodata.models import MAP_TYPES, Line
 from envergo.geodata.utils import (
     compute_hedge_densities_around_point,
     compute_hedge_density_around_lines,
@@ -183,12 +182,10 @@ class HedgeDensityBuffer(LatLngDemoMixin, FormView):
     def get_result_data(self, hedges):
         """Return context with data to display map"""
 
-        # Create multilinestring from hedges to remove
         hedges_to_remove_mls_merged = hedges.get_multilinestring_to_remove()
 
-        # Generate buffer 400m around hedges and get data
         density_400 = compute_hedge_density_around_lines(
-            hedges_to_remove_mls_merged, 400
+            hedges_to_remove_mls_merged, 400, display_simplify_tolerance=0.00005
         )
 
         buffered_400_polygon = (
@@ -196,44 +193,27 @@ class HedgeDensityBuffer(LatLngDemoMixin, FormView):
             or density_400["artifacts"]["buffer_zone"]
         )
 
-        # Get hedges intersects buffer and hedges map
-        hedges_400 = Line.objects.filter(
-            map__map_type=MAP_TYPES.haies,
-            geometry__intersects=buffered_400_polygon,
-        )
-
-        hedges_400_mls = []
-        for hedge in hedges_400:
-            geom = hedge.geometry
-            if geom:
-                hedges_400_mls.extend(geom)
-
-        polygons = []
-        polygons.append(
+        polygons = [
             {
-                "polygon": to_geojson(MultiLineString(hedges_400_mls, srid=EPSG_WGS84)),
+                "polygon": density_400["artifacts"]["display_geojson"],
                 "color": "#f0f921",
                 "legend": "Haies existantes",
                 "opacity": 1.0,
-            }
-        )
-        polygons.append(
+            },
             {
                 "polygon": to_geojson(hedges_to_remove_mls_merged),
                 "color": "red",
                 "className": "hedge to-remove",
                 "legend": "Haies à détruire",
                 "opacity": 1.0,
-            }
-        )
-        polygons.append(
+            },
             {
                 "polygon": to_geojson(buffered_400_polygon),
                 "color": "#457EAC",
                 "legend": "Zone tampon de 400m",
                 "opacity": 1.0,
-            }
-        )
+            },
+        ]
         context = {
             "result_available": True,
             "hedges_to_remove_mls": hedges_to_remove_mls_merged,

--- a/envergo/geodata/models.py
+++ b/envergo/geodata/models.py
@@ -69,6 +69,9 @@ class Map(models.Model):
             choices=DEPARTMENT_CHOICES,
         ),
     )
+    # `geography=True`: query with __covers/__coveredby/__intersects, NOT
+    # __contains/__within/__overlaps (silent cast to geometry bypasses the
+    # GIST index → seq scans).
     geometry = gis_models.GeometryField(
         _("Simplified geometry"),
         help_text=_(
@@ -115,6 +118,9 @@ class Zone(gis_models.Model):
     """Stores an annotated geographic polygon(s)."""
 
     map = models.ForeignKey(Map, on_delete=models.CASCADE, related_name="zones")
+    # `geography=True`: query with __covers/__coveredby/__intersects, NOT
+    # __contains/__within/__overlaps (silent cast to geometry bypasses the
+    # GIST index → seq scans).
     geometry = gis_models.MultiPolygonField(
         geography=True,
         help_text=_(
@@ -152,6 +158,9 @@ class Line(gis_models.Model):
     """Stores an annotated geographic Line(s)."""
 
     map = models.ForeignKey(Map, on_delete=models.CASCADE, related_name="lines")
+    # `geography=True`: query with __covers/__coveredby/__intersects, NOT
+    # __contains/__within/__overlaps (silent cast to geometry bypasses the
+    # GIST index → seq scans).
     geometry = gis_models.MultiLineStringField(
         geography=True,
         help_text=_(

--- a/envergo/geodata/tests/factories.py
+++ b/envergo/geodata/tests/factories.py
@@ -184,6 +184,43 @@ class ZoneFactory(DjangoModelFactory):
     species_taxrefs = []
 
 
+class TerresEmergeesMapFactory(MapFactory):
+    """A `terres_emergees` Map with no auto-generated zones.
+
+    The default `MapFactory` auto-creates one `ZoneFactory` zone via
+    `RelatedFactoryList`, with the default `france_multipolygon` geometry.
+    For tests of the off-land branch we need full control over which
+    geometries cover the test point, so this variant overrides the
+    related-factory list to size 0.
+    """
+
+    map_type = MAP_TYPES.terres_emergees
+    zones = factory.RelatedFactoryList(
+        "envergo.geodata.tests.factories.ZoneFactory",
+        factory_related_name="map",
+        size=0,
+    )
+
+
+class TerresEmergeesZoneFactory(DjangoModelFactory):
+    """A `terres_emergees` zone covering France's mainland.
+
+    Tests that exercise the on-land branch of the hedge density computation
+    need at least one `terres_emergees` zone in the DB — without one, the
+    on-land check returns False and the code silently falls through to the
+    off-land sentinel (`density=1.0`). The default `MapFactory` /
+    `ZoneFactory` pair does not create such a zone, so use this factory
+    instead when on-land behavior matters to the test.
+    """
+
+    class Meta:
+        model = Zone
+
+    map = factory.SubFactory(TerresEmergeesMapFactory)
+    geometry = france_multipolygon
+    species_taxrefs = []
+
+
 class DepartmentFactory(DjangoModelFactory):
     class Meta:
         model = Department

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -1,0 +1,130 @@
+"""Semantic-equivalence regression tests for the hedge density helpers.
+
+These tests pin the numerical output of `compute_hedge_density_around_point`
+and `compute_hedge_density_around_lines` against a fixed fixture so that
+upcoming refactors of the underlying SQL (multi-radius bundle query, faster
+trim_land, etc.) can be validated as semantics-preserving.
+
+Expected values were captured from the legacy implementation against the
+fixture defined below. They are deliberately written as literal floats with
+a tight tolerance — any drift bigger than floating-point noise is a real
+regression and the implementation should be fixed, not the test.
+"""
+
+import pytest
+from django.contrib.gis.geos import Point
+
+from envergo.geodata.tests.factories import (
+    LineFactory,
+    TerresEmergeesZoneFactory,
+    map_lines,
+)
+from envergo.geodata.utils import (
+    compute_hedge_density_around_lines,
+    compute_hedge_density_around_point,
+)
+
+pytestmark = [pytest.mark.django_db, pytest.mark.haie]
+
+
+# Fixed test point inside both the default `LineFactory` line area
+# (around lng~3.55, lat~49.33 — Limé, in northern France) and the
+# `france_multipolygon` covering mainland France.
+TEST_LNG = 3.58123
+TEST_LAT = 49.32252
+
+
+@pytest.fixture
+def hedge_density_fixture():
+    """Seed the test DB with one `terres_emergees` zone covering France
+    and one `haies` map with the default `LineFactory` MultiLineString.
+    """
+    LineFactory()
+    TerresEmergeesZoneFactory()
+    return Point(TEST_LNG, TEST_LAT, srid=4326)
+
+
+# Expected values captured from the legacy implementation against the
+# fixture above. Pinned to lock in semantic equivalence across refactors.
+EXPECTED_AROUND_POINT = {
+    200: {
+        "density": 0.0,
+        "length": 0.0,
+        "area_ha": 12.485780609039368,
+    },
+    400: {
+        "density": 20.041485812958307,
+        "length": 1000.9343797592853,
+        "area_ha": 49.943122436167236,
+    },
+    5000: {
+        "density": 1.2553400466934896,
+        "length": 9796.187757968033,
+        "area_ha": 7803.612880645973,
+    },
+}
+
+
+@pytest.mark.parametrize("radius", [200, 400, 5000])
+def test_compute_hedge_density_around_point_semantic_equivalence(
+    hedge_density_fixture, radius
+):
+    """Density/length/area_ha at each radius must match the pinned values.
+
+    This is the regression net for any refactor that changes how the
+    density math is computed (e.g. switching to a multi-radius bundle
+    query, simplifying or reorganising trim_land, changing the cast/length
+    pattern). If any of these literals drift, the implementation has
+    regressed semantics and must be fixed before landing.
+    """
+    expected = EXPECTED_AROUND_POINT[radius]
+    result = compute_hedge_density_around_point(hedge_density_fixture, radius)
+    artifacts = result["artifacts"]
+
+    assert result["density"] == pytest.approx(expected["density"], rel=1e-9, abs=1e-9)
+    assert artifacts["length"] == pytest.approx(expected["length"], rel=1e-9, abs=1e-9)
+    assert artifacts["area_ha"] == pytest.approx(expected["area_ha"], rel=1e-9, abs=1e-9)
+    # truncated_circle is non-None for an on-land point with land coverage
+    assert artifacts["truncated_circle"] is not None
+
+
+# Expected values for the lines variant: a 400 m buffer around the
+# `map_lines` MultiLineString, with the same `terres_emergees` zone and
+# the same `LineFactory`-seeded haies map. The buffer encompasses the
+# whole test line, so `length` matches the 5 km point variant above
+# (both fully contain the test line).
+EXPECTED_AROUND_LINES_400 = {
+    "density": 12.015016118818387,
+    "length": 9796.187757968033,
+    "area_ha": 815.3287237480157,
+}
+
+
+def test_compute_hedge_density_around_lines_semantic_equivalence(
+    hedge_density_fixture,
+):
+    """Density/length/area_ha for the 400 m buffer must match pinned values.
+
+    Companion regression net for `compute_hedge_density_around_lines`.
+    The fixture is the same as for the point variant; the input
+    MultiLineString is the `map_lines` constant from the factories
+    module — this is the same geometry the haies map was seeded with,
+    so the function buffers it by 400 m and finds itself.
+    """
+    # Clone so we don't mutate the module-level constant when SRID is set.
+    input_mls = map_lines.clone()
+    input_mls.srid = 4326
+
+    result = compute_hedge_density_around_lines(input_mls, 400)
+    artifacts = result["artifacts"]
+
+    assert result["density"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["density"], rel=1e-9, abs=1e-9
+    )
+    assert artifacts["length"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["length"], rel=1e-9, abs=1e-9
+    )
+    assert artifacts["area_ha"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["area_ha"], rel=1e-9, abs=1e-9
+    )
+    assert artifacts["truncated_buffer_zone"] is not None

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -1,14 +1,7 @@
-"""Semantic-equivalence regression tests for the hedge density helpers.
+"""Regression tests for the hedge density computation helpers.
 
-These tests pin the numerical output of `compute_hedge_density_around_point`
-and `compute_hedge_density_around_lines` against a fixed fixture so that
-upcoming refactors of the underlying SQL (multi-radius bundle query, faster
-trim_land, etc.) can be validated as semantics-preserving.
-
-Expected values were captured from the legacy implementation against the
-fixture defined below. They are deliberately written as literal floats with
-a tight tolerance — any drift bigger than floating-point noise is a real
-regression and the implementation should be fixed, not the test.
+Expected values are pinned as literal floats with tight tolerance.
+Any drift beyond floating-point noise is a real regression.
 """
 
 import pytest
@@ -20,111 +13,105 @@ from envergo.geodata.tests.factories import (
     map_lines,
 )
 from envergo.geodata.utils import (
+    compute_hedge_densities_around_point,
     compute_hedge_density_around_lines,
     compute_hedge_density_around_point,
 )
 
 pytestmark = [pytest.mark.django_db, pytest.mark.haie]
 
-
-# Fixed test point inside both the default `LineFactory` line area
-# (around lng~3.55, lat~49.33 — Limé, in northern France) and the
-# `france_multipolygon` covering mainland France.
 TEST_LNG = 3.58123
 TEST_LAT = 49.32252
 
 
 @pytest.fixture
 def hedge_density_fixture():
-    """Seed the test DB with one `terres_emergees` zone covering France
-    and one `haies` map with the default `LineFactory` MultiLineString.
-    """
+    """One `terres_emergees` zone + one `haies` map with the default line."""
     LineFactory()
     TerresEmergeesZoneFactory()
     return Point(TEST_LNG, TEST_LAT, srid=4326)
 
 
-# Expected values captured from the legacy implementation against the
-# fixture above. Pinned to lock in semantic equivalence across refactors.
 EXPECTED_AROUND_POINT = {
-    200: {
-        "density": 0.0,
-        "length": 0.0,
-        "area_ha": 12.485780609039368,
-    },
-    400: {
-        "density": 20.041485812958307,
-        "length": 1000.9343797592853,
-        "area_ha": 49.943122436167236,
-    },
-    5000: {
-        "density": 1.2553400466934896,
-        "length": 9796.187757968033,
-        "area_ha": 7803.612880645973,
-    },
+    200: {"density": 0.0, "length": 0.0, "area_ha": 12.485780609039368},
+    400: {"density": 20.041485812958307, "length": 1000.9343797592853, "area_ha": 49.943122436167236},
+    5000: {"density": 1.2553400466934896, "length": 9796.187757968033, "area_ha": 7803.612880645973},
 }
 
-
-@pytest.mark.parametrize("radius", [200, 400, 5000])
-def test_compute_hedge_density_around_point_semantic_equivalence(
-    hedge_density_fixture, radius
-):
-    """Density/length/area_ha at each radius must match the pinned values.
-
-    This is the regression net for any refactor that changes how the
-    density math is computed (e.g. switching to a multi-radius bundle
-    query, simplifying or reorganising trim_land, changing the cast/length
-    pattern). If any of these literals drift, the implementation has
-    regressed semantics and must be fixed before landing.
-    """
-    expected = EXPECTED_AROUND_POINT[radius]
-    result = compute_hedge_density_around_point(hedge_density_fixture, radius)
-    artifacts = result["artifacts"]
-
-    assert result["density"] == pytest.approx(expected["density"], rel=1e-9, abs=1e-9)
-    assert artifacts["length"] == pytest.approx(expected["length"], rel=1e-9, abs=1e-9)
-    assert artifacts["area_ha"] == pytest.approx(expected["area_ha"], rel=1e-9, abs=1e-9)
-    # truncated_circle is non-None for an on-land point with land coverage
-    assert artifacts["truncated_circle"] is not None
-
-
-# Expected values for the lines variant: a 400 m buffer around the
-# `map_lines` MultiLineString, with the same `terres_emergees` zone and
-# the same `LineFactory`-seeded haies map. The buffer encompasses the
-# whole test line, so `length` matches the 5 km point variant above
-# (both fully contain the test line).
 EXPECTED_AROUND_LINES_400 = {
     "density": 12.015016118818387,
     "length": 9796.187757968033,
     "area_ha": 815.3287237480157,
 }
 
+APPROX = {"rel": 1e-9, "abs": 1e-9}
 
-def test_compute_hedge_density_around_lines_semantic_equivalence(
-    hedge_density_fixture,
-):
-    """Density/length/area_ha for the 400 m buffer must match pinned values.
 
-    Companion regression net for `compute_hedge_density_around_lines`.
-    The fixture is the same as for the point variant; the input
-    MultiLineString is the `map_lines` constant from the factories
-    module — this is the same geometry the haies map was seeded with,
-    so the function buffers it by 400 m and finds itself.
-    """
-    # Clone so we don't mutate the module-level constant when SRID is set.
+@pytest.mark.parametrize("radius", [200, 400, 5000])
+def test_density_around_point_pinned_values(hedge_density_fixture, radius):
+    """Per-radius density/length/area_ha must match pinned values."""
+    expected = EXPECTED_AROUND_POINT[radius]
+    result = compute_hedge_density_around_point(hedge_density_fixture, radius)
+
+    assert result["density"] == pytest.approx(expected["density"], **APPROX)
+    assert result["artifacts"]["length"] == pytest.approx(expected["length"], **APPROX)
+    assert result["artifacts"]["area_ha"] == pytest.approx(expected["area_ha"], **APPROX)
+    assert result["artifacts"]["truncated_circle"] is not None
+
+
+def test_bundle_matches_legacy(hedge_density_fixture):
+    """Bundle function produces the same values as per-radius calls."""
+    radii = [200, 400, 5000]
+    bundle = compute_hedge_densities_around_point(hedge_density_fixture, radii)
+
+    for r in radii:
+        legacy = compute_hedge_density_around_point(hedge_density_fixture, r)
+        assert bundle[r]["density"] == pytest.approx(legacy["density"], **APPROX)
+        assert bundle[r]["artifacts"]["length"] == pytest.approx(legacy["artifacts"]["length"], **APPROX)
+        assert bundle[r]["artifacts"]["area_ha"] == pytest.approx(legacy["artifacts"]["area_ha"], **APPROX)
+
+    assert "display_geojson" not in bundle
+
+
+def test_bundle_display_geojson(hedge_density_fixture):
+    """Display geometry is a MultiLineString when tolerance is set."""
+    bundle = compute_hedge_densities_around_point(
+        hedge_density_fixture, radii=[200, 400, 5000], display_simplify_tolerance=0.00005,
+    )
+    display = bundle["display_geojson"]
+    assert display is not None
+    assert display["type"] == "MultiLineString"
+    assert len(display["coordinates"]) > 0
+
+
+def test_bundle_off_land():
+    """Off-land: sentinel values, but display geometry still populated."""
+    LineFactory()
+    p = Point(TEST_LNG, TEST_LAT, srid=4326)
+    bundle = compute_hedge_densities_around_point(
+        p, radii=[200, 400, 5000], display_simplify_tolerance=0.00005,
+    )
+
+    for r in [200, 400, 5000]:
+        assert bundle[r]["density"] == 1.0
+        assert bundle[r]["artifacts"]["length"] == 0
+        assert bundle[r]["artifacts"]["area_ha"] == 0.0
+        assert bundle[r]["artifacts"]["truncated_circle"] is None
+        assert bundle[r]["artifacts"]["circle"] is not None
+
+    display = bundle["display_geojson"]
+    assert display is not None
+    assert display["type"] == "MultiLineString"
+
+
+def test_density_around_lines_pinned_values(hedge_density_fixture):
+    """Lines variant: density/length/area_ha must match pinned values."""
     input_mls = map_lines.clone()
     input_mls.srid = 4326
 
     result = compute_hedge_density_around_lines(input_mls, 400)
-    artifacts = result["artifacts"]
 
-    assert result["density"] == pytest.approx(
-        EXPECTED_AROUND_LINES_400["density"], rel=1e-9, abs=1e-9
-    )
-    assert artifacts["length"] == pytest.approx(
-        EXPECTED_AROUND_LINES_400["length"], rel=1e-9, abs=1e-9
-    )
-    assert artifacts["area_ha"] == pytest.approx(
-        EXPECTED_AROUND_LINES_400["area_ha"], rel=1e-9, abs=1e-9
-    )
-    assert artifacts["truncated_buffer_zone"] is not None
+    assert result["density"] == pytest.approx(EXPECTED_AROUND_LINES_400["density"], **APPROX)
+    assert result["artifacts"]["length"] == pytest.approx(EXPECTED_AROUND_LINES_400["length"], **APPROX)
+    assert result["artifacts"]["area_ha"] == pytest.approx(EXPECTED_AROUND_LINES_400["area_ha"], **APPROX)
+    assert result["artifacts"]["truncated_buffer_zone"] is not None

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -46,17 +46,24 @@ EXPECTED_AROUND_LINES_400 = {
 APPROX = {"rel": 1e-9, "abs": 1e-9}
 
 
-@pytest.mark.parametrize("radius", [200, 400, 5000])
-def test_density_around_point_pinned_values(hedge_density_fixture, radius):
-    """Per-radius density/length/area_ha must match pinned values."""
-    expected = EXPECTED_AROUND_POINT[radius]
-    bundle = compute_hedge_densities_around_point(hedge_density_fixture, radii=[radius])
-    result = bundle[radius]
+def test_density_around_point_pinned_values(hedge_density_fixture):
+    """Per-radius density/length/area_ha must match pinned values.
 
-    assert result["density"] == pytest.approx(expected["density"], **APPROX)
-    assert result["artifacts"]["length"] == pytest.approx(expected["length"], **APPROX)
-    assert result["artifacts"]["area_ha"] == pytest.approx(expected["area_ha"], **APPROX)
-    assert result["artifacts"]["truncated_circle"] is not None
+    All radii are bundled in a single call — this is critical because
+    the query uses the largest circle for row filtering and fast-path
+    containment. A per-radius parameterized test would hide bugs where
+    smaller radii get inflated by the larger circle's containment check.
+    """
+    bundle = compute_hedge_densities_around_point(
+        hedge_density_fixture, radii=[200, 400, 5000]
+    )
+
+    for radius, expected in EXPECTED_AROUND_POINT.items():
+        result = bundle[radius]
+        assert result["density"] == pytest.approx(expected["density"], **APPROX)
+        assert result["artifacts"]["length"] == pytest.approx(expected["length"], **APPROX)
+        assert result["artifacts"]["area_ha"] == pytest.approx(expected["area_ha"], **APPROX)
+        assert result["artifacts"]["truncated_circle"] is not None
 
 
 def test_bundle_display_geojson(hedge_density_fixture):

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -33,8 +33,16 @@ def hedge_density_fixture():
 
 EXPECTED_AROUND_POINT = {
     200: {"density": 0.0, "length": 0.0, "area_ha": 12.485780609039368},
-    400: {"density": 20.041485812958307, "length": 1000.9343797592853, "area_ha": 49.943122436167236},
-    5000: {"density": 1.2553400466934896, "length": 9796.187757968033, "area_ha": 7803.612880645973},
+    400: {
+        "density": 20.041485812958307,
+        "length": 1000.9343797592853,
+        "area_ha": 49.943122436167236,
+    },
+    5000: {
+        "density": 1.2553400466934896,
+        "length": 9796.187757968033,
+        "area_ha": 7803.612880645973,
+    },
 }
 
 EXPECTED_AROUND_LINES_400 = {
@@ -61,15 +69,21 @@ def test_density_around_point_pinned_values(hedge_density_fixture):
     for radius, expected in EXPECTED_AROUND_POINT.items():
         result = bundle[radius]
         assert result["density"] == pytest.approx(expected["density"], **APPROX)
-        assert result["artifacts"]["length"] == pytest.approx(expected["length"], **APPROX)
-        assert result["artifacts"]["area_ha"] == pytest.approx(expected["area_ha"], **APPROX)
+        assert result["artifacts"]["length"] == pytest.approx(
+            expected["length"], **APPROX
+        )
+        assert result["artifacts"]["area_ha"] == pytest.approx(
+            expected["area_ha"], **APPROX
+        )
         assert result["artifacts"]["truncated_circle"] is not None
 
 
 def test_bundle_display_geojson(hedge_density_fixture):
     """Display geometry is a MultiLineString when tolerance is set."""
     bundle = compute_hedge_densities_around_point(
-        hedge_density_fixture, radii=[200, 400, 5000], display_simplify_tolerance=0.00005,
+        hedge_density_fixture,
+        radii=[200, 400, 5000],
+        display_simplify_tolerance=0.00005,
     )
     display = bundle["display_geojson"]
     assert display is not None
@@ -82,7 +96,9 @@ def test_bundle_off_land():
     LineFactory()
     p = Point(TEST_LNG, TEST_LAT, srid=4326)
     bundle = compute_hedge_densities_around_point(
-        p, radii=[200, 400, 5000], display_simplify_tolerance=0.00005,
+        p,
+        radii=[200, 400, 5000],
+        display_simplify_tolerance=0.00005,
     )
 
     for r in [200, 400, 5000]:
@@ -104,7 +120,13 @@ def test_density_around_lines_pinned_values(hedge_density_fixture):
 
     result = compute_hedge_density_around_lines(input_mls, 400)
 
-    assert result["density"] == pytest.approx(EXPECTED_AROUND_LINES_400["density"], **APPROX)
-    assert result["artifacts"]["length"] == pytest.approx(EXPECTED_AROUND_LINES_400["length"], **APPROX)
-    assert result["artifacts"]["area_ha"] == pytest.approx(EXPECTED_AROUND_LINES_400["area_ha"], **APPROX)
+    assert result["density"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["density"], **APPROX
+    )
+    assert result["artifacts"]["length"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["length"], **APPROX
+    )
+    assert result["artifacts"]["area_ha"] == pytest.approx(
+        EXPECTED_AROUND_LINES_400["area_ha"], **APPROX
+    )
     assert result["artifacts"]["truncated_buffer_zone"] is not None

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -15,7 +15,6 @@ from envergo.geodata.tests.factories import (
 from envergo.geodata.utils import (
     compute_hedge_densities_around_point,
     compute_hedge_density_around_lines,
-    compute_hedge_density_around_point,
 )
 
 pytestmark = [pytest.mark.django_db, pytest.mark.haie]
@@ -51,26 +50,13 @@ APPROX = {"rel": 1e-9, "abs": 1e-9}
 def test_density_around_point_pinned_values(hedge_density_fixture, radius):
     """Per-radius density/length/area_ha must match pinned values."""
     expected = EXPECTED_AROUND_POINT[radius]
-    result = compute_hedge_density_around_point(hedge_density_fixture, radius)
+    bundle = compute_hedge_densities_around_point(hedge_density_fixture, radii=[radius])
+    result = bundle[radius]
 
     assert result["density"] == pytest.approx(expected["density"], **APPROX)
     assert result["artifacts"]["length"] == pytest.approx(expected["length"], **APPROX)
     assert result["artifacts"]["area_ha"] == pytest.approx(expected["area_ha"], **APPROX)
     assert result["artifacts"]["truncated_circle"] is not None
-
-
-def test_bundle_matches_legacy(hedge_density_fixture):
-    """Bundle function produces the same values as per-radius calls."""
-    radii = [200, 400, 5000]
-    bundle = compute_hedge_densities_around_point(hedge_density_fixture, radii)
-
-    for r in radii:
-        legacy = compute_hedge_density_around_point(hedge_density_fixture, r)
-        assert bundle[r]["density"] == pytest.approx(legacy["density"], **APPROX)
-        assert bundle[r]["artifacts"]["length"] == pytest.approx(legacy["artifacts"]["length"], **APPROX)
-        assert bundle[r]["artifacts"]["area_ha"] == pytest.approx(legacy["artifacts"]["area_ha"], **APPROX)
-
-    assert "display_geojson" not in bundle
 
 
 def test_bundle_display_geojson(hedge_density_fixture):

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -658,42 +658,6 @@ def compute_hedge_density_data(buffer_zone, epsg_utm):
     return length, area_ha, density
 
 
-def compute_hedge_density_around_point(point_geos, radius):
-    """Compute the density of hedges around a point."""
-
-    # use specific projection to be able to use meters for buffering
-    epsg_utm = get_best_epsg_for_location(point_geos.x, point_geos.y)
-    centroid_meter = point_geos.transform(epsg_utm, clone=True)
-    circle = centroid_meter.buffer(radius)
-    circle = circle.transform(EPSG_WGS84, clone=True)  # switch back to WGS84
-
-    # Initially, we were first running a pre-check to see if the project was
-    # actually in land. Otherwise, would would return a sentinel density of 1.0
-    # That pre-check was measured to add query time instead of saving it,
-    # so it was removed.
-    truncated_circle = trim_land(circle)
-
-    if truncated_circle:
-        length, area_ha, density = compute_hedge_density_data(
-            truncated_circle, epsg_utm
-        )
-    else:
-        # there is no land in the circle (e.g. sea or foreign country)
-        length = Distance(0)
-        area_ha = 0.0
-        density = 1.0
-
-    return {
-        "density": density,
-        "artifacts": {
-            "circle": circle,
-            "truncated_circle": truncated_circle,
-            "length": length.standard,
-            "area_ha": area_ha,
-        },
-    }
-
-
 WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'
 EMPTY_POLYGON_EWKT = "SRID=4326;POLYGON EMPTY"
 

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -580,30 +580,48 @@ def get_best_epsg_for_location(longitude, latitude) -> int:
 def trim_land(geom):
     """Keep only the part of the geometry that is in France and not in the sea.
 
-    Django ORM does not support cumulative intersection (reduce(ST_Intersection)) across multiple geometries
-    so it uses raw SQL
+    Django ORM does not support cumulative intersection (reduce(ST_Intersection))
+    across multiple geometries so this uses raw SQL.
+
+    How the query works:
+
+     - Select all the "Terres emergées" polygons that intersect the geometry
+     - Clip the polygons to the geometry bounding box (cheap operation)
+     - Merge the remaining polygons
+     - Intersects the merged polygon with the input geometry
+
+    The clipping step is an optimization: it reduces the size of the polygons
+    before merging them (which is a costly operation).
+
     Returns:
-        - the intersection of the circle with the map zones
-        - None if there is no intersection
+        - the intersection of the input geometry with the union of land zones
+        - None if there is no intersection (input is entirely off-land)
     """
 
     with connection.cursor() as cursor:
         cursor.execute(
             """
             WITH input_poly AS (
-              SELECT ST_GeomFromEWKT(%s) AS geom
+              SELECT
+                ST_GeomFromEWKT(%s) AS geom,
+                ST_Envelope(ST_GeomFromEWKT(%s)) AS bbox
             ),
-            unioned_geom AS (
-              SELECT ST_Union(z.geometry::geometry) AS merged_geom
+            clipped AS (
+              SELECT ST_MakeValid(ST_ClipByBox2D(z.geometry::geometry, i.bbox)) AS g
               FROM geodata_zone z
               JOIN geodata_map m ON z.map_id = m.id
               JOIN input_poly i ON ST_Intersects(z.geometry, i.geom)
               WHERE m.map_type = %s
+            ),
+            unioned AS (
+              SELECT ST_Union(g) AS merged
+              FROM clipped
+              WHERE NOT ST_IsEmpty(g)
             )
-            SELECT ST_AsText(ST_Intersection(u.merged_geom, i.geom))
-            FROM unioned_geom u, input_poly i;
+            SELECT ST_AsText(ST_Intersection(u.merged, i.geom))
+            FROM unioned u, input_poly i;
         """,
-            [geom.ewkt, MAP_TYPES.terres_emergees],
+            [geom.ewkt, geom.ewkt, MAP_TYPES.terres_emergees],
         )
         wkt = cursor.fetchone()[0]
         if wkt:

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -694,6 +694,189 @@ def compute_hedge_density_around_point(point_geos, radius):
     }
 
 
+WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'
+EMPTY_POLYGON_EWKT = "SRID=4326;POLYGON EMPTY"
+
+
+def buffer_to_ewkt(geom):
+    """Return EWKT for a buffer geometry, or POLYGON EMPTY if None/empty."""
+
+    if geom is not None and not geom.empty:
+        return geom.ewkt
+    return EMPTY_POLYGON_EWKT
+
+
+def query_hedge_lengths_for_buffers(truncated_buffers, bbox_filter_buffer):
+    """Aggregate clipped hedge length for several buffers in a single SQL query.
+
+    Returns {radius: length_in_meters}.
+    """
+
+    radii = list(truncated_buffers.keys())
+    params = {"bbox": bbox_filter_buffer.ewkt, "map_type": MAP_TYPES.haies}
+
+    # One SUM(clipped length) column per radius
+    columns = []
+    for i, r in enumerate(radii):
+        param = f"b_{i}"
+        params[param] = buffer_to_ewkt(truncated_buffers[r])
+        columns.append(
+            f"COALESCE(SUM(ST_LengthSpheroid("
+            f"ST_Intersection(l.geometry, ST_GeomFromEWKT(%({param})s))"
+            f"::geometry(GEOMETRY,4326),"
+            f"'{WGS84_SPHEROID}'"
+            f")), 0) AS l_{i}"
+        )
+
+    sql = f"""
+        SELECT {', '.join(columns)}
+        FROM geodata_line l
+        JOIN geodata_map m ON l.map_id = m.id
+        WHERE m.map_type = %(map_type)s
+          AND ST_Intersects(l.geometry, ST_GeomFromEWKT(%(bbox)s));
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+
+    return {r: row[i] for i, r in enumerate(radii)}
+
+
+def query_hedges_display_geojson(buffer_geos, simplify_tolerance):
+    """Return simplified hedge geometries inside `buffer_geos` as GeoJSON.
+
+    Returns a parsed MultiLineString dict, or None if no haies match.
+    ST_Multi wraps the ST_Collect result to guarantee MultiLineString
+    output (ST_Collect alone can return GeometryCollection).
+
+    This is a separate query from `query_hedge_lengths_for_buffers` because
+    combining them into a single scan was empirically ~430 ms slower.
+    """
+
+    sql = """
+        SELECT ST_AsGeoJSON(ST_Multi(ST_Collect(
+            ST_SimplifyPreserveTopology(l.geometry::geometry, %(tol)s)
+        )))
+        FROM geodata_line l
+        JOIN geodata_map m ON l.map_id = m.id
+        WHERE m.map_type = %(map_type)s
+          AND ST_Intersects(l.geometry, ST_GeomFromEWKT(%(buffer)s));
+    """
+    params = {
+        "tol": simplify_tolerance,
+        "map_type": MAP_TYPES.haies,
+        "buffer": buffer_geos.ewkt,
+    }
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        raw = cursor.fetchone()[0]
+    if raw is None:
+        return None
+    return json.loads(raw)
+
+
+def build_circles(point_geos, radii):
+    """Build WGS84 circle polygons for each radius by buffering in UTM."""
+
+    epsg_utm = get_best_epsg_for_location(point_geos.x, point_geos.y)
+    centroid_m = point_geos.transform(epsg_utm, clone=True)
+    circles = {r: centroid_m.buffer(r).transform(EPSG_WGS84, clone=True) for r in radii}
+    return circles, epsg_utm
+
+
+def trim_circles_to_land(circles):
+    """Trim each circle to land, calling `trim_land` only once (on the largest).
+
+    Smaller truncated circles are derived via GEOS intersection with the
+    largest result, which is mathematically equivalent to calling
+    `trim_land` on each circle individually.
+
+    Returns {radius: truncated_geom | None}.
+    """
+
+    max_r = max(circles)
+    truncated_max = trim_land(circles[max_r])
+    if truncated_max is None:
+        return {r: None for r in circles}
+
+    result = {}
+    for r in circles:
+        if r == max_r:
+            result[r] = truncated_max
+            continue
+        t = truncated_max.intersection(circles[r])
+        if t.empty:
+            result[r] = None
+        else:
+            t.srid = EPSG_WGS84
+            result[r] = t
+    return result
+
+
+def area_in_ha(geom, epsg_utm):
+    """Compute area in hectares by projecting to the given UTM zone."""
+
+    if geom is None:
+        return 0.0
+    return geom.transform(epsg_utm, clone=True).area * 0.0001
+
+
+def compute_hedge_densities_around_point(
+    point_geos,
+    radii,
+    *,
+    display_simplify_tolerance=None,
+):
+    """Compute hedge density at multiple concentric radii around a point.
+
+    For the given point, for each radius:
+     - build a circle polygon
+     - trim it to land (sea excluded)
+     - get the hedges length inside that circle
+     - divide length by land area to get density
+
+    Returns {radius: {"density", "artifacts": {...}}, "display_geojson": ...}.
+    Off-land radii get the sentinel (density=1.0, length=0, area_ha=0).
+    """
+
+    if not radii:
+        raise ValueError("radii must be a non-empty iterable")
+    radii = list(radii)
+
+    # Build the multiple land-intersecting circle geometries
+    circles, epsg_utm = build_circles(point_geos, radii)
+    truncated = trim_circles_to_land(circles)
+    max_circle = circles[max(radii)]
+
+    # Compute the sum of hedge lengths for each circle
+    lengths = query_hedge_lengths_for_buffers(truncated, max_circle)
+
+    # Build the result dict
+    result = {}
+    for r in radii:
+        ha = area_in_ha(truncated[r], epsg_utm)
+        density = lengths[r] / ha if truncated[r] and ha > 0 else 1.0
+        result[r] = {
+            "density": density,
+            "artifacts": {
+                "circle": circles[r],
+                "truncated_circle": truncated[r],
+                "length": lengths[r],
+                "area_ha": ha,
+            },
+        }
+
+    # Run a distinct query for the hedges lines to display with leaflet
+    # It's quicker and lighter to display simplified geometries
+    if display_simplify_tolerance is not None:
+        result["display_geojson"] = query_hedges_display_geojson(
+            max_circle, display_simplify_tolerance
+        )
+
+    return result
+
+
 def compute_hedge_density_around_lines(line_geos, radius):
     """Compute the density of hedges in buffer radius."""
 

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -667,19 +667,13 @@ def compute_hedge_density_around_point(point_geos, radius):
     circle = centroid_meter.buffer(radius)
     circle = circle.transform(EPSG_WGS84, clone=True)  # switch back to WGS84
 
-    # Check if the circle center is on land
-    on_land = (
-        Zone.objects.filter(map__map_type=MAP_TYPES.terres_emergees)
-        .filter(geometry__covers=point_geos)
-        .exists()
-    )
-    truncated_circle = None
+    # Initially, we were first running a pre-check to see if the project was
+    # actually in land. Otherwise, would would return a sentinel density of 1.0
+    # That pre-check was measured to add query time instead of saving it,
+    # so it was removed.
+    truncated_circle = trim_land(circle)
 
-    if on_land:
-        # Remove the sea from the circle
-        truncated_circle = trim_land(circle)
-
-    if on_land and truncated_circle:
+    if truncated_circle:
         length, area_ha, density = compute_hedge_density_data(
             truncated_circle, epsg_utm
         )

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -877,17 +877,21 @@ def compute_hedge_densities_around_point(
     return result
 
 
-def compute_hedge_density_around_lines(line_geos, radius):
-    """Compute the density of hedges in buffer radius."""
+def compute_hedge_density_around_lines(
+    line_geos, radius, *, display_simplify_tolerance=None
+):
+    """Compute the density of hedges in buffer radius.
 
-    # use specific projection to be able to use meters for buffering
+    If `display_simplify_tolerance` is set, `artifacts` also contains a
+    `display_geojson` key with the simplified hedges inside the buffer.
+    """
+
     line_centroid = line_geos.centroid
     epsg_utm = get_best_epsg_for_location(line_centroid.x, line_centroid.y)
     line_meter = line_geos.transform(epsg_utm, clone=True)
     buffer_zone = line_meter.buffer(radius)
-    buffer_zone = buffer_zone.transform(EPSG_WGS84, clone=True)  # switch back to WGS84
+    buffer_zone = buffer_zone.transform(EPSG_WGS84, clone=True)
 
-    # Remove the sea from the circle
     truncated_buffer_zone = trim_land(buffer_zone)
 
     if truncated_buffer_zone:
@@ -895,20 +899,23 @@ def compute_hedge_density_around_lines(line_geos, radius):
             truncated_buffer_zone, epsg_utm
         )
     else:
-        # there is no land in the circle (e.g. sea or foreign country)
         length = Distance(0)
         area_ha = 0.0
         density = 1.0
 
-    return {
-        "density": density,
-        "artifacts": {
-            "buffer_zone": buffer_zone,
-            "truncated_buffer_zone": truncated_buffer_zone,
-            "length": length.standard,
-            "area_ha": area_ha,
-        },
+    artifacts = {
+        "buffer_zone": buffer_zone,
+        "truncated_buffer_zone": truncated_buffer_zone,
+        "length": length.standard,
+        "area_ha": area_ha,
     }
+
+    if display_simplify_tolerance is not None:
+        artifacts["display_geojson"] = query_hedges_display_geojson(
+            buffer_zone, display_simplify_tolerance
+        )
+
+    return {"density": density, "artifacts": artifacts}
 
 
 def _get_centered_url(url, hedges: "HedgeData"):

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -10,16 +10,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import requests
-from django.contrib.gis.db.models import GeometryField
-from django.contrib.gis.db.models.functions import Intersection, Length
 from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import GEOSGeometry, MultiLineString, MultiPolygon, Point
-from django.contrib.gis.measure import Distance
 from django.contrib.gis.utils.layermapping import LayerMapping
 from django.core.serializers import serialize
 from django.db import connection
-from django.db.models import QuerySet, Sum
-from django.db.models.functions import Cast
+from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
 from scipy.interpolate import griddata
 
@@ -632,32 +628,6 @@ def trim_land(geom):
         return trimmed_geom
 
 
-def compute_hedge_density_data(buffer_zone, epsg_utm):
-    """Compute hedge length, area in Ha and density"""
-
-    # compute the area in square meters with specific projection
-    truncated_buffer_zone_m = buffer_zone.transform(epsg_utm, clone=True)
-
-    area = truncated_buffer_zone_m.area
-    area_ha = area * 0.0001
-
-    # get the length of the hedges in the circles
-    length = (
-        Line.objects.filter(
-            geometry__intersects=buffer_zone,
-            map__map_type=MAP_TYPES.haies,
-        )
-        .annotate(clipped=Intersection("geometry", buffer_zone))
-        .annotate(length=Length(Cast("clipped", GeometryField())))
-        .aggregate(total=Sum("length"))["total"]
-    )
-    length = length if length else Distance(0)
-
-    density = length.standard / area_ha if area_ha > 0 else 0.0
-
-    return length, area_ha, density
-
-
 WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'
 EMPTY_POLYGON_EWKT = "SRID=4326;POLYGON EMPTY"
 
@@ -856,22 +826,16 @@ def compute_hedge_density_around_lines(
     buffer_zone = line_meter.buffer(radius)
     buffer_zone = buffer_zone.transform(EPSG_WGS84, clone=True)
 
-    truncated_buffer_zone = trim_land(buffer_zone)
-
-    if truncated_buffer_zone:
-        length, area_ha, density = compute_hedge_density_data(
-            truncated_buffer_zone, epsg_utm
-        )
-    else:
-        length = Distance(0)
-        area_ha = 0.0
-        density = 1.0
+    truncated = trim_land(buffer_zone)
+    lengths = query_hedge_lengths_for_buffers({radius: truncated}, buffer_zone)
+    ha = area_in_ha(truncated, epsg_utm)
+    density = lengths[radius] / ha if truncated and ha > 0 else 1.0
 
     artifacts = {
         "buffer_zone": buffer_zone,
-        "truncated_buffer_zone": truncated_buffer_zone,
-        "length": length.standard,
-        "area_ha": area_ha,
+        "truncated_buffer_zone": truncated,
+        "length": lengths[radius],
+        "area_ha": ha,
     }
 
     if display_simplify_tolerance is not None:

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -640,38 +640,67 @@ def buffer_to_ewkt(geom):
     return EMPTY_POLYGON_EWKT
 
 
-def query_hedge_lengths_for_buffers(truncated_buffers, bbox_filter_buffer):
+def query_hedge_lengths_for_buffers(truncated_buffers, untruncated_circle):
     """Aggregate clipped hedge length for several buffers in a single SQL query.
+
+    We need to compute lengths of hedge clipped to the circles, BUT running
+    ST_Intersect on every hedge is expensive. In many cases, most hedges are fully
+    INSIDE the circle.
+
+    So we use a switch statement, and only run the intersection when the hedge is
+    not fully inside the circle.
+
+    In a simulation with heavy hedge density, we saw a ~10x speedup on the query.
+
+    Args:
+        truncated_buffers: {radius: land-trimmed polygon | None}. Each hedge
+            is clipped to this shape before its length is summed.
+        untruncated_circle: the raw circle before land trimming. Used for
+            row filtering (WHERE) and as a fast containment check.
 
     Returns {radius: length_in_meters}.
     """
 
     radii = list(truncated_buffers.keys())
-    params = {"bbox": bbox_filter_buffer.ewkt, "map_type": MAP_TYPES.haies}
 
-    # One SUM(clipped length) column per radius
+    # No land in any buffer → all lengths are zero, skip the query.
+    if not any(t is not None and not t.empty for t in truncated_buffers.values()):
+        return {r: 0.0 for r in radii}
+
+    bbox_ewkt = untruncated_circle.ewkt
+
     columns = []
+    query_params = []
     for i, r in enumerate(radii):
-        param = f"b_{i}"
-        params[param] = buffer_to_ewkt(truncated_buffers[r])
-        columns.append(
-            f"COALESCE(SUM(ST_LengthSpheroid("
-            f"ST_Intersection(l.geometry, ST_GeomFromEWKT(%({param})s))"
-            f"::geometry(GEOMETRY,4326),"
-            f"'{WGS84_SPHEROID}'"
-            f")), 0) AS l_{i}"
-        )
 
+        # Build the conditional query
+        truncated = truncated_buffers[r]
+        columns.append(
+            f"""\
+            COALESCE(SUM(CASE
+            WHEN ST_CoveredBy(l.geometry, ST_GeomFromEWKT(%s))
+            THEN ST_LengthSpheroid(
+                l.geometry::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
+            ELSE ST_LengthSpheroid(
+                ST_Intersection(l.geometry, ST_GeomFromEWKT(%s))
+                ::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
+            END), 0) AS l_{i}"""
+        )
+        query_params.extend([bbox_ewkt, buffer_to_ewkt(truncated)])
+
+    query_params.extend([MAP_TYPES.haies, bbox_ewkt])
+
+    # Run a single query to compute lenghs for each truncated buffer
     sql = f"""
         SELECT {', '.join(columns)}
         FROM geodata_line l
         JOIN geodata_map m ON l.map_id = m.id
-        WHERE m.map_type = %(map_type)s
-          AND ST_Intersects(l.geometry, ST_GeomFromEWKT(%(bbox)s));
+        WHERE m.map_type = %s
+          AND ST_Intersects(l.geometry, ST_GeomFromEWKT(%s));
     """
 
     with connection.cursor() as cursor:
-        cursor.execute(sql, params)
+        cursor.execute(sql, query_params)
         row = cursor.fetchone()
 
     return {r: row[i] for i, r in enumerate(radii)}

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -629,70 +629,41 @@ def trim_land(geom):
 
 
 WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'
-EMPTY_POLYGON_EWKT = "SRID=4326;POLYGON EMPTY"
 
 
-def buffer_to_ewkt(geom):
-    """Return EWKT for a buffer geometry, or POLYGON EMPTY if None/empty."""
+def query_hedge_length(truncated_buffer, untruncated_circle):
+    """Sum the clipped hedge length inside a buffer.
 
-    if geom is not None and not geom.empty:
-        return geom.ewkt
-    return EMPTY_POLYGON_EWKT
+    We need to compute lengths of hedges clipped to the circle, BUT running
+    ST_Intersection on every hedge is expensive. In many cases, most hedges
+    are fully INSIDE the circle.
 
+    So we use a CASE statement, and only run the intersection when the hedge
+    is not fully inside the circle.
 
-def query_hedge_lengths_for_buffers(truncated_buffers, untruncated_circle):
-    """Aggregate clipped hedge length for several buffers in a single SQL query.
-
-    We need to compute lengths of hedge clipped to the circles, BUT running
-    ST_Intersect on every hedge is expensive. In many cases, most hedges are fully
-    INSIDE the circle.
-
-    So we use a switch statement, and only run the intersection when the hedge is
-    not fully inside the circle.
-
-    In a simulation with heavy hedge density, we saw a ~10x speedup on the query.
+    In a simulation with heavy hedge density, it significantly improves the query perf.
 
     Args:
-        truncated_buffers: {radius: land-trimmed polygon | None}. Each hedge
-            is clipped to this shape before its length is summed.
+        truncated_buffer: land-trimmed polygon, or None if off-land.
         untruncated_circle: the raw circle before land trimming. Used for
             row filtering (WHERE) and as a fast containment check.
 
-    Returns {radius: length_in_meters}.
+    Returns length in meters (float).
     """
 
-    radii = list(truncated_buffers.keys())
+    if truncated_buffer is None or truncated_buffer.empty:
+        return 0.0
 
-    # No land in any buffer → all lengths are zero, skip the query.
-    if not any(t is not None and not t.empty for t in truncated_buffers.values()):
-        return {r: 0.0 for r in radii}
-
-    bbox_ewkt = untruncated_circle.ewkt
-
-    columns = []
-    query_params = []
-    for i, r in enumerate(radii):
-
-        # Build the conditional query
-        truncated = truncated_buffers[r]
-        columns.append(
-            f"""\
-            COALESCE(SUM(CASE
+    circle_ewkt = untruncated_circle.ewkt
+    sql = f"""
+        SELECT COALESCE(SUM(CASE
             WHEN ST_CoveredBy(l.geometry, ST_GeomFromEWKT(%s))
             THEN ST_LengthSpheroid(
                 l.geometry::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
             ELSE ST_LengthSpheroid(
                 ST_Intersection(l.geometry, ST_GeomFromEWKT(%s))
                 ::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
-            END), 0) AS l_{i}"""
-        )
-        query_params.extend([bbox_ewkt, buffer_to_ewkt(truncated)])
-
-    query_params.extend([MAP_TYPES.haies, bbox_ewkt])
-
-    # Run a single query to compute lenghs for each truncated buffer
-    sql = f"""
-        SELECT {', '.join(columns)}
+        END), 0)
         FROM geodata_line l
         JOIN geodata_map m ON l.map_id = m.id
         WHERE m.map_type = %s
@@ -700,10 +671,16 @@ def query_hedge_lengths_for_buffers(truncated_buffers, untruncated_circle):
     """
 
     with connection.cursor() as cursor:
-        cursor.execute(sql, query_params)
-        row = cursor.fetchone()
-
-    return {r: row[i] for i, r in enumerate(radii)}
+        cursor.execute(
+            sql,
+            [
+                circle_ewkt,
+                truncated_buffer.ewkt,
+                MAP_TYPES.haies,
+                circle_ewkt,
+            ],
+        )
+        return cursor.fetchone()[0]
 
 
 def query_hedges_display_geojson(buffer_geos, simplify_tolerance):
@@ -812,8 +789,8 @@ def compute_hedge_densities_around_point(
     truncated = trim_circles_to_land(circles)
     max_circle = circles[max(radii)]
 
-    # Compute the sum of hedge lengths for each circle
-    lengths = query_hedge_lengths_for_buffers(truncated, max_circle)
+    # One length query per radius, each focused on its own hedge set
+    lengths = {r: query_hedge_length(truncated[r], circles[r]) for r in radii}
 
     # Build the result dict
     result = {}
@@ -856,14 +833,14 @@ def compute_hedge_density_around_lines(
     buffer_zone = buffer_zone.transform(EPSG_WGS84, clone=True)
 
     truncated = trim_land(buffer_zone)
-    lengths = query_hedge_lengths_for_buffers({radius: truncated}, buffer_zone)
+    length_m = query_hedge_length(truncated, buffer_zone)
     ha = area_in_ha(truncated, epsg_utm)
-    density = lengths[radius] / ha if truncated and ha > 0 else 1.0
+    density = length_m / ha if truncated and ha > 0 else 1.0
 
     artifacts = {
         "buffer_zone": buffer_zone,
         "truncated_buffer_zone": truncated,
-        "length": lengths[radius],
+        "length": length_m,
         "area_ha": ha,
     }
 

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -652,7 +652,7 @@ def compute_hedge_density_around_point(point_geos, radius):
     # Check if the circle center is on land
     on_land = (
         Zone.objects.filter(map__map_type=MAP_TYPES.terres_emergees)
-        .filter(geometry__contains=point_geos)
+        .filter(geometry__covers=point_geos)
         .exists()
     )
     truncated_circle = None

--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -17,8 +17,8 @@ from shapely import LineString, centroid, union_all
 
 from envergo.geodata.models import Department, Zone
 from envergo.geodata.utils import (
+    compute_hedge_densities_around_point,
     compute_hedge_density_around_lines,
-    compute_hedge_density_around_point,
     get_department_from_coords,
 )
 
@@ -488,14 +488,11 @@ class HedgeData(models.Model):
     def compute_density_around_points_with_artifacts(self):
         """Compute the density of hedges around the hedges to remove at 200m and 5000m."""
 
-        # get two circles at 200m and 5000m from the centroid of the hedges to remove
         centroid_shapely = self.get_centroid_to_remove()
         centroid_geos = GEOSGeometry(centroid_shapely.wkt, srid=EPSG_WGS84)
+        bundle = compute_hedge_densities_around_point(centroid_geos, radii=[200, 5000])
 
-        density_200 = compute_hedge_density_around_point(centroid_geos, 200)
-        density_5000 = compute_hedge_density_around_point(centroid_geos, 5000)
-
-        return density_200, density_5000, centroid_geos
+        return bundle[200], bundle[5000], centroid_geos
 
     def compute_density_around_lines_with_artifacts(self):
         """Compute the density of hedges around the hedges to remove in 400m buffer."""

--- a/envergo/moulinette/regulations/ep.py
+++ b/envergo/moulinette/regulations/ep.py
@@ -428,7 +428,7 @@ class EspecesProtegeesNormandie(
         # We use the centroid of the hedges to find the zone in which the hedges are located.
         zonage = (
             Zone.objects.filter(
-                geometry__contains=centroid_geos,
+                geometry__covers=centroid_geos,
                 map__map_type=MAP_TYPES.zonage,
             )
             .defer("geometry")


### PR DESCRIPTION
@pyDez @alexisig J'ai complété cette PR suite à votre dernière revue.

Nombreuses améliorations apportées sur le système de calcul de densité.

Sur une grosse simulation avec belle densité bocagère, sur ma machine on passe de ~8000ms à ~700ms.

<img width="1216" height="740" alt="image" src="https://github.com/user-attachments/assets/e2f5e35e-b336-4a07-a17c-58dbd218e740" />

Cette PR embarque aussi une correction de bug sur la sentinelle qui empêche le calcul de densité au milieu des forêts (quickfix déjà en prod).

La liste des optimisations:

## Utilise l'index gist

La requête géographique utilisait une fonction ST_Contains au lieu de ST_Covers, ce qui empêchait Postgres d'utiliser son index et nécessitait un seq scan. Sur ~4M de lignes, ça pique.

## Suppression du pre-check "sur terres émergées"

À chaque calcul de densité, on vérifiait au préalable par une requête dédiée si le projet était bien sur terre émergée.

Ce pré-check était coûteux en en plus était source de bug: on ne calculait pas la densité pour tout projet dont le centroïde se trouvait dans une forête par exemple.

Le pré-check a été enlevé.

## Clipage des polygones avant union

Lors du calcul de l'intersection d'un buffer (buffer des haies, cercles du démonstrateur…) avec  les terres émergées, on procédait ainsi :

 - Sélect de tous les polygones « terres émergées » qui intersectent le buffer sur lequel on veut calculer la densité
 - Fusion de ces polygones
 - Intersection avec le buffer de départ pour ne garder que le buffer « émergé »

Or l'étape 3 est coûteuse (fusion de potentiels assez gros polygones).

Cette PR procède ainsi:

 - Sélect des polygones terres émergées (inchang)
 - Pré-filtre les polygones avec la bounding box du buffer (cheap)
 - Fusion de ces polygones (plus légers, donc moins coûteux)
 - Fin de la requête inchangé

~ 5% gain.

## Mono-requête pour le trimming « sur terres émergées »

Sur le démonstrateur, on calcule la densité de haie pour des cercles de rayons différents. Actuellement, on lance une requête par cercle, ce qui est coûteux parce que le contenu des « petits » cercles est déjà contenu dans les résultats pour les « grands » cercles.

Une optimisation récupère toutes les haies en une requête, et le calcul d'intersection pour les plus petits cercles est fait en python.

## Requête simplifiée pour l'affichage

On simplifie la requête qui récupère les polygones à afficher en frontend. Environ 50 ~ 70% de taille en moins sur le json des haies. Donc la page s'affiche plus vite.

## Skip des intersections pour les haies dans les cercles

En calculant la densité, on réalisait l'intersection de *toutes les haies* contenues dans le buffer, ce qui était très coûteux

Maintenant, on distingue les haies qui sont entièrement contenues dans le buffer (la plupart des haies en général) et on évite l'opération coûteuse sur ces haies.

C'est l'optimisation la plus impactante, entre x8 et x20 sur la requête globale en fonction des cas.