### PR TITLE
Ajout de config au context de la page instructeur

### DIFF
--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -960,6 +960,7 @@ class PetitionProjectInstructorView(BasePetitionProjectInstructorView, DetailVie
         context["plantation_evaluation"] = PlantationEvaluator(
             context["moulinette"], context["moulinette"].catalog["haies"]
         )
+        context["config"] = context["moulinette"].config
         return context
 
     def get_success_url(self):


### PR DESCRIPTION
https://trello.com/c/ZMIVK4y2/2287-erreur-de-contexte-moulinetteconfig-dans-les-pages-instruction