### PR TITLE
Sentry bugs 238094

### DIFF
--- a/envergo/moulinette/management/commands/obsolete_moulinette_template_admin_alert.py
+++ b/envergo/moulinette/management/commands/obsolete_moulinette_template_admin_alert.py
@@ -13,6 +13,9 @@ class Command(BaseCommand):
     help = "Post a message when a moulinette template has an obsolete key."
 
     def handle(self, *args, **options):
+        if not settings.ENVERGO_AMENAGEMENT_DOMAIN:
+            return None
+
         obsolete_templates = MoulinetteTemplate.objects.exclude(
             key__in=[tuple[0] for tuple in get_all_template_keys()]
         ).select_related("config__department", "criterion")

--- a/envergo/moulinette/tests/test_commands.py
+++ b/envergo/moulinette/tests/test_commands.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+from envergo.moulinette.tests.factories import MoulinetteTemplateFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@patch("envergo.utils.mattermost.notify")
+def test_dossier_submission_admin_alert(mock_notify):
+    """Test obsolete moulinette template admin alert"""
+    # GIVEN a template with no existing template key
+    MoulinetteTemplateFactory()
+    # WHEN command is called
+    call_command("obsolete_moulinette_template_admin_alert")
+    # THEN notify should be called one
+    mock_notify.assert_called()
+    # AND message is related to config
+    args, kwargs = mock_notify.call_args_list[0]
+    assert 'La config Aménagement du département ["Loire-Atlantique (44)"]' in args[0]
+    assert " référence un gabarit moulinette obsolète" in args[0]
+    assert "amenagement" in args[1]
+
+
+@override_settings(ENVERGO_HAIE_DOMAIN="testserver")
+@override_settings(ENVERGO_AMENAGEMENT_DOMAIN="")
+@patch("envergo.utils.mattermost.notify")
+def test_dossier_submission_admin_alert_amenagement_domain_not_configured(
+    mock_notify,
+):
+    """Test obsolete moulinette template admin alert"""
+
+    # GIVEN a template with no existing template key
+    MoulinetteTemplateFactory()
+    # WHEN command is called
+    call_command("obsolete_moulinette_template_admin_alert")
+    # THEN notify should not be called because no amenagement domain is set
+    mock_notify.assert_not_called()

--- a/envergo/moulinette/tests/test_commands.py
+++ b/envergo/moulinette/tests/test_commands.py
@@ -4,7 +4,10 @@ import pytest
 from django.core.management import call_command
 from django.test import override_settings
 
-from envergo.moulinette.tests.factories import MoulinetteTemplateFactory
+from envergo.moulinette.tests.factories import (
+    CriterionFactory,
+    MoulinetteTemplateFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -12,15 +15,22 @@ pytestmark = pytest.mark.django_db
 @patch("envergo.utils.mattermost.notify")
 def test_dossier_submission_admin_alert(mock_notify):
     """Test obsolete moulinette template admin alert"""
+    criterion = CriterionFactory()
     # GIVEN a template with no existing template key
     MoulinetteTemplateFactory()
+    MoulinetteTemplateFactory(criterion=criterion, config=None)
     # WHEN command is called
     call_command("obsolete_moulinette_template_admin_alert")
-    # THEN notify should be called one
-    mock_notify.assert_called()
-    # AND message is related to config
-    args, kwargs = mock_notify.call_args_list[0]
+    # THEN notify should be called twice
+    assert mock_notify.call_count == 2
+    # AND first message is related to config
+    args, _ = mock_notify.call_args_list[0]
     assert 'La config Aménagement du département ["Loire-Atlantique (44)"]' in args[0]
+    assert " référence un gabarit moulinette obsolète" in args[0]
+    assert "amenagement" in args[1]
+    # AND second message is related to config
+    args, _ = mock_notify.call_args_list[1]
+    assert 'Le critère ["Zone humide"]' in args[0]
     assert " référence un gabarit moulinette obsolète" in args[0]
     assert "amenagement" in args[1]
 


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/238094/

Cette erreur se produit chaque semaine sur l'instance de formation du guichet unique de la haie lorsqu'une commande concernant envergo aménagement est exécutée par le cron. Mais sur cette instance il n'y a pas de domaine aménagement configuré.

Cette PR vérifie si un domaine aménagement est configuré, si non la commande renvoie None.