### PR TITLE
Sentry batch 20260507

### DIFF
--- a/envergo/evaluations/admin.py
+++ b/envergo/evaluations/admin.py
@@ -287,9 +287,12 @@ class EvaluationAdmin(admin.ModelAdmin):
             if form.is_valid():
                 message = form.cleaned_data.get("message")
                 try:
-                    evaluation.unpublish()
-                    version = evaluation.create_version(request.user, message)
-                    version.save()
+                    # Savepoint: if save() raises IntegrityError, only this block
+                    # rolls back, keeping the outer transaction usable for template rendering.
+                    with transaction.atomic():
+                        evaluation.unpublish()
+                        version = evaluation.create_version(request.user, message)
+                        version.save()
                     admin_url = reverse(
                         "admin:evaluations_evaluation_change", args=[evaluation.uid]
                     )

--- a/envergo/evaluations/tests/test_admin.py
+++ b/envergo/evaluations/tests/test_admin.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.urls import reverse
 
@@ -305,3 +307,21 @@ def test_display_published_version_message(evaluation, admin_client, admin_user)
     content = res.content.decode()
     # THEN There is no message indicating that the version is outdated
     assert "✅ Publié" in content
+
+
+def test_publish_view_handles_integrity_error(admin_client, admin_user, evaluation):
+    """When unpublish fails silently (e.g. race condition), the IntegrityError
+    should be caught gracefully instead of crashing with TransactionManagementError."""
+    # Ensure a published version already exists so the constraint fires
+    existing_version = evaluation.versions.first()
+    existing_version.published = True
+    existing_version.save()
+
+    url = reverse("admin:evaluations_evaluation_publish", args=[evaluation.uid])
+    with patch.object(type(evaluation), "unpublish", lambda self: None), patch.object(
+        type(evaluation), "render_content", lambda self: "<p>test</p>"
+    ):
+        res = admin_client.post(url, {"message": "test publish"}, follow=True)
+
+    assert res.status_code == 200
+    assert "Une erreur est survenue" in res.content.decode()

--- a/envergo/hedges/tests/test_views.py
+++ b/envergo/hedges/tests/test_views.py
@@ -86,3 +86,9 @@ def test_hedge_input_uses_config_matching_simulation_date(client):
     res = client.get(url, {"department": "44", "date": today_str})
     assert res.status_code == 200
     assert 'name="plantation-connexion_boisement"' not in res.content.decode()
+
+
+def test_hedge_conditions_get_returns_405(client):
+    url = reverse("hedge_conditions")
+    res = client.get(url, {"department": "44"})
+    assert res.status_code == 405

--- a/envergo/hedges/views.py
+++ b/envergo/hedges/views.py
@@ -217,6 +217,9 @@ class HedgeConditionsView(MoulinetteMixin, FormView):
         }
         return kwargs
 
+    def get(self, request, *args, **kwargs):
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+
     def post(self, request, *args, **kwargs):
         if not self.moulinette.is_valid():
             return JsonResponse({"error": "Moulinette is not valid"}, status=400)

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -15,6 +15,7 @@ from envergo.moulinette.forms.fields import (
     DisplayCharField,
     DisplayChoiceField,
     DisplayIntegerField,
+    SafeModelChoiceField,
     UnitInput,
     extract_choices,
     extract_display_function,
@@ -340,7 +341,7 @@ CONTEXT_CHOICES = (
 
 
 class MoulinetteFormHaie(BaseMoulinetteForm):
-    department = forms.ModelChoiceField(
+    department = SafeModelChoiceField(
         queryset=Department.objects.all(),
         required=True,
         to_field_name="department",

--- a/envergo/moulinette/forms/fields.py
+++ b/envergo/moulinette/forms/fields.py
@@ -2,6 +2,8 @@ import logging
 import re
 
 from django import forms
+from django.core.exceptions import ValidationError
+from django.db import DataError
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +92,18 @@ def extract_display_function(choices):
     return lambda value: next(
         (choice[2] for choice in choices if choice[0] == value), None
     )
+
+
+class SafeModelChoiceField(forms.ModelChoiceField):
+    """ModelChoiceField that converts DataError (e.g. NUL bytes) to ValidationError."""
+
+    def clean(self, value):
+        try:
+            return super().clean(value)
+        except DataError:
+            raise ValidationError(
+                self.error_messages["invalid_choice"], code="invalid_choice"
+            )
 
 
 class UnitInput(forms.TextInput):

--- a/envergo/moulinette/forms/fields.py
+++ b/envergo/moulinette/forms/fields.py
@@ -95,7 +95,13 @@ def extract_display_function(choices):
 
 
 class SafeModelChoiceField(forms.ModelChoiceField):
-    """ModelChoiceField that converts DataError (e.g. NUL bytes) to ValidationError."""
+    """ModelChoiceField that converts DataError to ValidationError.
+
+    Django's ModelChoiceField passes user input directly to a DB query.
+    Malformed values raise a raw psycopg DataError instead of a
+    user-facing ValidationError, causing a 500. Known triggers:
+    NUL bytes, invalid encoding, or values exceeding the PK column length.
+    """
 
     def clean(self, value):
         try:

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -15,7 +15,7 @@ from django.contrib.gis.measure import Distance as D
 from django.contrib.postgres.constraints import ExclusionConstraint
 from django.contrib.postgres.fields import ArrayField, DateRangeField, RangeOperators
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import DataError, models
 from django.db.backends.postgresql.psycopg_any import DateRange
 from django.db.models import (
     CheckConstraint,
@@ -2708,12 +2708,15 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         if dept is None:
             return None
 
-        qs = (
-            Department.objects.defer("geometry")
-            .annotate(centroid=Centroid("geometry"))
-            .filter(department=dept)
-        )
-        return qs.first()
+        try:
+            qs = (
+                Department.objects.defer("geometry")
+                .annotate(centroid=Centroid("geometry"))
+                .filter(department=dept)
+            )
+            return qs.first()
+        except DataError:
+            return None
 
     def get_regulations(self):
         """Find the activated regulations and their criteria."""

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2716,6 +2716,8 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             )
             return qs.first()
         except DataError:
+            # Malformed values raise a raw psycopg DataError, causing a 500. Known triggers:
+            # NUL bytes, invalid encoding, or values exceeding the PK column length.
             return None
 
     def get_regulations(self):

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1012,3 +1012,11 @@ def test_triage_get_initial_normalizes_projet_specifique_to_projet(client):
         assert (
             form.initial.get("contexte") == "projet"
         ), f"Expected initial contexte='projet' when URL has contexte='{contexte}'"
+
+
+def test_triage_nul_byte_in_department(client):
+    """NUL bytes in the department param should not cause a DataError (Sentry #267046)."""
+    DCConfigHaieFactory()
+    url = reverse("triage")
+    res = client.get(f"{url}?department=44%00")
+    assert res.status_code in (200, 302)

--- a/envergo/pages/tests/test_views.py
+++ b/envergo/pages/tests/test_views.py
@@ -249,6 +249,14 @@ class TestHomeHaie:
 
         assert response.status_code == 200
 
+    def test_malicious_department_id_does_not_500(self, client):
+        """SQL injection payloads in department field should not cause a 500."""
+        response = client.post(
+            reverse("home"),
+            {"department": "(select(0)from(select(sleep(15)))v)"},
+        )
+        assert response.status_code == 200
+
 
 @pytest.mark.haie
 class TestContactHaie:

--- a/envergo/pages/views.py
+++ b/envergo/pages/views.py
@@ -117,7 +117,7 @@ class HomeHaieView(TemplateView):
         if department_id:
             try:
                 department = Department.objects.defer("geometry").get(id=department_id)
-            except Department.DoesNotExist:
+            except (Department.DoesNotExist, ValueError, TypeError):
                 pass  # Invalid id submitted — department stays None, handled gracefully below
 
         config = ConfigHaie.objects.get_valid_config(department) if department else None


### PR DESCRIPTION
Quelques fix pour des bugs sentry. 
Trois d'entre eux (1, 3 et 4) permettent d'eviter des 500 en cas de comportements malveillants (GET sur un endpoint POST only, NUL byte dans les valeurs soumis, SQL injection). Honnetement, je ne suis pas sur de la bonne manière de réagir : renvoyer une 4XX ou une 500. Dites moi ce que vous en pensez.


[Commit 1](https://sentry.incubateur.net/organizations/betagouv/issues/271208/?environment=production&project=201&query=is%3Aunresolved%20issue.priority%3A[high%2C%20medium]&referrer=issue-stream)

[Commit 2](https://sentry.incubateur.net/organizations/betagouv/issues/275052/?alert_rule_id=175&alert_timestamp=1777879073622&alert_type=email&environment=production&notification_uuid=aa2a90d6-c849-4102-894d-ea0d24f654bc&project=201&referrer=alert_email)


[Commit 3](https://sentry.incubateur.net/organizations/betagouv/issues/267045/?environment=production&project=201&query=is%3Aunresolved%20issue.priority%3A[high%2C%20medium]&referrer=issue-stream)

[Commit 4](https://sentry.incubateur.net/organizations/betagouv/issues/267046/?environment=production&project=201&query=is%3Aunresolved%20issue.priority%3A[high%2C%20medium]&referrer=issue-stream)