### PR TITLE
Corrige les artefacts liés à la simplification des haies (démonstrateurs)

### DIFF
--- a/envergo/demos/views.py
+++ b/envergo/demos/views.py
@@ -89,13 +89,10 @@ class HedgeDensity(LatLngDemoMixin, FormView):
         """Return context with data to display map"""
         lng_lat = Point(float(lng), float(lat), srid=EPSG_WGS84)
         # Get the density data for different circles around the point.
-        # For display purpose, we fetch hedges with a simplified geometry.
-        # Tolerance ~5 m at French latitudes is well below pixel resolution
-        # at the demo's 5 km zoom.
         bundle = compute_hedge_densities_around_point(
             lng_lat,
             radii=[400, 5000],
-            display_simplify_tolerance=0.00005,
+            include_display_geojson=True,
         )
         density_400 = bundle[400]
         density_5000 = bundle[5000]
@@ -185,7 +182,7 @@ class HedgeDensityBuffer(LatLngDemoMixin, FormView):
         hedges_to_remove_mls_merged = hedges.hedges_to_remove().to_multilinestring()
 
         density_400 = compute_hedge_density_around_lines(
-            hedges_to_remove_mls_merged, 400, display_simplify_tolerance=0.00005
+            hedges_to_remove_mls_merged, 400, include_display_geojson=True
         )
 
         buffered_400_polygon = (

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -80,11 +80,11 @@ def test_density_around_point_pinned_values(hedge_density_fixture):
 
 
 def test_bundle_display_geojson(hedge_density_fixture):
-    """Display geometry is a MultiLineString when tolerance is set."""
+    """Display geometry is a MultiLineString."""
     bundle = compute_hedge_densities_around_point(
         hedge_density_fixture,
         radii=[200, 400, 5000],
-        display_simplify_tolerance=0.00005,
+        include_display_geojson=True,
     )
     display = bundle["display_geojson"]
     assert display is not None
@@ -99,7 +99,7 @@ def test_bundle_off_land():
     bundle = compute_hedge_densities_around_point(
         p,
         radii=[200, 400, 5000],
-        display_simplify_tolerance=0.00005,
+        include_display_geojson=True,
     )
 
     for r in [200, 400, 5000]:

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -735,38 +735,53 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
 def query_hedges_display_geojson(
     truncated_buffer, untruncated_circle, simplify_tolerance
 ):
-    """Return simplified hedge geometries clipped to the truncated buffer.
+    """Return hedge geometries clipped to the truncated buffer for display.
 
-    Since this is for map display, the truncated buffer is simplified at 10×
-    the hedge tolerance before clipping. This reduces vertex count (e.g. 2077
-    → ~880 for a complex coastline) and makes ST_Intersection much cheaper,
-    with no visible difference at the display zoom level.
+    Uses the same CTE excluded-zone strategy as `query_hedge_length`:
 
-    The WHERE clause filters against the simple untruncated circle for
-    efficient spatial index lookups.
+      Fast path — hedge fully inside the truncated buffer: simplify only,
+        no clipping needed. Covers the vast majority of hedges.
+
+      Slow path — hedge crosses a boundary (coast, forest, circle edge):
+        clip against a simplified truncated buffer, then simplify. Clipping
+        before simplification preserves precise intersection points at the
+        buffer boundary. The buffer is simplified (10× hedge tolerance) to
+        reduce intersection cost — only boundary hedges are affected, and at
+        display zoom the difference is imperceptible.
 
     Returns a parsed MultiLineString dict, or None if no hedges match.
     """
 
     sql = """
-        WITH buf AS (
-            SELECT ST_SimplifyPreserveTopology(
-                ST_GeomFromEWKT(%(truncated)s)::geometry, %(buf_tol)s
-            ) AS geom
+        WITH zones AS (
+            SELECT
+                ST_GeomFromEWKT(%(circle)s) AS circ,
+                ST_SimplifyPreserveTopology(
+                    ST_GeomFromEWKT(%(truncated)s)::geometry, %(buf_tol)s
+                ) AS trunc_simple,
+                ST_Difference(
+                    ST_GeomFromEWKT(%(circle)s),
+                    ST_GeomFromEWKT(%(truncated)s)
+                ) AS excluded
         )
         SELECT ST_AsGeoJSON(ST_CollectionExtract(ST_Collect(
-            ST_Intersection(
-                ST_SimplifyPreserveTopology(l.geometry::geometry, %(hedge_tol)s),
-                buf.geom)
+            CASE
+                WHEN ST_CoveredBy(l.geometry, zones.circ)
+                     AND NOT ST_Intersects(l.geometry, zones.excluded)
+                THEN ST_SimplifyPreserveTopology(l.geometry::geometry, %(tol)s)
+                ELSE ST_SimplifyPreserveTopology(
+                    ST_Intersection(l.geometry, zones.trunc_simple)
+                    ::geometry, %(tol)s)
+            END
         ), 2))
         FROM geodata_line l
         JOIN geodata_map m ON l.map_id = m.id
-        CROSS JOIN buf
+        CROSS JOIN zones
         WHERE m.map_type = %(map_type)s
-          AND ST_Intersects(l.geometry, ST_GeomFromEWKT(%(circle)s));
+          AND ST_Intersects(l.geometry, zones.circ);
     """
     params = {
-        "hedge_tol": simplify_tolerance,
+        "tol": simplify_tolerance,
         "buf_tol": simplify_tolerance * 10,
         "map_type": MAP_TYPES.haies,
         "truncated": truncated_buffer.ewkt,

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -493,14 +493,12 @@ def fill_polygon_stats():
     This is only used manually when the need arises, for debugging purpose.
     """
     with connection.cursor() as cursor:
-        cursor.execute(
-            """
+        cursor.execute("""
         UPDATE geodata_zone
         SET
             area = ST_Area(geometry),
             npoints = ST_NPoints(geometry::geometry);
-        """
-        )
+        """)
 
 
 def get_catchment_area(lng, lat):
@@ -732,22 +730,16 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
         return cursor.fetchone()[0]
 
 
-def query_hedges_display_geojson(
-    truncated_buffer, untruncated_circle, simplify_tolerance
-):
+def query_hedges_display_geojson(truncated_buffer, untruncated_circle):
     """Return hedge geometries clipped to the truncated buffer for display.
 
     Uses the same CTE excluded-zone strategy as `query_hedge_length`:
 
-      Fast path — hedge fully inside the truncated buffer: simplify only,
-        no clipping needed. Covers the vast majority of hedges.
+      Fast path — hedge fully inside the truncated buffer (covered by the
+        simple circle and not touching the excluded zone): return as-is.
 
       Slow path — hedge crosses a boundary (coast, forest, circle edge):
-        clip against a simplified truncated buffer, then simplify. Clipping
-        before simplification preserves precise intersection points at the
-        buffer boundary. The buffer is simplified (10× hedge tolerance) to
-        reduce intersection cost — only boundary hedges are affected, and at
-        display zoom the difference is imperceptible.
+        clip against the truncated buffer via ST_Intersection.
 
     Returns a parsed MultiLineString dict, or None if no hedges match.
     """
@@ -756,9 +748,7 @@ def query_hedges_display_geojson(
         WITH zones AS (
             SELECT
                 ST_GeomFromEWKT(%(circle)s) AS circ,
-                ST_SimplifyPreserveTopology(
-                    ST_GeomFromEWKT(%(truncated)s)::geometry, %(buf_tol)s
-                ) AS trunc_simple,
+                ST_GeomFromEWKT(%(truncated)s) AS trunc,
                 ST_Difference(
                     ST_GeomFromEWKT(%(circle)s),
                     ST_GeomFromEWKT(%(truncated)s)
@@ -768,10 +758,8 @@ def query_hedges_display_geojson(
             CASE
                 WHEN ST_CoveredBy(l.geometry, zones.circ)
                      AND NOT ST_Intersects(l.geometry, zones.excluded)
-                THEN ST_SimplifyPreserveTopology(l.geometry::geometry, %(tol)s)
-                ELSE ST_SimplifyPreserveTopology(
-                    ST_Intersection(l.geometry, zones.trunc_simple)
-                    ::geometry, %(tol)s)
+                THEN l.geometry::geometry
+                ELSE ST_Intersection(l.geometry, zones.trunc)::geometry
             END
         ), 2))
         FROM geodata_line l
@@ -781,8 +769,6 @@ def query_hedges_display_geojson(
           AND ST_Intersects(l.geometry, zones.circ);
     """
     params = {
-        "tol": simplify_tolerance,
-        "buf_tol": simplify_tolerance * 10,
         "map_type": MAP_TYPES.haies,
         "truncated": truncated_buffer.ewkt,
         "circle": untruncated_circle.ewkt,
@@ -845,7 +831,7 @@ def compute_hedge_densities_around_point(
     point_geos,
     radii,
     *,
-    display_simplify_tolerance=None,
+    include_display_geojson=False,
 ):
     """Compute hedge density at multiple concentric radii around a point.
 
@@ -886,23 +872,23 @@ def compute_hedge_densities_around_point(
             },
         }
 
-    if display_simplify_tolerance is not None:
+    if include_display_geojson:
         max_r = max(radii)
         display_truncated = truncated[max_r] or max_circle
         result["display_geojson"] = query_hedges_display_geojson(
-            display_truncated, max_circle, display_simplify_tolerance
+            display_truncated, max_circle
         )
 
     return result
 
 
 def compute_hedge_density_around_lines(
-    line_geos, radius, *, display_simplify_tolerance=None
+    line_geos, radius, *, include_display_geojson=False
 ):
     """Compute the density of hedges in buffer radius.
 
-    If `display_simplify_tolerance` is set, `artifacts` also contains a
-    `display_geojson` key with the simplified hedges inside the buffer.
+    If `include_display_geojson` is set, `artifacts` also contains a
+    `display_geojson` key with the hedges clipped to the buffer.
     """
 
     line_centroid = line_geos.centroid
@@ -923,10 +909,10 @@ def compute_hedge_density_around_lines(
         "area_ha": ha,
     }
 
-    if display_simplify_tolerance is not None:
+    if include_display_geojson:
         display_truncated = truncated or buffer_zone
         artifacts["display_geojson"] = query_hedges_display_geojson(
-            display_truncated, buffer_zone, display_simplify_tolerance
+            display_truncated, buffer_zone
         )
 
     return {"density": density, "artifacts": artifacts}

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -493,12 +493,14 @@ def fill_polygon_stats():
     This is only used manually when the need arises, for debugging purpose.
     """
     with connection.cursor() as cursor:
-        cursor.execute("""
+        cursor.execute(
+            """
         UPDATE geodata_zone
         SET
             area = ST_Area(geometry),
             npoints = ST_NPoints(geometry::geometry);
-        """)
+        """
+        )
 
 
 def get_catchment_area(lng, lat):


### PR DESCRIPTION
Les dernières optimisations de performance sur le démonstrateur a introduit une petite régression sur l'affichage.

Sur certaines urls, le démonstrateur retourne >9000 haies, qu'il faut intersecter avec les polygones de terres emergées.

https://haie.incubateur.net/demonstrateurs/densite-haie/?lng=-0.95856&lat=49.18582&leaflet-base-layers_52=on&address=

Pour économiser en performance, on travaillait avec des géométries simplifiée (haies et zones). Malheureusement, l'imprécision au niveau de l'affichage était trop grande.

En compromis, on simplifie les zones, mais l'intersection se fait sur la géometrie originale des haies, qui seulement ensuite est simplifiée. C'est malheureusement beaucoup plus lent.