### PR TITLE
De-duplicate plantation conditions

### DIFF
--- a/envergo/hedges/regulations.py
+++ b/envergo/hedges/regulations.py
@@ -127,6 +127,20 @@ class MinLengthCondition(PlantationCondition):
         return self.context["length_to_check"] > 0
 
 
+class RUMinLengthCondition(MinLengthCondition):
+    """Evaluate if there is enough hedges to plant in the project.
+
+    The difference with the base MinLengthCondition:
+     - MinLengthCondition uses the global R, which is the max R for each evaluators.
+     - RuMinLengthCondition uses the specific R for the current evaluator.
+    """
+
+    def evaluate(self):
+        # Override R with the local evaluator value
+        self.R = self.criterion_evaluator.get_replantation_coefficient()
+        return super().evaluate()
+
+
 class NormandieMinLengthCondition(MinLengthCondition):
     """MinLengthCondition with cross-type reduction for Normandie.
 

--- a/envergo/hedges/regulations.py
+++ b/envergo/hedges/regulations.py
@@ -83,6 +83,7 @@ class PlantationCondition(ABC):
 
         Only meaningful for conditions of the same class — raises TypeError
         otherwise. Delegates to compare_strictness for the actual comparison.
+        Subclasses should override compare_strictness, not this method.
         """
         if type(self) is not type(other):
             raise TypeError(
@@ -96,8 +97,8 @@ class PlantationCondition(ABC):
 
         Called by is_stricter_than after type validation. Override in subclasses
         that can be duplicated across evaluators. Returns False by default,
-        meaning neither instance claims to be stricter — deduplication picks
-        one arbitrarily.
+        meaning neither instance claims to be stricter — deduplication keeps
+        the first one in evaluator iteration order (deterministic).
         """
         return False
 
@@ -638,8 +639,7 @@ class RUQualityCondition(BaseQualityCondition):
         }
 
     def compare_strictness(self, other):
-        """The condition requiring more total compensation is stricter."""
-        return self.context.get("lpm", 0) > other.context.get("lpm", 0)
+        return self.context["lpm"] > other.context["lpm"]
 
     @property
     def text(self):

--- a/envergo/hedges/regulations.py
+++ b/envergo/hedges/regulations.py
@@ -78,6 +78,29 @@ class PlantationCondition(ABC):
         """
         return True
 
+    def is_stricter_than(self, other):
+        """Whether self imposes stricter requirements than other.
+
+        Only meaningful for conditions of the same class — raises TypeError
+        otherwise. Delegates to compare_strictness for the actual comparison.
+        """
+        if type(self) is not type(other):
+            raise TypeError(
+                f"Cannot compare strictness between {type(self).__name__} "
+                f"and {type(other).__name__}"
+            )
+        return self.compare_strictness(other)
+
+    def compare_strictness(self, other):
+        """Compare strictness with another instance of the same condition class.
+
+        Called by is_stricter_than after type validation. Override in subclasses
+        that can be duplicated across evaluators. Returns False by default,
+        meaning neither instance claims to be stricter — deduplication picks
+        one arbitrarily.
+        """
+        return False
+
     @abstractmethod
     def evaluate(self):
         raise NotImplementedError(
@@ -139,6 +162,10 @@ class RUMinLengthCondition(MinLengthCondition):
         # Override R with the local evaluator value
         self.R = self.criterion_evaluator.get_replantation_coefficient()
         return super().evaluate()
+
+    def compare_strictness(self, other):
+        """The condition requiring the longer minimum length is stricter."""
+        return self.context["length_to_check"] > other.context["length_to_check"]
 
 
 class NormandieMinLengthCondition(MinLengthCondition):
@@ -609,6 +636,10 @@ class RUQualityCondition(BaseQualityCondition):
             "lm": sum(self.remaining.values()),
             "lp": sum(initial_compensating.values()),
         }
+
+    def compare_strictness(self, other):
+        """The condition requiring more total compensation is stricter."""
+        return self.context.get("lpm", 0) > other.context.get("lpm", 0)
 
     @property
     def text(self):

--- a/envergo/hedges/regulations.py
+++ b/envergo/hedges/regulations.py
@@ -156,7 +156,7 @@ class NormandieMinLengthCondition(MinLengthCondition):
         destruction and compensation lengths, applies the cross-type reduction,
         and returns the sum across all types.
         """
-        coefficients = self.catalog["effective_coefficients"]
+        coefficients = self.criterion_evaluator.effective_coefficients
         destruction, compensation = compute_lengths_per_type(
             self.hedge_data.hedges_to_remove(), coefficients
         )
@@ -470,7 +470,7 @@ class NormandieQualityCondition(BaseQualityCondition):
 
     def get_amounts_to_compensate(self):
         """Compute LC from effective per-hedge coefficients."""
-        coefficients = self.catalog["effective_coefficients"]
+        coefficients = self.criterion_evaluator.effective_coefficients
         _, compensation = compute_lengths_per_type(
             self.hedge_data.hedges_to_remove(), coefficients
         )
@@ -500,7 +500,7 @@ class NormandieQualityCondition(BaseQualityCondition):
         LPm_r — reduced minimum per type (after cross-type reduction),
         lpm/reduced_lpm — scalar totals, lm/lp — scalar remaining/planted.
         """
-        coefficients = self.catalog["effective_coefficients"]
+        coefficients = self.criterion_evaluator.effective_coefficients
         destruction, _ = compute_lengths_per_type(
             self.hedge_data.hedges_to_remove(), coefficients
         )
@@ -587,7 +587,7 @@ class RUQualityCondition(BaseQualityCondition):
 
     def get_amounts_to_compensate(self):
         """Per-hedge compensation amounts from effective coefficients."""
-        coefficients = self.catalog["effective_coefficients"]
+        coefficients = self.criterion_evaluator.effective_coefficients
         lc = defaultdict(float)
         for hedge in self.hedge_data.hedges_to_remove():
             if hedge.id in coefficients:
@@ -678,7 +678,7 @@ class StrenghteningCondition(PlantationCondition):
 
     def compute_lpm(self):
         """Compute the total compensation length from effective per-hedge coefficients."""
-        coefficients = self.catalog.get("effective_coefficients", {})
+        coefficients = self.criterion_evaluator.effective_coefficients
         _, compensation = compute_lengths_per_type(
             self.hedge_data.hedges_to_remove(), coefficients
         )
@@ -831,32 +831,27 @@ class PlantationConditionMixin:
             f"Implement the `{type(self).__name__}.get_replantation_coefficient` method."
         )
 
+    @property
+    def effective_coefficients(self):
+        """Per-hedge compensation coefficients used by plantation conditions.
+
+        Returns a ``{hedge_id: float}`` dict mapping each hedge-to-remove to
+        its compensation multiplier. Override in evaluators whose conditions
+        depend on per-hedge coefficients.
+        """
+        return {}
+
     def plantation_evaluate(self, hedge_data, R, catalog=None):
         """Evaluate all plantation conditions for this evaluator.
 
         Returns an empty list when the evaluator's result_code is in
         plantation_skip_results — those states mean no plantation obligation
         exists for this evaluator, so conditions should not be created at all.
-
-        Otherwise, creates a catalog copy with an effective_coefficients key:
-        reads from {slug}_effective_coefficients if the evaluator wrote
-        adjusted values via get_post_evaluate_data(), otherwise falls
-        back to the raw per_hedge_coefficients.
-
-        The reason we have to do this is that each evaluator may generate different
-        coefficients.
         """
         if self.result_code in self.plantation_skip_results:
             return []
 
         catalog = dict(catalog or {})
-        slug_key = f"{self.slug}_effective_coefficients"
-        if slug_key in self.catalog:
-            catalog["effective_coefficients"] = self.catalog[slug_key]
-        elif "per_hedge_coefficients" in catalog:
-            catalog["effective_coefficients"] = catalog["per_hedge_coefficients"]
-        else:
-            catalog["effective_coefficients"] = {}
         return [
             condition(hedge_data, R, self, catalog).evaluate()
             for condition in self.plantation_conditions

--- a/envergo/hedges/services.py
+++ b/envergo/hedges/services.py
@@ -395,8 +395,7 @@ class PlantationEvaluator:
             return 0
 
         return [
-            max(group, key=cmp_to_key(compare_strictness))
-            for group in groups.values()
+            max(group, key=cmp_to_key(compare_strictness)) for group in groups.values()
         ]
 
     def find_condition(self, condition_cls, evaluator=None):

--- a/envergo/hedges/services.py
+++ b/envergo/hedges/services.py
@@ -289,6 +289,9 @@ class PlantationEvaluator:
 
     @property
     def conditions(self):
+        """Deduplicated subset — when several evaluators produce the same condition
+        class, only the strictest is kept. See ``all_conditions`` for the full list.
+        """
         if not hasattr(self, "_conditions"):
             self.evaluate()
 
@@ -296,10 +299,8 @@ class PlantationEvaluator:
 
     @property
     def all_conditions(self):
-        """All evaluated conditions, including duplicates across evaluators.
-
-        Per-regulation views use this to show each evaluator's own conditions.
-        The ``conditions`` property returns the deduplicated list.
+        """Full list before deduplication, used when the caller needs to
+        disambiguate by evaluator. See ``conditions`` for the deduplicated subset.
         """
         if not hasattr(self, "_all_conditions"):
             self.evaluate()
@@ -330,7 +331,7 @@ class PlantationEvaluator:
         return f"{self.moulinette.result}_{self.result}"
 
     def evaluate(self):
-        """Returns if the plantation is compliant with the regulation"""
+        """Populate ``_all_conditions``, ``_conditions`` (deduplicated), and ``_result``."""
 
         R = self.replantation_coefficient
         conditions = []
@@ -364,46 +365,41 @@ class PlantationEvaluator:
                 MinLengthCondition(self.hedge_data, R, None, None).evaluate()
             )
 
-        all_displayable = [
-            c for c in conditions if c.result is not None and c.must_display()
-        ]
-        self._all_conditions = sorted(all_displayable, key=attrgetter("order"))
-        self._conditions = sorted(
-            self.deduplicate_conditions(all_displayable), key=attrgetter("order")
+        all_displayable = sorted(
+            [c for c in conditions if c.result is not None and c.must_display()],
+            key=attrgetter("order"),
         )
+        self._all_conditions = all_displayable
+        self._conditions = self.deduplicate_conditions(all_displayable)
         self._result = (
             PlantationResults.Adequate.value
             if len(self.invalid_conditions) == 0
             else PlantationResults.Inadequate.value
         )
 
-    def deduplicate_conditions(self, conditions):
-        """Keep only the strictest instance of each condition class.
-
-        Groups conditions by type and selects the strictest from each group
-        using is_stricter_than as a pairwise comparator.
+    @staticmethod
+    def deduplicate_conditions(conditions):
+        """When all conditions in a group tie (no compare_strictness override),
+        the first one in evaluator iteration order wins.
         """
         groups = defaultdict(list)
-        for c in conditions:
-            groups[type(c)].append(c)
+        for condition in conditions:
+            groups[type(condition)].append(condition)
 
-        def compare_strictness(a, b):
+        def strictness_cmp(a, b):
             if a.is_stricter_than(b):
                 return 1
             if b.is_stricter_than(a):
                 return -1
             return 0
 
-        return [
-            max(group, key=cmp_to_key(compare_strictness)) for group in groups.values()
-        ]
+        return [max(group, key=cmp_to_key(strictness_cmp)) for group in groups.values()]
 
     def find_condition(self, condition_cls, evaluator=None):
-        """Find an evaluated condition by type, optionally filtering by evaluator.
-
-        Searches the full (non-deduplicated) condition list so that
-        per-regulation views can find conditions from a specific evaluator
-        even when that condition was removed from the global list.
+        """Searches ``all_conditions`` so per-regulation views can locate a
+        specific evaluator's condition even after deduplication. Evaluator
+        filtering uses identity (``is``), so caller and condition must share
+        the same moulinette instance.
         """
         for condition in self.all_conditions:
             if not isinstance(condition, condition_cls):

--- a/envergo/hedges/services.py
+++ b/envergo/hedges/services.py
@@ -1,6 +1,8 @@
+from collections import defaultdict
 from dataclasses import dataclass
 from decimal import Decimal as D
 from enum import Enum
+from functools import cmp_to_key
 from itertools import product
 from operator import attrgetter
 from types import SimpleNamespace
@@ -293,6 +295,18 @@ class PlantationEvaluator:
         return self._conditions
 
     @property
+    def all_conditions(self):
+        """All evaluated conditions, including duplicates across evaluators.
+
+        Per-regulation views use this to show each evaluator's own conditions.
+        The ``conditions`` property returns the deduplicated list.
+        """
+        if not hasattr(self, "_all_conditions"):
+            self.evaluate()
+
+        return self._all_conditions
+
+    @property
     def global_result(self):
         """Return the project result combining both removal and plantation.
 
@@ -350,23 +364,49 @@ class PlantationEvaluator:
                 MinLengthCondition(self.hedge_data, R, None, None).evaluate()
             )
 
-        conditions = [
+        all_displayable = [
             c for c in conditions if c.result is not None and c.must_display()
         ]
-        self._conditions = sorted(conditions, key=attrgetter("order"))
+        self._all_conditions = sorted(all_displayable, key=attrgetter("order"))
+        self._conditions = sorted(
+            self.deduplicate_conditions(all_displayable), key=attrgetter("order")
+        )
         self._result = (
             PlantationResults.Adequate.value
             if len(self.invalid_conditions) == 0
             else PlantationResults.Inadequate.value
         )
 
+    def deduplicate_conditions(self, conditions):
+        """Keep only the strictest instance of each condition class.
+
+        Groups conditions by type and selects the strictest from each group
+        using is_stricter_than as a pairwise comparator.
+        """
+        groups = defaultdict(list)
+        for c in conditions:
+            groups[type(c)].append(c)
+
+        def compare_strictness(a, b):
+            if a.is_stricter_than(b):
+                return 1
+            if b.is_stricter_than(a):
+                return -1
+            return 0
+
+        return [
+            max(group, key=cmp_to_key(compare_strictness))
+            for group in groups.values()
+        ]
+
     def find_condition(self, condition_cls, evaluator=None):
         """Find an evaluated condition by type, optionally filtering by evaluator.
 
-        Evaluator filtering uses identity (``is``), which requires both this
-        evaluator and the caller to share the same moulinette instance.
+        Searches the full (non-deduplicated) condition list so that
+        per-regulation views can find conditions from a specific evaluator
+        even when that condition was removed from the global list.
         """
-        for condition in self.conditions:
+        for condition in self.all_conditions:
             if not isinstance(condition, condition_cls):
                 continue
             if evaluator is None or condition.criterion_evaluator is evaluator:

--- a/envergo/hedges/tests/conftest.py
+++ b/envergo/hedges/tests/conftest.py
@@ -10,7 +10,9 @@ from envergo.moulinette.tests.utils import (
 
 
 def make_mock_evaluator(
-    single_procedure=False, result_code="soumis", ep_bonus=None,
+    single_procedure=False,
+    result_code="soumis",
+    ep_bonus=None,
     effective_coefficients=None,
 ):
     """Create a mock criterion evaluator.
@@ -20,7 +22,9 @@ def make_mock_evaluator(
     ev = Mock()
     ev.moulinette.config.single_procedure = single_procedure
     ev.result_code = result_code
-    ev.effective_coefficients = effective_coefficients if effective_coefficients is not None else {}
+    ev.effective_coefficients = (
+        effective_coefficients if effective_coefficients is not None else {}
+    )
     if ep_bonus is not None:
         ev.get_ep_ru_bonus.return_value = ep_bonus
     return ev

--- a/envergo/hedges/tests/conftest.py
+++ b/envergo/hedges/tests/conftest.py
@@ -9,7 +9,10 @@ from envergo.moulinette.tests.utils import (
 )
 
 
-def make_mock_evaluator(single_procedure=False, result_code="soumis", ep_bonus=None):
+def make_mock_evaluator(
+    single_procedure=False, result_code="soumis", ep_bonus=None,
+    effective_coefficients=None,
+):
     """Create a mock criterion evaluator.
 
     Set ``ep_bonus`` to wire up ``get_ep_ru_bonus`` (needed for RU tests).
@@ -17,6 +20,7 @@ def make_mock_evaluator(single_procedure=False, result_code="soumis", ep_bonus=N
     ev = Mock()
     ev.moulinette.config.single_procedure = single_procedure
     ev.result_code = result_code
+    ev.effective_coefficients = effective_coefficients if effective_coefficients is not None else {}
     if ep_bonus is not None:
         ev.get_ep_ru_bonus.return_value = ep_bonus
     return ev

--- a/envergo/hedges/tests/test_calvados_quality_condition.py
+++ b/envergo/hedges/tests/test_calvados_quality_condition.py
@@ -212,13 +212,17 @@ def test_calvados_quality_condition_l350(hedge_data):
     }
     catalog = {"aggregated_r": 2.0}
 
-    evaluator = Mock(result_code="dispense_L350", effective_coefficients=per_hedge_coefficients)
+    evaluator = Mock(
+        result_code="dispense_L350", effective_coefficients=per_hedge_coefficients
+    )
     evaluator.moulinette.config.single_procedure = False
     condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
     condition.evaluate()
     assert condition.result
 
-    evaluator = Mock(result_code="a_verifier_L350", effective_coefficients=per_hedge_coefficients)
+    evaluator = Mock(
+        result_code="a_verifier_L350", effective_coefficients=per_hedge_coefficients
+    )
     evaluator.moulinette.config.single_procedure = False
     condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
     condition.evaluate()
@@ -253,7 +257,9 @@ class TestNormandieQualityConditionCompensation:
 
     def test_same_type_fills_deficit(self):
         """Same-type planted hedges fill deficit at rate 1.0."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"mixte": (100, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -263,7 +269,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert condition.result
@@ -273,7 +282,9 @@ class TestNormandieQualityConditionCompensation:
 
         Need ~80m arbustive. Plant ~70m mixte → 70/0.8 = 87.5m effective.
         """
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"arbustive": (80, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -283,14 +294,19 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert condition.result
 
     def test_cross_type_insufficient_at_reduced_rate(self):
         """60m mixte at 0.8 rate → 75m effective, not enough for 80m arbustive."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"arbustive": (80, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -300,14 +316,19 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert not condition.result
 
     def test_buissonnante_for_degradee_no_rate_reduction(self):
         """Buissonnante compensating degradee uses rate 1.0 (exception to 0.8 rule)."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"degradee": (20, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -317,14 +338,19 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert condition.result
 
     def test_buissonnante_for_degradee_insufficient_without_bonus(self):
         """15m buissonnante at rate 1.0 cannot fill 20m degradee deficit."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"degradee": (20, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -334,7 +360,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert not condition.result
@@ -345,7 +374,9 @@ class TestNormandieQualityConditionCompensation:
 
         20m arbustive / 0.8 = 25m effective → fills 20m degradee.
         """
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"degradee": (20, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -355,7 +386,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert condition.result
@@ -379,7 +413,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 2.0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            2.0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert "réduite" in condition.hint
@@ -401,7 +438,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 1.0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            1.0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert "réduite" not in condition.hint
@@ -419,7 +459,10 @@ class TestNormandieQualityConditionCompensation:
         )
         hedge_data = HedgeDataFactory(hedges=to_remove)
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert not condition.result
@@ -431,7 +474,9 @@ class TestNormandieQualityConditionCompensation:
 
     def test_text_valid_when_passes(self):
         """When condition passes, text is the valid message."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"mixte": (100, 1.0)}
+        )
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -441,7 +486,10 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
+            catalog,
         )
         condition.evaluate()
         assert condition.result
@@ -449,18 +497,26 @@ class TestNormandieQualityConditionCompensation:
 
     def test_l350_dispense_forces_pass(self):
         """L350 dispense result code forces condition to pass."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"mixte": (100, 1.0)}
+        )
         hedge_data = HedgeDataFactory(hedges=to_remove)
-        evaluator = make_mock_evaluator(result_code="dispense_L350", effective_coefficients=coefficients)
+        evaluator = make_mock_evaluator(
+            result_code="dispense_L350", effective_coefficients=coefficients
+        )
         condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
         condition.evaluate()
         assert condition.result
 
     def test_l350_a_verifier_forces_pass(self):
         """L350 a_verifier result code forces condition to pass."""
-        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
+            {"mixte": (100, 1.0)}
+        )
         hedge_data = HedgeDataFactory(hedges=to_remove)
-        evaluator = make_mock_evaluator(result_code="a_verifier_L350", effective_coefficients=coefficients)
+        evaluator = make_mock_evaluator(
+            result_code="a_verifier_L350", effective_coefficients=coefficients
+        )
         condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
         condition.evaluate()
         assert condition.result

--- a/envergo/hedges/tests/test_calvados_quality_condition.py
+++ b/envergo/hedges/tests/test_calvados_quality_condition.py
@@ -186,8 +186,8 @@ def test_calvados_quality_condition(hedge_data):
         "D5": 2.0,
         "D6": 1.0,
     }
-    catalog = {"effective_coefficients": per_hedge_coefficients, "aggregated_r": 2.0}
-    evaluator = Mock()
+    catalog = {"aggregated_r": 2.0}
+    evaluator = Mock(effective_coefficients=per_hedge_coefficients)
     evaluator.moulinette.config.single_procedure = False
     condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
     condition.evaluate()
@@ -210,15 +210,15 @@ def test_calvados_quality_condition_l350(hedge_data):
         "D5": 2.0,
         "D6": 1.0,
     }
-    catalog = {"effective_coefficients": per_hedge_coefficients, "aggregated_r": 2.0}
+    catalog = {"aggregated_r": 2.0}
 
-    evaluator = Mock(result_code="dispense_L350")
+    evaluator = Mock(result_code="dispense_L350", effective_coefficients=per_hedge_coefficients)
     evaluator.moulinette.config.single_procedure = False
     condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
     condition.evaluate()
     assert condition.result
 
-    evaluator = Mock(result_code="a_verifier_L350")
+    evaluator = Mock(result_code="a_verifier_L350", effective_coefficients=per_hedge_coefficients)
     evaluator.moulinette.config.single_procedure = False
     condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
     condition.evaluate()
@@ -241,11 +241,8 @@ def make_hedges_and_catalog(coefficients_by_type, aggregated_r=1.0):
         hedges.append(hedge)
         if coeff > 0:
             per_hedge_coefficients[hedge.id] = coeff
-    catalog = {
-        "effective_coefficients": per_hedge_coefficients,
-        "aggregated_r": aggregated_r,
-    }
-    return hedges, catalog
+    catalog = {"aggregated_r": aggregated_r}
+    return hedges, per_hedge_coefficients, catalog
 
 
 # --- Comprehensive NormandieQualityCondition tests (public interface) ---
@@ -256,7 +253,7 @@ class TestNormandieQualityConditionCompensation:
 
     def test_same_type_fills_deficit(self):
         """Same-type planted hedges fill deficit at rate 1.0."""
-        to_remove, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -266,7 +263,7 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert condition.result
@@ -276,7 +273,7 @@ class TestNormandieQualityConditionCompensation:
 
         Need ~80m arbustive. Plant ~70m mixte → 70/0.8 = 87.5m effective.
         """
-        to_remove, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -286,14 +283,14 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert condition.result
 
     def test_cross_type_insufficient_at_reduced_rate(self):
         """60m mixte at 0.8 rate → 75m effective, not enough for 80m arbustive."""
-        to_remove, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"arbustive": (80, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -303,14 +300,14 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert not condition.result
 
     def test_buissonnante_for_degradee_no_rate_reduction(self):
         """Buissonnante compensating degradee uses rate 1.0 (exception to 0.8 rule)."""
-        to_remove, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -320,14 +317,14 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert condition.result
 
     def test_buissonnante_for_degradee_insufficient_without_bonus(self):
         """15m buissonnante at rate 1.0 cannot fill 20m degradee deficit."""
-        to_remove, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -337,7 +334,7 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert not condition.result
@@ -348,7 +345,7 @@ class TestNormandieQualityConditionCompensation:
 
         20m arbustive / 0.8 = 25m effective → fills 20m degradee.
         """
-        to_remove, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"degradee": (20, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -358,7 +355,7 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert condition.result
@@ -370,7 +367,7 @@ class TestNormandieQualityConditionCompensation:
         deficit can be reduced by 0.8 rate. The hint should mention both
         the full and reduced amounts.
         """
-        to_remove, catalog = make_hedges_and_catalog(
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
             {"mixte": (100, 2.0), "arbustive": (50, 2.0)}, aggregated_r=2.0
         )
         hedge_data = HedgeDataFactory(
@@ -382,7 +379,7 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 2.0, make_mock_evaluator(), catalog
+            hedge_data, 2.0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert "réduite" in condition.hint
@@ -392,7 +389,7 @@ class TestNormandieQualityConditionCompensation:
 
         Only mixte hedges → no 0.8 reduction applies.
         """
-        to_remove, catalog = make_hedges_and_catalog(
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
             {"mixte": (100, 1.0)}, aggregated_r=1.0
         )
         hedge_data = HedgeDataFactory(
@@ -404,14 +401,14 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 1.0, make_mock_evaluator(), catalog
+            hedge_data, 1.0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert "réduite" not in condition.hint
 
     def test_text_lists_deficit_per_type(self):
         """When condition fails, text lists missing amounts for each type."""
-        to_remove, catalog = make_hedges_and_catalog(
+        to_remove, coefficients, catalog = make_hedges_and_catalog(
             {
                 "mixte": (10, 1.0),
                 "alignement": (5, 1.0),
@@ -422,7 +419,7 @@ class TestNormandieQualityConditionCompensation:
         )
         hedge_data = HedgeDataFactory(hedges=to_remove)
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert not condition.result
@@ -434,7 +431,7 @@ class TestNormandieQualityConditionCompensation:
 
     def test_text_valid_when_passes(self):
         """When condition passes, text is the valid message."""
-        to_remove, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
         hedge_data = HedgeDataFactory(
             hedges=[
                 *to_remove,
@@ -444,7 +441,7 @@ class TestNormandieQualityConditionCompensation:
             ]
         )
         condition = NormandieQualityCondition(
-            hedge_data, 0, make_mock_evaluator(), catalog
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients), catalog
         )
         condition.evaluate()
         assert condition.result
@@ -452,18 +449,18 @@ class TestNormandieQualityConditionCompensation:
 
     def test_l350_dispense_forces_pass(self):
         """L350 dispense result code forces condition to pass."""
-        to_remove, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
         hedge_data = HedgeDataFactory(hedges=to_remove)
-        evaluator = make_mock_evaluator(result_code="dispense_L350")
+        evaluator = make_mock_evaluator(result_code="dispense_L350", effective_coefficients=coefficients)
         condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
         condition.evaluate()
         assert condition.result
 
     def test_l350_a_verifier_forces_pass(self):
         """L350 a_verifier result code forces condition to pass."""
-        to_remove, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
+        to_remove, coefficients, catalog = make_hedges_and_catalog({"mixte": (100, 1.0)})
         hedge_data = HedgeDataFactory(hedges=to_remove)
-        evaluator = make_mock_evaluator(result_code="a_verifier_L350")
+        evaluator = make_mock_evaluator(result_code="a_verifier_L350", effective_coefficients=coefficients)
         condition = NormandieQualityCondition(hedge_data, 0, evaluator, catalog)
         condition.evaluate()
         assert condition.result

--- a/envergo/hedges/tests/test_regulations.py
+++ b/envergo/hedges/tests/test_regulations.py
@@ -332,14 +332,13 @@ def test_hedge_quality_should_not_be_sufficient_ru(ep_criterion_evaluator_ru):
     }
 
 
-def test_strengthening_condition(calvados_hedge_data, ep_criterion_evaluator):
+def test_strengthening_condition(calvados_hedge_data):
     hedge_data = calvados_hedge_data
-    catalog = {
-        "reimplantation": "replantation",
-        "effective_coefficients": {"D1": 1.0, "D2": 1.0, "D3": 1.0},
-    }
+    coefficients = {"D1": 1.0, "D2": 1.0, "D3": 1.0}
+    catalog = {"reimplantation": "replantation"}
+    evaluator = make_mock_evaluator(effective_coefficients=coefficients)
 
-    condition = StrenghteningCondition(hedge_data, 1.0, ep_criterion_evaluator, catalog)
+    condition = StrenghteningCondition(hedge_data, 1.0, evaluator, catalog)
     condition.evaluate()
     assert condition.result
     assert condition.context["strengthening_length"] == 0.0
@@ -348,7 +347,7 @@ def test_strengthening_condition(calvados_hedge_data, ep_criterion_evaluator):
     hedge_data.data[-1]["additionalData"]["mode_plantation"] = "renforcement"
     hedge_data.data[-2]["additionalData"]["mode_plantation"] = "reconnexion"
 
-    condition = StrenghteningCondition(hedge_data, 1.0, ep_criterion_evaluator, catalog)
+    condition = StrenghteningCondition(hedge_data, 1.0, evaluator, catalog)
     condition.evaluate()
     lpm = condition.compute_lpm()
     assert not condition.result
@@ -680,95 +679,3 @@ class TestAisneQualityConditionSubstitution:
         assert condition.result
 
 
-class SpyCondition(MinLengthCondition):
-    """Condition that records the catalog it receives.
-
-    plantation_evaluate() builds a private catalog copy with injected keys
-    before passing it to each condition. Real conditions consume the catalog
-    internally, so the only way to assert on what was injected is to
-    intercept the catalog at construction time.
-    """
-
-    captured_catalogs = []
-
-    def evaluate(self):
-        SpyCondition.captured_catalogs.append(dict(self.catalog))
-        self.result = True
-        return self
-
-
-class TestPlantationEvaluateInjection:
-    """Test that plantation_evaluate injects effective_coefficients correctly."""
-
-    def setup_method(self):
-        SpyCondition.captured_catalogs = []
-
-    def make_evaluator(self, slug, catalog, plantation_conditions=None):
-        """Build a mock evaluator with the PlantationConditionMixin interface."""
-        ev = Mock()
-        ev.slug = slug
-        ev.catalog = catalog
-        ev.plantation_conditions = plantation_conditions or [SpyCondition]
-        ev.plantation_skip_results = frozenset()
-        ev.result_code = "soumis"
-        ev.get_replantation_coefficient.return_value = 1.0
-
-        from envergo.hedges.regulations import PlantationConditionMixin
-
-        ev.plantation_evaluate = PlantationConditionMixin.plantation_evaluate.__get__(
-            ev
-        )
-        return ev
-
-    def test_slug_key_takes_precedence(self):
-        """When {slug}_effective_coefficients exists, it is injected."""
-        raw = {"h1": 1.0}
-        effective = {"h1": 1.5}
-        moulinette_catalog = {
-            "per_hedge_coefficients": raw,
-            "myslug_effective_coefficients": effective,
-        }
-        ev = self.make_evaluator("myslug", moulinette_catalog)
-        hedge_data = HedgeDataFactory(hedges=[])
-
-        ev.plantation_evaluate(hedge_data, 1.0, {"per_hedge_coefficients": raw})
-
-        captured = SpyCondition.captured_catalogs[0]
-        assert captured["effective_coefficients"] is effective
-
-    def test_fallback_to_raw_when_no_slug_key(self):
-        """Without a slug key, per_hedge_coefficients becomes effective."""
-        raw = {"h1": 1.0}
-        moulinette_catalog = {}
-        ev = self.make_evaluator("myslug", moulinette_catalog)
-        hedge_data = HedgeDataFactory(hedges=[])
-
-        ev.plantation_evaluate(hedge_data, 1.0, {"per_hedge_coefficients": raw})
-
-        captured = SpyCondition.captured_catalogs[0]
-        assert captured["effective_coefficients"] is raw
-
-    def test_no_coefficients_at_all(self):
-        """When neither key exists, effective_coefficients defaults to empty dict."""
-        ev = self.make_evaluator("myslug", {})
-        hedge_data = HedgeDataFactory(hedges=[])
-
-        ev.plantation_evaluate(hedge_data, 1.0, {})
-
-        captured = SpyCondition.captured_catalogs[0]
-        assert captured["effective_coefficients"] == {}
-
-    def test_original_catalog_not_mutated(self):
-        """The passed-in catalog dict is not modified."""
-        raw = {"h1": 1.0}
-        effective = {"h1": 2.0}
-        moulinette_catalog = {"myslug_effective_coefficients": effective}
-        ev = self.make_evaluator("myslug", moulinette_catalog)
-        hedge_data = HedgeDataFactory(hedges=[])
-
-        original_catalog = {"per_hedge_coefficients": raw}
-        original_keys = set(original_catalog.keys())
-
-        ev.plantation_evaluate(hedge_data, 1.0, original_catalog)
-
-        assert set(original_catalog.keys()) == original_keys

--- a/envergo/hedges/tests/test_regulations.py
+++ b/envergo/hedges/tests/test_regulations.py
@@ -685,6 +685,7 @@ class TestIsStricterThan:
     """Tests for the is_stricter_than / compare_strictness protocol."""
 
     def test_different_classes_raises_type_error(self):
+        """Comparing different condition classes raises TypeError."""
         hedge_data = HedgeDataFactory(
             hedges=[
                 HedgeFactory(length=100),
@@ -721,6 +722,7 @@ class TestIsStricterThan:
         assert not cond_b.is_stricter_than(cond_a)
 
     def test_ru_min_length_higher_requirement_is_stricter(self):
+        """Higher local R produces a longer minimum — the stricter condition."""
         hedge_data = HedgeDataFactory(
             hedges=[
                 HedgeFactory(length=100),
@@ -741,6 +743,7 @@ class TestIsStricterThan:
         assert not cond_low.is_stricter_than(cond_high)
 
     def test_ru_min_length_equal_requirement_neither_stricter(self):
+        """Same R on both conditions — neither claims stricter."""
         hedge_data = HedgeDataFactory(
             hedges=[
                 HedgeFactory(length=100),
@@ -759,6 +762,7 @@ class TestIsStricterThan:
         assert not cond_b.is_stricter_than(cond_a)
 
     def test_ru_quality_higher_lpm_is_stricter(self):
+        """Higher per-hedge coefficients produce a larger LPm — the stricter condition."""
         to_remove = HedgeFactory(length=100, additionalData__type_haie="buissonnante")
         hedge_data = HedgeDataFactory(
             hedges=[

--- a/envergo/hedges/tests/test_regulations.py
+++ b/envergo/hedges/tests/test_regulations.py
@@ -759,9 +759,7 @@ class TestIsStricterThan:
         assert not cond_b.is_stricter_than(cond_a)
 
     def test_ru_quality_higher_lpm_is_stricter(self):
-        to_remove = HedgeFactory(
-            length=100, additionalData__type_haie="buissonnante"
-        )
+        to_remove = HedgeFactory(length=100, additionalData__type_haie="buissonnante")
         hedge_data = HedgeDataFactory(
             hedges=[
                 to_remove,
@@ -808,5 +806,3 @@ class TestIsStricterThan:
 
         assert not cond_a.is_stricter_than(cond_b)
         assert not cond_b.is_stricter_than(cond_a)
-
-

--- a/envergo/hedges/tests/test_regulations.py
+++ b/envergo/hedges/tests/test_regulations.py
@@ -10,6 +10,8 @@ from envergo.hedges.regulations import (
     EssencesBocageresCondition,
     MinLengthCondition,
     PacParcelCondition,
+    RUMinLengthCondition,
+    RUQualityCondition,
     SafetyCondition,
     StrenghteningCondition,
     TreeAlignmentsCondition,
@@ -677,5 +679,134 @@ class TestAisneQualityConditionSubstitution:
         condition = AisneQualityCondition(hedge_data, 1.0, evaluator)
         condition.evaluate()
         assert condition.result
+
+
+class TestIsStricterThan:
+    """Tests for the is_stricter_than / compare_strictness protocol."""
+
+    def test_different_classes_raises_type_error(self):
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(length=100),
+                HedgeFactory(to_plant=True, length=200),
+            ]
+        )
+        evaluator = make_mock_evaluator(single_procedure=True)
+        evaluator.get_replantation_coefficient.return_value = 1.0
+
+        min_length = RUMinLengthCondition(hedge_data, 1.0, evaluator)
+        min_length.evaluate()
+        safety = SafetyCondition(hedge_data, 1.0, evaluator)
+        safety.evaluate()
+
+        with pytest.raises(TypeError):
+            min_length.is_stricter_than(safety)
+
+    def test_base_class_returns_false(self):
+        """Non-overridden compare_strictness returns False (no deduplication)."""
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(length=100),
+                HedgeFactory(to_plant=True, length=200),
+            ]
+        )
+        evaluator = make_mock_evaluator(single_procedure=True)
+
+        cond_a = MinLengthCondition(hedge_data, 1.0, evaluator)
+        cond_a.evaluate()
+        cond_b = MinLengthCondition(hedge_data, 1.0, evaluator)
+        cond_b.evaluate()
+
+        assert not cond_a.is_stricter_than(cond_b)
+        assert not cond_b.is_stricter_than(cond_a)
+
+    def test_ru_min_length_higher_requirement_is_stricter(self):
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(length=100),
+                HedgeFactory(to_plant=True, length=200),
+            ]
+        )
+        evaluator_low = make_mock_evaluator(single_procedure=True)
+        evaluator_low.get_replantation_coefficient.return_value = 1.0
+        evaluator_high = make_mock_evaluator(single_procedure=True)
+        evaluator_high.get_replantation_coefficient.return_value = 1.5
+
+        cond_low = RUMinLengthCondition(hedge_data, 1.0, evaluator_low)
+        cond_low.evaluate()
+        cond_high = RUMinLengthCondition(hedge_data, 1.5, evaluator_high)
+        cond_high.evaluate()
+
+        assert cond_high.is_stricter_than(cond_low)
+        assert not cond_low.is_stricter_than(cond_high)
+
+    def test_ru_min_length_equal_requirement_neither_stricter(self):
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(length=100),
+                HedgeFactory(to_plant=True, length=200),
+            ]
+        )
+        evaluator = make_mock_evaluator(single_procedure=True)
+        evaluator.get_replantation_coefficient.return_value = 1.0
+
+        cond_a = RUMinLengthCondition(hedge_data, 1.0, evaluator)
+        cond_a.evaluate()
+        cond_b = RUMinLengthCondition(hedge_data, 1.0, evaluator)
+        cond_b.evaluate()
+
+        assert not cond_a.is_stricter_than(cond_b)
+        assert not cond_b.is_stricter_than(cond_a)
+
+    def test_ru_quality_higher_lpm_is_stricter(self):
+        to_remove = HedgeFactory(
+            length=100, additionalData__type_haie="buissonnante"
+        )
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                to_remove,
+                HedgeFactory(
+                    to_plant=True,
+                    length=200,
+                    additionalData__type_haie="buissonnante",
+                ),
+            ]
+        )
+        hedge_id = to_remove.id
+        evaluator_low = make_mock_evaluator(
+            single_procedure=True,
+            effective_coefficients={hedge_id: 1.0},
+        )
+        evaluator_high = make_mock_evaluator(
+            single_procedure=True,
+            effective_coefficients={hedge_id: 1.5},
+        )
+
+        cond_low = RUQualityCondition(hedge_data, 1.0, evaluator_low)
+        cond_low.evaluate()
+        cond_high = RUQualityCondition(hedge_data, 1.5, evaluator_high)
+        cond_high.evaluate()
+
+        assert cond_high.is_stricter_than(cond_low)
+        assert not cond_low.is_stricter_than(cond_high)
+
+    def test_safety_uses_base_behavior(self):
+        """SafetyCondition is stateless — neither claims stricter, one is picked arbitrarily."""
+        hedge_data = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(length=100),
+                HedgeFactory(to_plant=True, length=200),
+            ]
+        )
+        evaluator_a = make_mock_evaluator(single_procedure=True)
+        evaluator_b = make_mock_evaluator(single_procedure=True)
+
+        cond_a = SafetyCondition(hedge_data, 1.0, evaluator_a)
+        cond_a.evaluate()
+        cond_b = SafetyCondition(hedge_data, 1.0, evaluator_b)
+        cond_b.evaluate()
+
+        assert not cond_a.is_stricter_than(cond_b)
+        assert not cond_b.is_stricter_than(cond_a)
 
 

--- a/envergo/hedges/tests/test_ru_quality_condition.py
+++ b/envergo/hedges/tests/test_ru_quality_condition.py
@@ -39,8 +39,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 2.0, "h2": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -55,8 +56,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert not condition.result
         assert condition.remaining[HedgeTypeBase.MIXTE] == pytest.approx(150, abs=1)
@@ -77,8 +79,9 @@ class TestRUQualityConditionCompensation:
                 ),
             ]
         )
-        catalog = {"effective_coefficients": {"h1": 2.5}}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients={"h1": 2.5}),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -97,8 +100,9 @@ class TestRUQualityConditionCompensation:
                 ),
             ]
         )
-        catalog = {"effective_coefficients": {"h1": 2.5}}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients={"h1": 2.5}),
+        )
         condition.evaluate()
         assert not condition.result
         assert condition.remaining[HedgeTypeBase.ARBUSTIVE] == pytest.approx(50, abs=1)
@@ -116,8 +120,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 1.5}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -134,8 +139,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 1.5}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -152,8 +158,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -168,8 +175,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert not condition.result
         assert condition.remaining[HedgeTypeBase.MIXTE] == pytest.approx(200, abs=1)
@@ -189,8 +197,9 @@ class TestRUQualityConditionCompensation:
         )
         # Only h2 has a coefficient — aa1 is excluded
         coefficients = {"h2": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
         assert HedgeTypeBase.ALIGNEMENT not in condition.remaining
@@ -208,8 +217,9 @@ class TestRUQualityConditionCompensation:
         )
         # h1 has R=1.5, h2 has R=2.0 → need ~150 + ~200 = ~350m
         coefficients = {"h1": 1.5, "h2": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert condition.result
 
@@ -225,8 +235,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         coefficients = {"h1": 1.5, "h2": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert not condition.result
         assert condition.remaining[HedgeTypeBase.MIXTE] > 0
@@ -246,8 +257,9 @@ class TestRUQualityConditionText:
             ]
         )
         coefficients = {"h1": 1.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert "convient" in condition.text
 
@@ -259,8 +271,9 @@ class TestRUQualityConditionText:
             ]
         )
         coefficients = {"h1": 2.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert "de haie arborée" in condition.text
 
@@ -274,8 +287,9 @@ class TestRUQualityConditionText:
             ]
         )
         coefficients = {"h1": 1.5}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert "de haie arbustive ou arborée" in condition.text
 
@@ -289,8 +303,9 @@ class TestRUQualityConditionText:
             ]
         )
         coefficients = {"h1": 1.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         assert "de haie buissonnante, arbustive ou arborée" in condition.text
 
@@ -306,8 +321,9 @@ class TestRUQualityConditionText:
             ]
         )
         coefficients = {"h1": 1.0, "h2": 1.0, "h3": 1.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         condition.evaluate()
         text = condition.text
         assert "arborée" in text
@@ -326,15 +342,15 @@ class TestRUQualityConditionMustDisplay:
             ]
         )
         coefficients = {"h1": 1.0}
-        catalog = {"effective_coefficients": coefficients}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(
+            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+        )
         assert condition.must_display()
 
     def test_no_display_when_nothing_to_compensate(self):
         """Hidden when no hedges need compensation."""
         hedge_data = HedgeDataFactory(hedges=[])
-        catalog = {"effective_coefficients": {}}
-        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator(), catalog)
+        condition = RUQualityCondition(hedge_data, 0, make_mock_evaluator())
         assert not condition.must_display()
 
     def test_no_display_when_all_coefficients_zero(self):
@@ -345,8 +361,7 @@ class TestRUQualityConditionMustDisplay:
             ]
         )
         coefficients = {"h1": 0.0}
-        catalog = {"effective_coefficients": coefficients}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(ep_bonus=0.0), catalog
+            hedge_data, 0, make_mock_evaluator(ep_bonus=0.0, effective_coefficients=coefficients),
         )
         assert not condition.must_display()

--- a/envergo/hedges/tests/test_ru_quality_condition.py
+++ b/envergo/hedges/tests/test_ru_quality_condition.py
@@ -40,7 +40,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 2.0, "h2": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -57,7 +59,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert not condition.result
@@ -80,7 +84,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients={"h1": 2.5}),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients={"h1": 2.5}),
         )
         condition.evaluate()
         assert condition.result
@@ -101,7 +107,9 @@ class TestRUQualityConditionCompensation:
             ]
         )
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients={"h1": 2.5}),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients={"h1": 2.5}),
         )
         condition.evaluate()
         assert not condition.result
@@ -121,7 +129,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 1.5}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -140,7 +150,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 1.5}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -159,7 +171,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -176,7 +190,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert not condition.result
@@ -198,7 +214,9 @@ class TestRUQualityConditionCompensation:
         # Only h2 has a coefficient — aa1 is excluded
         coefficients = {"h2": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -218,7 +236,9 @@ class TestRUQualityConditionCompensation:
         # h1 has R=1.5, h2 has R=2.0 → need ~150 + ~200 = ~350m
         coefficients = {"h1": 1.5, "h2": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert condition.result
@@ -236,7 +256,9 @@ class TestRUQualityConditionCompensation:
         )
         coefficients = {"h1": 1.5, "h2": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert not condition.result
@@ -258,7 +280,9 @@ class TestRUQualityConditionText:
         )
         coefficients = {"h1": 1.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert "convient" in condition.text
@@ -272,7 +296,9 @@ class TestRUQualityConditionText:
         )
         coefficients = {"h1": 2.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert "de haie arborée" in condition.text
@@ -288,7 +314,9 @@ class TestRUQualityConditionText:
         )
         coefficients = {"h1": 1.5}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert "de haie arbustive ou arborée" in condition.text
@@ -304,7 +332,9 @@ class TestRUQualityConditionText:
         )
         coefficients = {"h1": 1.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         assert "de haie buissonnante, arbustive ou arborée" in condition.text
@@ -322,7 +352,9 @@ class TestRUQualityConditionText:
         )
         coefficients = {"h1": 1.0, "h2": 1.0, "h3": 1.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         condition.evaluate()
         text = condition.text
@@ -343,7 +375,9 @@ class TestRUQualityConditionMustDisplay:
         )
         coefficients = {"h1": 1.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(effective_coefficients=coefficients),
         )
         assert condition.must_display()
 
@@ -362,6 +396,8 @@ class TestRUQualityConditionMustDisplay:
         )
         coefficients = {"h1": 0.0}
         condition = RUQualityCondition(
-            hedge_data, 0, make_mock_evaluator(ep_bonus=0.0, effective_coefficients=coefficients),
+            hedge_data,
+            0,
+            make_mock_evaluator(ep_bonus=0.0, effective_coefficients=coefficients),
         )
         assert not condition.must_display()

--- a/envergo/hedges/tests/test_services.py
+++ b/envergo/hedges/tests/test_services.py
@@ -1,7 +1,12 @@
 import pytest
 
 from envergo.geodata.conftest import bizous_town_center, france_map  # noqa
-from envergo.hedges.regulations import MinLengthCondition
+from envergo.hedges.regulations import (
+    MinLengthCondition,
+    RUMinLengthCondition,
+    RUQualityCondition,
+    SafetyCondition,
+)
 from envergo.hedges.services import PlantationEvaluator
 from envergo.hedges.tests.factories import HedgeDataFactory
 from envergo.moulinette.models import MoulinetteHaie
@@ -183,3 +188,126 @@ def test_ep_dispense_excludes_conditions_from_result(ep_ru_criterion, ru_criteri
         and isinstance(c.criterion_evaluator, RegimeUniqueHaie)
     ]
     assert len(ru_min_length) == 1
+
+
+class TestConditionDeduplication:
+    """Tests for condition deduplication when multiple evaluators share condition classes."""
+
+    def test_global_conditions_are_deduplicated(self, ep_ru_criterion, ru_criterion):
+        """When both RU and EPRU are active, global conditions contains one of each class."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=50)],
+            reimplantation="replantation",
+        )
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        condition_types = [type(c) for c in evaluator.conditions]
+        assert condition_types.count(RUMinLengthCondition) == 1
+        assert condition_types.count(RUQualityCondition) == 1
+        assert condition_types.count(SafetyCondition) == 1
+
+    def test_strictest_condition_is_kept(self, ep_ru_criterion, ru_criterion):
+        """The deduplicated condition comes from EPRU (stricter coefficients)."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=50)],
+            reimplantation="replantation",
+        )
+
+        # Sanity check: EPRU should not be in dispense
+        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        min_length = next(
+            c for c in evaluator.conditions if isinstance(c, RUMinLengthCondition)
+        )
+        assert isinstance(min_length.criterion_evaluator, EspecesProtegeesRegimeUnique)
+
+    def test_all_conditions_contains_duplicates(self, ep_ru_criterion, ru_criterion):
+        """all_conditions retains both evaluators' conditions (no deduplication)."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=50)],
+            reimplantation="replantation",
+        )
+        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        all_types = [type(c) for c in evaluator.all_conditions]
+        assert all_types.count(RUMinLengthCondition) == 2
+        assert all_types.count(RUQualityCondition) == 2
+        assert all_types.count(SafetyCondition) == 2
+
+    def test_find_condition_uses_all_conditions(self, ep_ru_criterion, ru_criterion):
+        """find_condition can locate a specific evaluator's condition even after dedup."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=50)],
+            reimplantation="replantation",
+        )
+        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        ru_evaluator = moulinette.regime_unique_haie.regime_unique_haie.get_evaluator()
+        ep_evaluator = moulinette.ep.ep_regime_unique.get_evaluator()
+
+        ru_cond = evaluator.find_condition(RUMinLengthCondition, ru_evaluator)
+        ep_cond = evaluator.find_condition(RUMinLengthCondition, ep_evaluator)
+
+        assert ru_cond is not None
+        assert ep_cond is not None
+        assert ru_cond is not ep_cond
+        assert isinstance(ru_cond.criterion_evaluator, RegimeUniqueHaie)
+        assert isinstance(ep_cond.criterion_evaluator, EspecesProtegeesRegimeUnique)
+
+    def test_ep_dispense_no_deduplication_needed(self, ep_ru_criterion, ru_criterion):
+        """When EPRU is in dispense, only RU conditions exist — no duplicates."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=8)],
+            reimplantation="replantation",
+        )
+        assert moulinette.ep.ep_regime_unique.result_code == "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        all_types = [type(c) for c in evaluator.all_conditions]
+        assert all_types.count(RUMinLengthCondition) == 1
+        assert all_types.count(SafetyCondition) == 1
+
+        # conditions and all_conditions should be identical
+        assert evaluator.conditions == evaluator.all_conditions
+
+    def test_to_json_returns_deduplicated(self, ep_ru_criterion, ru_criterion):
+        """to_json serializes only the deduplicated conditions."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=50)],
+            reimplantation="replantation",
+        )
+        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+
+        json_data = evaluator.to_json()
+        labels = [item["label"] for item in json_data]
+        assert labels.count("Longueur de la haie plantée") == 1
+        assert labels.count("Type de haie plantée") == 1
+        assert labels.count("Sécurité") == 1

--- a/envergo/hedges/tests/test_services.py
+++ b/envergo/hedges/tests/test_services.py
@@ -193,73 +193,66 @@ def test_ep_dispense_excludes_conditions_from_result(ep_ru_criterion, ru_criteri
 class TestConditionDeduplication:
     """Tests for condition deduplication when multiple evaluators share condition classes."""
 
-    def test_global_conditions_are_deduplicated(self, ep_ru_criterion, ru_criterion):
-        """When both RU and EPRU are active, global conditions contains one of each class."""
+    @pytest.fixture
+    def evaluated(self, ep_ru_criterion, ru_criterion):
+        """PlantationEvaluator with both RU and EPRU active (no dispense)."""
         RUConfigHaieFactory()
         moulinette = make_moulinette_haie_with_density(
             density=60,
             hedges=[make_hedge_factory(length=50)],
             reimplantation="replantation",
         )
+        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
 
         evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
         evaluator.evaluate()
+        return moulinette, evaluator
+
+    @pytest.fixture
+    def evaluated_dispense(self, ep_ru_criterion, ru_criterion):
+        """PlantationEvaluator where EPRU is in dispense (short hedge)."""
+        RUConfigHaieFactory()
+        moulinette = make_moulinette_haie_with_density(
+            density=60,
+            hedges=[make_hedge_factory(length=8)],
+            reimplantation="replantation",
+        )
+        assert moulinette.ep.ep_regime_unique.result_code == "dispense"
+
+        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
+        evaluator.evaluate()
+        return moulinette, evaluator
+
+    def test_global_conditions_are_deduplicated(self, evaluated):
+        """When both RU and EPRU are active, conditions has one of each class."""
+        _moulinette, evaluator = evaluated
 
         condition_types = [type(c) for c in evaluator.conditions]
         assert condition_types.count(RUMinLengthCondition) == 1
         assert condition_types.count(RUQualityCondition) == 1
         assert condition_types.count(SafetyCondition) == 1
 
-    def test_strictest_condition_is_kept(self, ep_ru_criterion, ru_criterion):
+    def test_strictest_condition_is_kept(self, evaluated):
         """The deduplicated condition comes from EPRU (stricter coefficients)."""
-        RUConfigHaieFactory()
-        moulinette = make_moulinette_haie_with_density(
-            density=60,
-            hedges=[make_hedge_factory(length=50)],
-            reimplantation="replantation",
-        )
-
-        # Sanity check: EPRU should not be in dispense
-        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
-
-        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
-        evaluator.evaluate()
+        _moulinette, evaluator = evaluated
 
         min_length = next(
             c for c in evaluator.conditions if isinstance(c, RUMinLengthCondition)
         )
         assert isinstance(min_length.criterion_evaluator, EspecesProtegeesRegimeUnique)
 
-    def test_all_conditions_contains_duplicates(self, ep_ru_criterion, ru_criterion):
+    def test_all_conditions_contains_duplicates(self, evaluated):
         """all_conditions retains both evaluators' conditions (no deduplication)."""
-        RUConfigHaieFactory()
-        moulinette = make_moulinette_haie_with_density(
-            density=60,
-            hedges=[make_hedge_factory(length=50)],
-            reimplantation="replantation",
-        )
-        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
-
-        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
-        evaluator.evaluate()
+        _moulinette, evaluator = evaluated
 
         all_types = [type(c) for c in evaluator.all_conditions]
         assert all_types.count(RUMinLengthCondition) == 2
         assert all_types.count(RUQualityCondition) == 2
         assert all_types.count(SafetyCondition) == 2
 
-    def test_find_condition_uses_all_conditions(self, ep_ru_criterion, ru_criterion):
+    def test_find_condition_uses_all_conditions(self, evaluated):
         """find_condition can locate a specific evaluator's condition even after dedup."""
-        RUConfigHaieFactory()
-        moulinette = make_moulinette_haie_with_density(
-            density=60,
-            hedges=[make_hedge_factory(length=50)],
-            reimplantation="replantation",
-        )
-        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
-
-        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
-        evaluator.evaluate()
+        moulinette, evaluator = evaluated
 
         ru_evaluator = moulinette.regime_unique_haie.regime_unique_haie.get_evaluator()
         ep_evaluator = moulinette.ep.ep_regime_unique.get_evaluator()
@@ -273,18 +266,9 @@ class TestConditionDeduplication:
         assert isinstance(ru_cond.criterion_evaluator, RegimeUniqueHaie)
         assert isinstance(ep_cond.criterion_evaluator, EspecesProtegeesRegimeUnique)
 
-    def test_ep_dispense_no_deduplication_needed(self, ep_ru_criterion, ru_criterion):
+    def test_ep_dispense_no_deduplication_needed(self, evaluated_dispense):
         """When EPRU is in dispense, only RU conditions exist — no duplicates."""
-        RUConfigHaieFactory()
-        moulinette = make_moulinette_haie_with_density(
-            density=60,
-            hedges=[make_hedge_factory(length=8)],
-            reimplantation="replantation",
-        )
-        assert moulinette.ep.ep_regime_unique.result_code == "dispense"
-
-        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
-        evaluator.evaluate()
+        _moulinette, evaluator = evaluated_dispense
 
         all_types = [type(c) for c in evaluator.all_conditions]
         assert all_types.count(RUMinLengthCondition) == 1
@@ -293,18 +277,9 @@ class TestConditionDeduplication:
         # conditions and all_conditions should be identical
         assert evaluator.conditions == evaluator.all_conditions
 
-    def test_to_json_returns_deduplicated(self, ep_ru_criterion, ru_criterion):
+    def test_to_json_returns_deduplicated(self, evaluated):
         """to_json serializes only the deduplicated conditions."""
-        RUConfigHaieFactory()
-        moulinette = make_moulinette_haie_with_density(
-            density=60,
-            hedges=[make_hedge_factory(length=50)],
-            reimplantation="replantation",
-        )
-        assert moulinette.ep.ep_regime_unique.result_code != "dispense"
-
-        evaluator = PlantationEvaluator(moulinette, moulinette.catalog["haies"])
-        evaluator.evaluate()
+        _moulinette, evaluator = evaluated
 
         json_data = evaluator.to_json()
         labels = [item["label"] for item in json_data]

--- a/envergo/moulinette/regulations/ep.py
+++ b/envergo/moulinette/regulations/ep.py
@@ -20,6 +20,7 @@ from envergo.hedges.regulations import (
     NormandieMinLengthCondition,
     NormandieQualityCondition,
     PlantationConditionMixin,
+    RUMinLengthCondition,
     RUQualityCondition,
     SafetyCondition,
     StrenghteningCondition,
@@ -731,7 +732,7 @@ class EspecesProtegeesRegimeUnique(
     choice_label = "EP > EP Régime unique"
     slug = "ep_regime_unique"
     debug_template = "haie/moulinette/debug/ep_regime_unique.html"
-    plantation_conditions = [MinLengthCondition, RUQualityCondition, SafetyCondition]
+    plantation_conditions = [RUMinLengthCondition, RUQualityCondition, SafetyCondition]
     plantation_skip_results = frozenset({"dispense", "non_concerne", "non_disponible"})
     form_class = None
     settings_form_class = EspecesProtegeesRegimeUniqueSettings

--- a/envergo/moulinette/regulations/ep.py
+++ b/envergo/moulinette/regulations/ep.py
@@ -590,6 +590,11 @@ class EspecesProtegeesNormandie(
 
         return result
 
+    @property
+    def effective_coefficients(self):
+        """Normandie density-based per-hedge compensation coefficients."""
+        return self.catalog.get("per_hedge_coefficients", {})
+
     def get_replantation_coefficient(self):
         if self.result_code == "dispense_L350" or self.result_code == "a_verifier_L350":
             # If the result is "dispense_L350" or "a_verifier_L350", the replantation coefficient is 1.0
@@ -982,32 +987,24 @@ class EspecesProtegeesRegimeUnique(
             bonus += EP_RU_SENSITIVE_SPECIES_BONUS
         return bonus
 
-    def get_post_evaluate_data(self):
-        """Write effective per-hedge coefficients (raw + EP bonus) to catalog.
+    @property
+    def effective_coefficients(self):
+        """Raw per-hedge coefficients adjusted with the EP bonus.
 
         Dispense means no compensation is required, so effective coefficients
-        are empty. The slug key must still be present so that
-        ``plantation_evaluate()`` picks it up instead of falling back to the
-        raw ``per_hedge_coefficients``.
+        are empty.
         """
-        slug_key = f"{self.slug}_effective_coefficients"
         if self.result_code == "dispense":
-            return {slug_key: {}}
+            return {}
         bonus = self.get_ep_ru_bonus()
         raw = self.catalog.get("per_hedge_coefficients", {})
-        effective = {h: c + bonus for h, c in raw.items()}
-        return {slug_key: effective}
+        return {h: c + bonus for h, c in raw.items()}
 
     def get_replantation_coefficient(self):
-        """Weighted average of the effective per-hedge coefficients.
-
-        Reads from the slug-keyed effective coefficients written by
-        ``get_post_evaluate_data()``, which already include the EP bonus.
-        For dispense, the effective dict is empty and R is 0.
-        """
-        slug_key = f"{self.slug}_effective_coefficients"
-        effective = self.catalog.get(slug_key, {})
-        return compute_ru_compensation_ratio(self.moulinette, coefficients=effective)
+        """Weighted average of the effective per-hedge coefficients."""
+        return compute_ru_compensation_ratio(
+            self.moulinette, coefficients=self.effective_coefficients
+        )
 
     def build_hedge_rows(self):
         """Build per-hedge display rows for non-alignement hedges.
@@ -1040,7 +1037,7 @@ class EspecesProtegeesRegimeUnique(
         """Return density, EP-specific, and RU zone debug data."""
         context = super().get_debug_context()
 
-        hedge_rows = build_ru_hedge_detail_rows(self.catalog, self.slug)
+        hedge_rows = build_ru_hedge_detail_rows(self.catalog, self)
         per_hedge_results = self.per_hedge_results
         for row in hedge_rows:
             row["partial_result"] = per_hedge_results.get(row["hedge_id"], "-")

--- a/envergo/moulinette/regulations/ep.py
+++ b/envergo/moulinette/regulations/ep.py
@@ -16,7 +16,6 @@ from envergo.hedges.regulations import (
     EssencesBocageresCondition,
     LineaireInterchamp,
     LineaireSurTalusCondition,
-    MinLengthCondition,
     NormandieMinLengthCondition,
     NormandieQualityCondition,
     PlantationConditionMixin,

--- a/envergo/moulinette/regulations/regime_unique.py
+++ b/envergo/moulinette/regulations/regime_unique.py
@@ -234,7 +234,7 @@ def get_ru_debug_context(catalog):
     }
 
 
-def build_ru_hedge_detail_rows(catalog, evaluator_slug):
+def build_ru_hedge_detail_rows(catalog, evaluator):
     """Build per-hedge rows merging zone info with compensation coefficients.
 
     Each row contains zone metadata (zone_id, x_densite, high_density, length)
@@ -242,8 +242,7 @@ def build_ru_hedge_detail_rows(catalog, evaluator_slug):
     "Détail par haie" partial template.
     """
     per_hedge_info = catalog.get("ru_per_hedge_zone_info", {})
-    effective_key = f"{evaluator_slug}_effective_coefficients"
-    effective_coefficients = catalog.get(effective_key, {})
+    effective_coefficients = evaluator.effective_coefficients
 
     rows = []
     for hedge_id, info in per_hedge_info.items():

--- a/envergo/moulinette/regulations/regime_unique_haie.py
+++ b/envergo/moulinette/regulations/regime_unique_haie.py
@@ -6,8 +6,8 @@ Determines whether a hedge project falls under the régime unique
 
 from envergo.evaluations.models import RESULTS
 from envergo.hedges.regulations import (
-    MinLengthCondition,
     PlantationConditionMixin,
+    RUMinLengthCondition,
     RUQualityCondition,
     SafetyCondition,
 )
@@ -45,7 +45,7 @@ class RegimeUniqueHaie(PlantationConditionMixin, HedgeDensityMixin, CriterionEva
 
     choice_label = "Régime unique haie > Régime unique haie"
     slug = "regime_unique_haie"
-    plantation_conditions = [MinLengthCondition, RUQualityCondition, SafetyCondition]
+    plantation_conditions = [RUMinLengthCondition, RUQualityCondition, SafetyCondition]
 
     RESULT_MATRIX = {
         "non_disponible": RESULTS.non_disponible,

--- a/envergo/moulinette/regulations/regime_unique_haie.py
+++ b/envergo/moulinette/regulations/regime_unique_haie.py
@@ -99,6 +99,11 @@ class RegimeUniqueHaie(PlantationConditionMixin, HedgeDensityMixin, CriterionEva
         context.update(get_ru_debug_context(self.catalog))
         return context
 
+    @property
+    def effective_coefficients(self):
+        """Raw per-hedge zone-based compensation coefficients."""
+        return self.catalog.get("per_hedge_coefficients", {})
+
     def get_replantation_coefficient(self):
         """Return the RU compensation ratio for replantation requirements."""
         return compute_ru_compensation_ratio(self.moulinette)

--- a/envergo/moulinette/tests/test_ep_regime_unique.py
+++ b/envergo/moulinette/tests/test_ep_regime_unique.py
@@ -456,11 +456,11 @@ def test_ep_ru_catalog_with_sensitive_species(ep_ru_criterion):
 # ---------------------------------------------------------------------------
 
 
-def test_ep_ru_post_evaluate_writes_effective_coefficients(
+def test_ep_ru_effective_coefficients_include_bonus(
     ep_ru_criterion,
     regime_unique_haie_criterion,
 ):
-    """After evaluate(), effective coefficients appear in the catalog under the slug key."""
+    """The effective_coefficients property returns raw + EP bonus."""
     RUConfigHaieFactory()
     moulinette = make_moulinette_haie_with_density(
         density=60,
@@ -471,9 +471,7 @@ def test_ep_ru_post_evaluate_writes_effective_coefficients(
     evaluator = criterion.get_evaluator()
     assert criterion.result_code == "derogation_simplifiee"
 
-    slug_key = f"{evaluator.slug}_effective_coefficients"
-    assert slug_key in moulinette.catalog
-    effective = moulinette.catalog[slug_key]
+    effective = evaluator.effective_coefficients
     raw = moulinette.catalog["per_hedge_coefficients"]
     bonus = evaluator.get_ep_ru_bonus()
     assert bonus > 0
@@ -489,8 +487,8 @@ def test_ep_ru_effective_coefficients_diverge_from_ru(
     """EPRU effective coefficients include the EP bonus; RU's do not.
 
     Both evaluators share the same raw per_hedge_coefficients. After
-    evaluate(), EPRU writes a slug-namespaced effective key with the
-    bonus applied. RU has no such key — its effective equals raw.
+    evaluate(), EPRU's effective_coefficients property adds the bonus
+    while RU's returns the raw values unchanged.
     """
     RUConfigHaieFactory()
     moulinette = make_moulinette_haie_with_density(
@@ -501,15 +499,14 @@ def test_ep_ru_effective_coefficients_diverge_from_ru(
     raw = moulinette.catalog["per_hedge_coefficients"]
 
     ep_evaluator = moulinette.ep.ep_regime_unique.get_evaluator()
-    ep_slug_key = f"{ep_evaluator.slug}_effective_coefficients"
-    ep_effective = moulinette.catalog[ep_slug_key]
+    ep_effective = ep_evaluator.effective_coefficients
 
     ru_evaluator = moulinette.regime_unique_haie.regime_unique_haie.get_evaluator()
-    ru_slug_key = f"{ru_evaluator.slug}_effective_coefficients"
-    assert ru_slug_key not in moulinette.catalog
+    ru_effective = ru_evaluator.effective_coefficients
 
     for hedge_id in raw:
         assert ep_effective[hedge_id] > raw[hedge_id]
+        assert ru_effective[hedge_id] == raw[hedge_id]
 
 
 def test_ep_ru_dispense_effective_empty(
@@ -527,6 +524,5 @@ def test_ep_ru_dispense_effective_empty(
     assert criterion.result_code == "dispense"
 
     evaluator = criterion.get_evaluator()
-    slug_key = f"{evaluator.slug}_effective_coefficients"
-    assert moulinette.catalog[slug_key] == {}
+    assert evaluator.effective_coefficients == {}
     assert evaluator.get_replantation_coefficient() == 0.0

--- a/envergo/petitions/regulations/ep.py
+++ b/envergo/petitions/regulations/ep.py
@@ -111,7 +111,7 @@ def ep_regime_unique_get_instructor_view_context(
 
     # Per-hedge rows with zone info and coefficients
     context["hedge_detail_rows"] = build_ru_hedge_detail_rows(
-        moulinette.catalog, evaluator.slug
+        moulinette.catalog, evaluator
     )
 
     # Zone configs for the coefficient matrix accordion

--- a/envergo/petitions/regulations/regime_unique_haie.py
+++ b/envergo/petitions/regulations/regime_unique_haie.py
@@ -20,7 +20,7 @@ def regime_unique_haie_get_instructor_view_context(
     context["ru_zone_configs"] = ru_debug["ru_zone_configs"]
 
     context["hedge_detail_rows"] = build_ru_hedge_detail_rows(
-        moulinette.catalog, evaluator.slug
+        moulinette.catalog, evaluator
     )
 
     context["quality_condition"] = {}

--- a/envergo/petitions/templatetags/petitions.py
+++ b/envergo/petitions/templatetags/petitions.py
@@ -101,7 +101,7 @@ def regulation_plantation_conditions(plantation_evaluation, regulation):
     """Render the subset of plantation conditions related to a given regulation."""
 
     condition_to_display = []
-    for condition in plantation_evaluation.conditions:
+    for condition in plantation_evaluation.all_conditions:
         for criterion in regulation.criteria.all():
             if condition.criterion_evaluator == criterion.get_evaluator():
                 condition_to_display.append(condition)
@@ -118,7 +118,7 @@ def regulation_plantation_conditions(plantation_evaluation, regulation):
 @register.simple_tag
 def regulation_has_condition_to_display(plantation_evaluation, regulation):
     """Check if there are any plantation conditions to display for a given regulation."""
-    for condition in plantation_evaluation.conditions:
+    for condition in plantation_evaluation.all_conditions:
         for criterion in regulation.criteria.all():
             if condition.criterion_evaluator == criterion.get_evaluator():
                 return True

--- a/envergo/petitions/templatetags/petitions.py
+++ b/envergo/petitions/templatetags/petitions.py
@@ -98,7 +98,10 @@ def instructor_view_part(
 
 @register.simple_tag
 def regulation_plantation_conditions(plantation_evaluation, regulation):
-    """Render the subset of plantation conditions related to a given regulation."""
+    """Uses ``all_conditions`` (not the deduplicated ``conditions``) so each
+    regulation's view shows its own evaluator's conditions, even when a
+    stricter duplicate hides them from the global list.
+    """
 
     condition_to_display = []
     for condition in plantation_evaluation.all_conditions:
@@ -117,7 +120,7 @@ def regulation_plantation_conditions(plantation_evaluation, regulation):
 
 @register.simple_tag
 def regulation_has_condition_to_display(plantation_evaluation, regulation):
-    """Check if there are any plantation conditions to display for a given regulation."""
+    """Uses ``all_conditions`` — see ``regulation_plantation_conditions``."""
     for condition in plantation_evaluation.all_conditions:
         for criterion in regulation.criteria.all():
             if condition.criterion_evaluator == criterion.get_evaluator():

--- a/envergo/templates/haie/moulinette/result_debug.html
+++ b/envergo/templates/haie/moulinette/result_debug.html
@@ -45,7 +45,7 @@
     <h2>Conditions d'acceptabilité</h2>
 
     <ul class="fr-mb-2w">
-      {% for condition in plantation_evaluation.conditions %}
+      {% for condition in plantation_evaluation.all_conditions %}
         <li>
           {{ condition.label }} : {{ condition.result|yesno:"Remplie,Non remplie" }}
           {% if condition.context %}


### PR DESCRIPTION
https://trello.com/c/HyeCRKGF/2403-les-conditions-dacceptabilit%C3%A9-ne-doivent-pas-%C3%AAtre-dupliqu%C3%A9es

Dé-duplique les conditions d'acceptabilité.

Quand deux critères injectent chacun une même condition de replantation similaire, on veut éviter que cette condition apparaisse deux fois dans les résultats.

Par ailleurs, deux critères peuvent avoir une même condition mais avec un résultat différent (cas de coefficients différents). On ne veut garder que la condition la plus contraignante.