### PR TITLE
Démarches Simplifiées → Démarche Numérique : help texts and messages

### DIFF
--- a/docs/haie/guh.md
+++ b/docs/haie/guh.md
@@ -2,7 +2,7 @@
 
 ## Ajouter une nouvelle config
 
-### Configurer le compte unique sur Démarches Simplifiées
+### Configurer le compte unique sur Démarche numérique
 
 Lorsqu'une nouvelle démarche est créée sur le compte `guichet.haie@haie.beta.gouv.fr` les étapes suivantes doivent être effectuées :
 

--- a/docs/haie/services_externes.md
+++ b/docs/haie/services_externes.md
@@ -1,10 +1,10 @@
 # Services externes
 
-## Démarches simplifiées
+## Démarche numérique
 
-Un module démarches simplifiées est disponible dans le module petitions.
+Un module « Démarche numérique » est disponible dans le module petitions.
 
-Il est utilisé principalement dans le guichet unique de la haie, pour faire le lien avec les dossiers déposés dans Démarches Simplifiées.
+Il est utilisé principalement dans le guichet unique de la haie, pour faire le lien avec les dossiers déposés dans « Démarche numérique ».
 
 Celui-ci permet d'envoyer des requêtes GraphQL pour :
 

--- a/envergo/moulinette/tests/test_models.py
+++ b/envergo/moulinette/tests/test_models.py
@@ -186,7 +186,7 @@ def test_config_haie_has_invalid_demarche_simplifiee_config(
         )
         config_haie.clean()
     assert exc_info.value.messages == [
-        "Chaque champ (ou annotation privée) doit contenir au moins l'id côté Démarches Simplifiées et la "
+        "Chaque champ (ou annotation privée) doit contenir au moins l'id côté « Démarche numérique » et la "
         "source de la valeur côté guichet unique de la haie."
     ]
 

--- a/envergo/petitions/demarches_simplifiees/client.py
+++ b/envergo/petitions/demarches_simplifiees/client.py
@@ -42,7 +42,7 @@ DEMARCHES_SIMPLIFIEES_FAKE_DATA_PATH = Path(
     settings.APPS_DIR / "petitions" / "demarches_simplifiees" / "data"
 )
 
-DS_DISABLED_BASE_MESSAGE = "Demarches Simplifiees is not enabled. Doing nothing. Use fake dossier if dossier is not draft."  # noqa: E501
+DS_DISABLED_BASE_MESSAGE = "« Démarche numérique » is not enabled. Doing nothing. Use fake dossier if dossier is not draft."  # noqa: E501
 
 
 class DemarchesSimplifieesClient:
@@ -58,7 +58,7 @@ class DemarchesSimplifieesClient:
         )
 
     def _fake_execute(self, fake_dossier_filename):
-        """Mock response when Demarches Simplifiees is not enabled"""
+        """Mock response when « Démarche numérique » is not enabled"""
         with open(
             DEMARCHES_SIMPLIFIEES_FAKE_DATA_PATH / fake_dossier_filename,
             "r",
@@ -68,13 +68,13 @@ class DemarchesSimplifieesClient:
 
     def execute(self, query_str: str, variables: dict = None):
         if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
-            raise NotImplementedError("Démarches simplifiées is not enabled")
+            raise NotImplementedError("« Démarche numérique » is not enabled")
 
         query = gql(query_str)
         try:
             result = self.client.execute(query, variable_values=variables or {})
             logger.info(
-                "Demarches simplifiees API request succeed",
+                "« Démarche numérique » API request succeed",
                 extra={
                     "result": result,
                     "query": query_str,
@@ -84,7 +84,7 @@ class DemarchesSimplifieesClient:
 
         except (TransportError, GraphQLError, ConnectionError) as e:
             logger.error(
-                "Demarches simplifiees API request failed",
+                "« Démarche numérique » API request failed",
                 extra={
                     "error": e,
                     "query": query_str,
@@ -129,7 +129,7 @@ class DemarchesSimplifieesClient:
                     )
                 ):
                     logger.info(
-                        "A Demarches simplifiees dossier is not found, but the project is not marked as submitted yet",
+                        "A « Démarche numérique » dossier is not found, but the project is not marked as submitted yet",
                         extra={
                             "dossier_number": dossier_number,
                             "error": e.__cause__ if e.__cause__ else e.message,
@@ -152,7 +152,7 @@ class DemarchesSimplifieesClient:
 
         if "dossier" not in data or not data["dossier"]:
             logger.error(
-                "Demarches simplifiees API response is not well formated",
+                "« Démarche numérique » API response is not well formated",
                 extra={
                     "response": data,
                     "query": query,
@@ -273,7 +273,7 @@ class DemarchesSimplifieesClient:
                 data = self.execute(query, variables)
             except DemarchesSimplifieesError as e:
                 logger.error(
-                    "Error when getting credentials to direct upload file to Demarches Simplifiees",
+                    "Error when getting credentials to direct upload file to « Démarche numérique »",
                     extra={
                         "dossier_number": dossier_number,
                         "error": e.__cause__ if e.__cause__ else e.message,
@@ -310,7 +310,7 @@ class DemarchesSimplifieesClient:
                         )
                 except Exception as e:
                     logger.error(
-                        f"Error when sending attachment file Demarches Simplifiees direct upload : {e}",
+                        f"Error when sending attachment file « Démarche numérique » direct upload : {e}",
                         extra={
                             "dossier_number": dossier_number,
                         },
@@ -342,7 +342,7 @@ class DemarchesSimplifieesClient:
 
             else:
                 logger.error(
-                    "Error with credentials for direct upload to Demarches Simplifiees",
+                    "Error with credentials for direct upload to « Démarche numérique »",
                     extra={
                         "dossier_number": dossier_number,
                         "query": query,
@@ -412,7 +412,7 @@ class DemarchesSimplifieesClient:
                 data = self.execute(query, variables)
             except DemarchesSimplifieesError as e:
                 logger.error(
-                    "Error when sending message to Demarches Simplifiees",
+                    "Error when sending message to « Démarche numérique »",
                     extra={
                         "dossier_number": dossier_number,
                         "error": e.__cause__ if e.__cause__ else e.message,
@@ -437,7 +437,7 @@ class DemarchesSimplifieesClient:
         # If message has not been sent because errors
         if query_name not in data or data[query_name]["errors"]:
             logger.error(
-                "Error when sending message to Demarches Simplifiees",
+                "Error when sending message to « Démarche numérique »",
                 extra={
                     "response": data,
                     "query": query,
@@ -505,7 +505,7 @@ class DemarchesSimplifieesClient:
 
         if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
             logger.warning(
-                f"Demarches Simplifiees is not enabled. Doing nothing."
+                f"« Démarche numérique » is not enabled. Doing nothing."
                 f"Use fake dossier if dossier is not draft."
                 f"\nquery: {query}"
                 f"\nvariables: {variables}"
@@ -537,7 +537,7 @@ class DemarchesSimplifieesClient:
                 data = self.execute(query, variables)
             except DemarchesSimplifieesError as e:
                 logger.error(
-                    "Error when changing dossier state via Demarches Simplifiees API",
+                    "Error when changing dossier state via « Démarche numérique » API",
                     extra={
                         "dossier_id": dossier_id,
                         "error": e.__cause__ if e.__cause__ else e.message,
@@ -564,7 +564,7 @@ class DemarchesSimplifieesClient:
             or data[result_key].get("errors")
         ):
             logger.error(
-                "Error when changing dossier state via Demarches Simplifiees API",
+                "Error when changing dossier state via « Démarche numérique » API",
                 extra={
                     "response": data,
                     "query": query,
@@ -699,7 +699,7 @@ class DemarchesSimplifieesClient:
 
 
 class DemarchesSimplifieesError(Exception):
-    """Démarches Simplifiées client Exception"""
+    """Démarche numérique client Exception"""
 
     def __init__(self, query: str = None, variables: dict = None, message: str = None):
         super().__init__(message)

--- a/envergo/petitions/forms.py
+++ b/envergo/petitions/forms.py
@@ -109,7 +109,7 @@ def validate_mime_type(value):
 
 
 class PetitionProjectInstructorMessageForm(forms.Form):
-    """Form to send a message through demarches simplifiées API."""
+    """Form to send a message through « Démarche numérique » API."""
 
     message_body = forms.CharField(
         label="Message",

--- a/envergo/petitions/management/commands/dossier_submission_admin_alert.py
+++ b/envergo/petitions/management/commands/dossier_submission_admin_alert.py
@@ -19,13 +19,15 @@ DOMAIN_BLACK_LIST = settings.DEMARCHES_SIMPLIFIEES["DOSSIER_DOMAIN_BLACK_LIST"]
 
 
 class Command(BaseCommand):
-    help = "Fetch freshly submitted dossier on Démarches Simplifiées and notify admins."
+    help = (
+        "Fetch freshly submitted dossier on « Démarche numérique » and notify admins."
+    )
 
     def handle(self, *args, **options):
         """get all the dossier updated in the last hour"""
 
         if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
-            logger.warning("Demarches Simplifiees is not enabled. Doing nothing.")
+            logger.warning("« Démarche numérique » is not enabled. Doing nothing.")
             return None
         set_urlconf("config.urls_haie")
 
@@ -114,7 +116,7 @@ class Command(BaseCommand):
         if any(domain in project_url for domain in DOMAIN_BLACK_LIST):
             # project url is from a blacklisted domain, it should have been created in another environment
             logger.warning(
-                "A demarches simplifiees dossier has no corresponding project, it was probably "
+                "A « Démarche numérique » dossier has no corresponding project, it was probably "
                 "created on another environment",
                 extra={
                     "dossier_number": dossier.number,
@@ -126,7 +128,7 @@ class Command(BaseCommand):
             # Either this dossier has been created in this environment but do not match an existing project,
             # or it has been created in a heterodox way.
             logger.warning(
-                "A demarches simplifiees dossier has no corresponding project, it may have been "
+                "A « Démarche numérique » dossier has no corresponding project, it may have been "
                 "created without the guh",
                 extra={
                     "dossier_number": dossier.number,

--- a/envergo/petitions/services.py
+++ b/envergo/petitions/services.py
@@ -146,7 +146,7 @@ def get_project_context(petition_project, moulinette) -> dict:
 
 
 def get_context_from_ds(petition_project) -> dict:
-    """Get parts of context for instructor pages from Demarches Simplifiées"""
+    """Get parts of context for instructor pages from « Démarche numérique »"""
     # Get ds details
     config = petition_project.config
     dossier = get_demarches_simplifiees_dossier(petition_project)
@@ -166,7 +166,7 @@ def get_context_from_ds(petition_project) -> dict:
         or not display_dn_fields.get("pacage", None)
     ):
         logger.error(
-            "Missing Demarches Simplifiees ids in Haie Config",
+            "Missing « Démarche numérique » ids in Haie Config",
             extra={
                 "config.id": config.id,
             },
@@ -295,7 +295,7 @@ def get_messages_and_senders_from_ds(
 
     if not dossier_with_messages:
         logger.error(
-            f"Cannot get messages from Démarches Simplifiées for dossier number {dossier_number}"
+            f"Cannot get messages from « Démarche numérique » for dossier number {dossier_number}"
         )
         return None, None, None
 
@@ -388,11 +388,11 @@ def get_demarches_simplifiees_dossier(
     petition_project,
     force_update: bool = False,
 ) -> Dossier | None:
-    """Get dossier from Demarches Simplifiees either from DB if it is up to date, or from Demarches Simplifiees API.
+    """Get dossier from « Démarche numérique » either from DB if it is up to date, or from « Démarche numérique » API.
 
     args:
         petition_project: The petition project to update with the fetched details.
-        force_update: If True, forces an update from Demarches Simplifiees even if the last sync is recent.
+        force_update: If True, forces an update from « Démarche numérique » even if the last sync is recent.
     returns:
         Dossier object if found, None otherwise.
     """
@@ -405,7 +405,7 @@ def get_demarches_simplifiees_dossier(
         or petition_project.demarches_simplifiees_last_sync is not None
         and petition_project.demarches_simplifiees_last_sync < one_hour_ago_utc
     ):
-        # If the last sync is older than one hour, we fetch the dossier from Demarches Simplifiees
+        # If the last sync is older than one hour, we fetch the dossier from « Démarche numérique »
         dossier_number = petition_project.demarches_simplifiees_dossier_number
         ds_client = DemarchesSimplifieesClient()
         dossier_as_dict = ds_client.get_dossier_with_messages(dossier_number)
@@ -480,7 +480,7 @@ def update_demarches_simplifiees_status(petition_project, new_status):
     else:
         # update failed, notification should have been sent by the DS client
         raise DemarchesSimplifieesError(
-            "", {}, "Unable to update status on Démarches Simplifiées"
+            "", {}, "Unable to update status on « Démarche numérique »"
         )
 
 

--- a/envergo/petitions/templatetags/petitions.py
+++ b/envergo/petitions/templatetags/petitions.py
@@ -278,7 +278,7 @@ def display_pause(due_date):
 
 @register.simple_tag(takes_context=True)
 def get_ds_field(context, field_name):
-    """Get field from démarche numérique as an Item object,
+    """Get field from « Démarche numérique » as an Item object,
     related to a given config and a given petition project.
 
     `field_name` must be set in config.demarches_simplifiees_display_fields.
@@ -296,7 +296,7 @@ def get_ds_field(context, field_name):
 
 @register.inclusion_tag("haie/petitions/_item_ds.html", takes_context=True)
 def display_ds_field(context, field_name, inline=False):
-    """Includes template to display a field from démarche numérique as an Item object,
+    """Includes template to display a field from « Démarche numérique » as an Item object,
     related to a given config and a given petition project.
 
     `field_name` must be set in config.demarches_simplifiees_display_fields.

--- a/envergo/petitions/tests/factories.py
+++ b/envergo/petitions/tests/factories.py
@@ -22,9 +22,9 @@ from envergo.users.tests.factories import UserFactory
 
 DEMARCHES_SIMPLIFIEES_FAKE = {
     "ENABLED": True,
-    "DOSSIER_BASE_URL": "https://www.demarches-simplifiees.example.com/",
-    "PRE_FILL_API_URL": "https://www.demarches-simplifiees.example.com/api/public/v1/",
-    "GRAPHQL_API_URL": "https://www.demarches-simplifiees.example.com/api/v2/graphql",
+    "DOSSIER_BASE_URL": "https://www.demarche-numerique.example.com/",
+    "PRE_FILL_API_URL": "https://www.demarche-numerique.example.com/api/public/v1/",
+    "GRAPHQL_API_URL": "https://www.demarche-numerique.example.com/api/v2/graphql",
     "GRAPHQL_API_BEARER_TOKEN": None,
     "DOSSIER_DOMAIN_BLACK_LIST": [],
     "INSTRUCTEUR_ID": "ABCD1234",

--- a/envergo/petitions/tests/test_commands.py
+++ b/envergo/petitions/tests/test_commands.py
@@ -27,7 +27,7 @@ def test_dossier_submission_admin_alert_ds_not_enabled(caplog):
             [
                 rec.message
                 for rec in caplog.records
-                if "Demarches Simplifiees is not enabled" in rec.message
+                if "« Démarche numérique » is not enabled" in rec.message
             ]
         )
         > 0
@@ -122,7 +122,7 @@ def test_dossier_submission_admin_alert(
 
     args, kwargs = mock_notify_command.call_args_list[0]
     assert (
-        "Un dossier a été déposé sur démarches-simplifiées, qui ne correspond à aucun projet dans la base du GUH."
+        "Un dossier a été déposé sur « Démarche numérique », qui ne correspond à aucun projet dans la base du GUH."
         in args[0]
     )
     assert "(test) Guichet unique de la haie / Demande d'autorisation" in args[0]

--- a/envergo/petitions/tests/test_services.py
+++ b/envergo/petitions/tests/test_services.py
@@ -59,8 +59,8 @@ pytestmark = pytest.mark.django_db
     "envergo.petitions.demarches_simplifiees.client.DemarchesSimplifieesClient.execute"
 )
 def test_fetch_project_details_from_demarches_simplifiees(mock_post, haie_user, site):
-    """Test fetch project details from démarches simplifiées"""
-    # GIVEN a project with a valid dossier in Démarches Simplifiées
+    """Test fetch project details from « Démarche numérique »"""
+    # GIVEN a project with a valid dossier in « Démarche numérique »
     mock_post.return_value = GET_DOSSIER_FAKE_RESPONSE["data"]
 
     DCConfigHaieFactory(
@@ -147,7 +147,7 @@ def test_fetch_project_details_from_demarches_simplifiees_not_enabled(
             [
                 rec.message
                 for rec in caplog.records
-                if "Demarches Simplifiees is not enabled" in rec.message
+                if "« Démarche numérique » is not enabled" in rec.message
             ]
         )
         > 0
@@ -195,7 +195,7 @@ def test_fetch_project_details_from_demarches_simplifiees_should_notify_API_erro
 
     args, kwargs = mock_notify.call_args
     assert (
-        "L'API de Démarches Simplifiées a retourné une erreur lors de la récupération du dossier"
+        "L'API de « Démarche numérique » a retourné une erreur lors de la récupération du dossier"
         in args[0]
     )
     assert "haie" in args[1]
@@ -221,7 +221,7 @@ def test_fetch_project_details_from_demarches_simplifiees_should_notify_unexpect
 
     args, kwargs = mock_notify.call_args
     assert (
-        "La réponse de l'API de Démarches Simplifiées ne répond pas au format attendu."
+        "La réponse de l'API de « Démarche numérique » ne répond pas au format attendu."
         in args[0]
     )
     assert "haie" in args[1]
@@ -231,7 +231,7 @@ def test_fetch_project_details_from_demarches_simplifiees_should_notify_unexpect
 
 @patch("envergo.petitions.services.get_demarches_simplifiees_dossier")
 def test_compute_instructor_information(mock_get_dossier):
-    """Test compute instructor information from démarche simplifiées dossier data"""
+    """Test compute instructor information from « Démarche numérique » dossier data"""
     mock_get_dossier.return_value = Dossier.from_dict(
         GET_DOSSIER_FAKE_RESPONSE["data"]["dossier"]
     )
@@ -856,8 +856,8 @@ def test_aa_get_instructor_view_context(france_map):  # noqa
 def test_get_message_project_via_demarches_simplifiees(
     mock_gql_execute, haie_user, site
 ):
-    """Test send message for project via demarches simplifiées"""
-    # GIVEN a project with a valid dossier in Démarches Simplifiées
+    """Test send message for project via « Démarche numérique »"""
+    # GIVEN a project with a valid dossier in « Démarche numérique »
     mock_gql_execute.return_value = GET_DOSSIER_FAKE_RESPONSE["data"]
 
     DCConfigHaieFactory()
@@ -885,7 +885,7 @@ def test_get_message_project_via_demarches_simplifiees(
 def test_send_message_project_via_demarches_simplifiees(
     mock_gql_execute, haie_user, site
 ):
-    """Test send message for project via demarches simplifiées"""
+    """Test send message for project via « Démarche numérique »"""
 
     DCConfigHaieFactory()
 
@@ -925,7 +925,7 @@ def test_send_message_project_via_demarches_simplifiees(
 def test_send_message_project_via_demarches_simplifiees_with_attachments(
     mock_gql_execute, mock_request_put, haie_user, site
 ):
-    """Test send message for project via demarches simplifiées"""
+    """Test send message for project via « Démarche numérique »"""
 
     DCConfigHaieFactory()
 

--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -244,7 +244,7 @@ def test_pre_fill_demarche_simplifiee_not_enabled(mock_reverse, mock_post, caplo
             [
                 rec.message
                 for rec in caplog.records
-                if "Demarches Simplifiees is not enabled" in rec.message
+                if "« Démarche numérique » is not enabled" in rec.message
             ]
         )
         > 0

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -372,7 +372,7 @@ class PetitionProjectCreate(FormView):
         if not department:
             logger.error(
                 "Moulinette URL for guichet unique de la haie should always contain a department to "
-                "start a demarche simplifiée",
+                "start a « Démarche numérique »",
                 extra={"moulinette_url": moulinette_url},
             )
             return None, None
@@ -432,7 +432,7 @@ class PetitionProjectCreate(FormView):
 
         if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
             logger.warning(
-                f"Demarches Simplifiees is not enabled. Doing nothing."
+                f"« Démarche numérique » is not enabled. Doing nothing."
                 f"\nrequest.url: {api_url}"
                 f"\nrequest.body: {body}"
             )
@@ -524,7 +524,7 @@ class PetitionProjectCreate(FormView):
             regulation_result = getattr(moulinette, regulation_slug, None)
             if regulation_result is None:
                 logger.warning(
-                    "Unable to get the regulation result to pre-fill a démarche simplifiée",
+                    "Unable to get the regulation result to pre-fill a « Démarche numérique »",
                     extra={
                         "regulation_slug": regulation_slug,
                         "moulinette_url": petition_project.moulinette_url,
@@ -552,7 +552,7 @@ class PetitionProjectCreate(FormView):
             criteria = getattr(regulation, criteria_slug, None)
             if criteria is None:
                 logger.warning(
-                    "Unable to get the criteria result code to pre-fill a démarche simplifiée",
+                    "Unable to get the criteria result code to pre-fill a « Démarche numérique »",
                     extra={
                         "source": source,
                         "moulinette_url": petition_project.moulinette_url,
@@ -577,7 +577,7 @@ class PetitionProjectCreate(FormView):
                 value = moulinette.catalog[source]
             else:
                 logger.warning(
-                    "Unable to get the moulinette value to pre-fill a démarche simplifiée",
+                    "Unable to get the moulinette value to pre-fill a « Démarche numérique »",
                     extra={
                         "source": source,
                         "moulinette_url": petition_project.moulinette_url,
@@ -890,7 +890,7 @@ class PetitionProjectInstructorMixin(SingleObjectMixin):
         if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
             messages.info(
                 self.request,
-                """L'accès à l'API démarches simplifiées n'est pas activée.
+                """L'accès à l'API « Démarche numérique » n'est pas activée.
                 Les données proviennent d'un dossier factice.""",
             )
 
@@ -1109,7 +1109,7 @@ class PetitionProjectInstructorRegulationView(BasePetitionProjectInstructorUpdat
 class PetitionProjectInstructorDossierDSView(
     BasePetitionProjectInstructorView, DetailView
 ):
-    """View for petition project page with demarches simplifiées data"""
+    """View for petition project page with Démarche numérique data"""
 
     template_name = "haie/petitions/instructor_view_dossier_ds.html"
 
@@ -1127,7 +1127,7 @@ class PetitionProjectInstructorDossierDSView(
         if not context["project_details"]:
             messages.warning(
                 self.request,
-                f"""Impossible de récupérer les informations du dossier Démarche Numérique.
+                f"""Impossible de récupérer les informations du dossier « Démarche numérique ».
                         Si le problème persiste,
                         <a href='{reverse("contact_us")}{settings.CONTACT_TEAM_ANCHOR}'>
                             contacter l'équipe du guichet unique de la haie
@@ -1162,7 +1162,7 @@ class PetitionProjectInstructorNotesView(BasePetitionProjectInstructorUpdateView
 class PetitionProjectInstructorMessagerieView(
     BasePetitionProjectInstructorView, FormView
 ):
-    """View for petition project instructor page with demarche simplifiées messagerie"""
+    """View for petition project instructor page with Démarche numérique messagerie"""
 
     template_name = "haie/petitions/instructor_view_dossier_messagerie.html"
     event_category = "message"
@@ -1201,7 +1201,7 @@ class PetitionProjectInstructorMessagerieView(
         if context["ds_messages"] is None:
             messages.warning(
                 self.request,
-                f"""Impossible de récupérer les informations du dossier Démarche Numérique.
+                f"""Impossible de récupérer les informations du dossier « Démarche numérique ».
                         Si le problème persiste,
                         <a href='{reverse("contact_us")}{settings.CONTACT_TEAM_ANCHOR}'>
                             contacter l'équipe du guichet unique de la haie
@@ -1303,7 +1303,7 @@ class PetitionProjectInstructorMessagerieView(
 class PetitionProjectInstructorMessagerieMarkUnreadView(
     BasePetitionProjectInstructorView, View
 ):
-    """View for petition project instructor page with demarche simplifiées messagerie"""
+    """View for petition project instructor page with Démarche numérique messagerie"""
 
     event_category = "message"
     event_action = "marquage_non_lu"
@@ -1610,7 +1610,7 @@ class PetitionProjectInstructorProcedureView(
                 form.add_error(
                     None,
                     mark_safe(
-                        f"""Impossible de mettre à jour le dossier dans Démarches Simplifiées. Si le problème persiste,
+                        f"""Impossible de mettre à jour le dossier dans « Démarche numérique ». Si le problème persiste,
                         <a href='{reverse("contact_us")}{settings.CONTACT_TEAM_ANCHOR}'>
                             contacter l'équipe du guichet unique de la haie
                         </a> en indiquant l'identifiant du dossier."""
@@ -1694,7 +1694,7 @@ class PetitionProjectInstructorRequestAdditionalInfoView(
                     if not settings.DEMARCHES_SIMPLIFIEES["ENABLED"]:
                         messages.info(
                             self.request,
-                            """L'accès à l'API démarches simplifiées n'est pas activée.
+                            """L'accès à l'API « Démarche numérique » n'est pas activée.
                             Le message n'est pas envoyé""",
                         )
                     else:

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -1700,7 +1700,7 @@ class PetitionProjectInstructorRequestAdditionalInfoView(
                     else:
                         # We raise an exception to make sure the data model transaction
                         # is aborted
-                        raise DemarchesSimplifieesError(message="DS message not sent")
+                        raise DemarchesSimplifieesError(message="DN message not sent")
 
             # Send Mattermost notification
             haie_site = Site.objects.get(domain=settings.ENVERGO_HAIE_DOMAIN)

--- a/envergo/static/js/libs/form_project_creation.js
+++ b/envergo/static/js/libs/form_project_creation.js
@@ -74,7 +74,7 @@
       .then(response => response.json())
       .then(data => {
         if (data.demarche_simplifiee_url && data.read_only_url) {
-          // open démarche simplifiée in a new tab and display the read only version of the simulation result
+          // open Démarche numérique in a new tab and display the read only version of the simulation result
           if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
             // if the new tab was blocked by the browser, display the link in the current tab
             displayMessage("Votre navigateur empêche l'ouverture d'un nouvel onglet.",

--- a/envergo/templates/admin/moulinette/confighaie/demarche_simplifiee_pre_fill_config_help_text.html
+++ b/envergo/templates/admin/moulinette/confighaie/demarche_simplifiee_pre_fill_config_help_text.html
@@ -4,15 +4,15 @@
   <div>
     <p>
       Ce champ doit comporter un tableau au format json comportant une entrée pour chaque champ ou annotation privée à
-      pré-remplir dans Démarches Simplifiées avec des données provenant du guichet unique de la haie.
+      pré-remplir dans « Démarche numérique » avec des données provenant du guichet unique de la haie.
       Chaque entrée comporte les clés suivantes :
     </p>
     <ul>
-      <li>id : l'id du champ ou de l'annotation privée côté Démarches Simplifiées</li>
+      <li>id : l'id du champ ou de l'annotation privée côté « Démarche numérique »</li>
       <li>value : la source de la valeur côté guichet unique de la haie</li>
       <li>
         mapping (facultatif) : un tableau de correspondance entre les valeurs côté guichet unique de la haie et les
-        valeurs côté Démarches Simplifiées
+        valeurs côté « Démarche numérique »
       </li>
     </ul>
 
@@ -76,7 +76,7 @@
     <p>
       Ce mapping est nécessaire dans le cas des questions de type choix (simple ou multiple) ou les questions de type
       checkbox. Il faut que la valeur du pré-remplissage soit
-      rigoureusement la même que la valeur du label dans Démarches Simplifiées. Si ce n'est pas le cas, il faut utiliser
+      rigoureusement la même que la valeur du label dans « Démarche numérique ». Si ce n'est pas le cas, il faut utiliser
       le mapping pour faire correspondre les valeurs.
     </p>
   </div>

--- a/envergo/templates/haie/moulinette/petition_project.html
+++ b/envergo/templates/haie/moulinette/petition_project.html
@@ -13,7 +13,7 @@
           <a class="fr-btn"
              href="{{ ds_url }}"
              target="_blank"
-             rel="noopener external">Voir le dossier sur Démarches simplifiées</a>
+             rel="noopener external">Voir le dossier sur Démarche numérique</a>
         </span>
       </li>
     {% endif %}

--- a/envergo/templates/haie/pages/privacy.html
+++ b/envergo/templates/haie/pages/privacy.html
@@ -209,7 +209,7 @@
       </td>
     </tr>
     <tr>
-      <td>Démarches simplifiées</td>
+      <td>Démarche numérique</td>
       <td>France</td>
       <td>Hébergement des données du dossier de demande d'autorisation</td>
       <td>

--- a/envergo/templates/haie/petitions/instructor_view_base.html
+++ b/envergo/templates/haie/petitions/instructor_view_base.html
@@ -102,7 +102,7 @@
                   </li>
                   <li>
                     <a class="fr-btn  fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
-                       title="Dossier dans Démarches Simplifiées"
+                       title="Dossier dans Démarche numérique"
                        href="{% url 'petition_project_hedge_data_export' petition_project.reference %}">Télécharger les haies (SIG)</a>
                   </li>
                 </ul>

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error.txt
@@ -1,8 +1,8 @@
-### Récupération des statuts des dossiers depuis Démarches-simplifiées : :x: erreur
+### Récupération des statuts des dossiers depuis Démarche numérique : :x: erreur
 
-L'API de Démarches Simplifiées a retourné une erreur lors de la récupération des dossiers de la démarche n°{{demarche_number}}.
+L'API de « Démarche numérique » a retourné une erreur lors de la récupération des dossiers de la démarche n°{{demarche_number}}.
 
-Réponse de Démarches Simplifiées :
+Réponse de « Démarche numérique » :
 ```
 {{ error|safe }}
 ```

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_change_dossier_state.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_change_dossier_state.txt
@@ -1,8 +1,8 @@
-### Changement de statut d'un dossier sur Démarches-simplifiées : :x: erreur
+### Changement de statut d'un dossier sur Démarche numérique : :x: erreur
 
-L'API de Démarches Simplifiées a retourné une erreur lors d'un changement de statut sur le dossier {{dossier_number}}.
+L'API de « Démarche numérique » a retourné une erreur lors d'un changement de statut sur le dossier {{dossier_number}}.
 
-Réponse de Démarches Simplifiées :
+Réponse de « Démarche numérique » :
 ```
 {{ error|safe }}
 ```

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_dossier_send_message.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_dossier_send_message.txt
@@ -1,8 +1,8 @@
-### Envoi d'un message sur Démarches-simplifiées : :x: erreur
+### Envoi d'un message sur Démarche numérique : :x: erreur
 
-L'API de Démarches Simplifiées a retourné une erreur lors de l'envoi d'un message sur le dossier {{dossier_number}} de la démarche n°{{demarche_number}}.
+L'API de « Démarche numérique » a retourné une erreur lors de l'envoi d'un message sur le dossier {{dossier_number}} de la démarche n°{{demarche_number}}.
 
-Réponse de Démarches Simplifiées :
+Réponse de « Démarche numérique » :
 ```
 {{ error|safe }}
 ```

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_one_dossier.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_error_one_dossier.txt
@@ -1,8 +1,8 @@
-### Récupération des informations d'un dossier depuis Démarches-simplifiées : :x: erreur
+### Récupération des informations d'un dossier depuis Démarche numérique : :x: erreur
 
-L'API de Démarches Simplifiées a retourné une erreur lors de la récupération du dossier n°{{ dossier_number }}.
+L'API de « Démarche numérique » a retourné une erreur lors de la récupération du dossier n°{{ dossier_number }}.
 
-Réponse de Démarches Simplifiées :
+Réponse de « Démarche numérique » :
 ```
 {{ error|safe }}
 ```

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_unexpected_format.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_api_unexpected_format.txt
@@ -1,8 +1,8 @@
-### Récupération des statuts d'un ou plusieurs dossiers depuis Démarches-simplifiées : :warning: anomalie
+### Récupération des statuts d'un ou plusieurs dossiers depuis Démarche numérique : :warning: anomalie
 
-La réponse de l'API de Démarches Simplifiées ne répond pas au format attendu. Le statut des dossiers concernés n'a pas pu être récupéré.
+La réponse de l'API de « Démarche numérique » ne répond pas au format attendu. Le statut des dossiers concernés n'a pas pu être récupéré.
 
-Réponse de Démarches Simplifiées :
+Réponse de « Démarche numérique » :
 ```
 {{ response|safe }}
 ```

--- a/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_donnees_manquantes.txt
+++ b/envergo/templates/haie/petitions/mattermost_demarches_simplifiees_donnees_manquantes.txt
@@ -1,4 +1,4 @@
-### Récupération des informations d'un dossier depuis Démarches-simplifiées : :x: erreur
+### Récupération des informations d'un dossier depuis Démarche numérique : :x: erreur
 
 Les identifiants des champs PACAGE, commune principale et/ou structure ne sont pas renseignés dans la configuration du département {{ department }}.
 

--- a/envergo/templates/haie/petitions/mattermost_project_creation_anomalie.txt
+++ b/envergo/templates/haie/petitions/mattermost_project_creation_anomalie.txt
@@ -1,5 +1,5 @@
-#### Mapping avec Démarches-simplifiées : :warning: anomalie
-Un dossier a été créé sur démarches-simplifiées :
+#### Mapping avec Démarche numérique : :warning: anomalie
+Un dossier a été créé sur « Démarche numérique » :
 * [projet dans l’admin]({{ projet_url }})
 
 {% if config %}

--- a/envergo/templates/haie/petitions/mattermost_project_creation_erreur.txt
+++ b/envergo/templates/haie/petitions/mattermost_project_creation_erreur.txt
@@ -1,5 +1,5 @@
-### Mapping avec Démarches-simplifiées : :x: erreur
-La création d’un dossier démarches-simplifiées n’a pas pu aboutir.
+### Mapping avec Démarche numérique : :x: erreur
+La création d’un dossier « Démarche numérique » n’a pas pu aboutir.
 {% if config_url %}
 Cette erreur révèle une possible anomalie de la
 {% if department %}

--- a/envergo/templates/haie/petitions/mattermost_project_creation_problem.txt
+++ b/envergo/templates/haie/petitions/mattermost_project_creation_problem.txt
@@ -6,12 +6,12 @@
 {% endif %}
 
 {% if problem.key == "missing_demarche_simplifiee_number" %}
-Un département activé doit toujours avoir un numéro de démarche sur Démarches Simplifiées
+Un département activé doit toujours avoir un numéro de démarche sur « Démarche numérique »
 {% elif problem.key == "invalid_prefill_field" %}
 Chaque entrée de la configuration de pré-remplissage doit obligatoirement avoir un id et une valeur. Le mapping est optionnel.
 * Champ : {{ problem.extra.field }}
 {% elif problem.key == "ds_api_http_error" %}
-L'API de Démarches Simplifiées a retourné une erreur lors de la création du dossier.
+L'API de « Démarche numérique » a retourné une erreur lors de la création du dossier.
 ** Requête:**
 * url : {{ problem.extra.api_url }}
 * body :

--- a/envergo/templates/haie/petitions/mattermost_unlinked_dossier_notif.txt
+++ b/envergo/templates/haie/petitions/mattermost_unlinked_dossier_notif.txt
@@ -1,6 +1,6 @@
-### Récupération des statuts des dossiers depuis Démarches-simplifiées : :warning: anomalie
+### Récupération des statuts des dossiers depuis Démarche numérique : :warning: anomalie
 
-Un dossier a été déposé sur démarches-simplifiées, qui ne correspond à aucun projet dans la base du GUH.
+Un dossier a été déposé sur « Démarche numérique », qui ne correspond à aucun projet dans la base du GUH.
 
 Il peut s'agir :
  * d'un dossier dupliqué sur DS par l’utilisateur, à partir du dossier pré-rempli


### PR DESCRIPTION
https://trello.com/c/QKMhi0fJ/2187-d%C3%A9marches-simplifi%C3%A9es-d%C3%A9marche-num%C3%A9rique

La suite : les mots dans les messages

J'ai pris le parti de mettre « Démarche numérique » comme c'est écrit dans [la documentation](https://doc.demarche.numerique.gouv.fr/), sauf pour les titres et les docstring courts pour ne pas surcharger.