### PR TITLE
Refacto du filtrage des critères "staff only"

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1840,9 +1840,9 @@ class Moulinette(MoulinetteUrlMixin, ABC):
 
     @cached_property
     def optional_forms(self):
-        return self.get_optional_forms(exclude_staff_only_criterion=False)
+        return self.get_optional_forms()
 
-    def get_optional_forms(self, exclude_staff_only_criterion=True):
+    def get_optional_forms(self):
         """Get a list of instanciated optional forms.
 
         Optional forms can be selectively activated during a simulation.
@@ -1854,9 +1854,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
            the moulinette regulations.
         """
         forms = []
-        form_classes = self.optional_form_classes(
-            exclude_staff_only_criterion=exclude_staff_only_criterion
-        )
+        form_classes = self.optional_form_classes()
 
         for form_class in form_classes:
             # Every optional form has a "activate" field
@@ -1878,7 +1876,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
                 forms.append(form)
         return forms
 
-    def _get_optional_criteria_list(self, exclude_staff_only_criterion=True):
+    def get_optional_criteria_list(self):
         if self.is_evaluated():
             criteria = [
                 c
@@ -1889,16 +1887,13 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         else:
             criteria = list(self.get_optional_criteria())
 
-        if exclude_staff_only_criterion:
-            criteria = [c for c in criteria if not c.is_staff_only]
-
         return criteria
 
-    def optional_form_classes(self, exclude_staff_only_criterion=True):
+    def optional_form_classes(self):
         """Return the list of forms for optional questions."""
         form_classes = []
 
-        for criterion in self._get_optional_criteria_list(exclude_staff_only_criterion):
+        for criterion in self.get_optional_criteria_list():
             if self.is_evaluated():
                 form_class = criterion.get_form_class()
             else:
@@ -1913,7 +1908,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
 
         all_forms = [self.main_form]
         all_forms.extend(self.additional_forms)
-        all_forms.extend(self.get_optional_forms(exclude_staff_only_criterion=False))
+        all_forms.extend(self.optional_forms)
 
         if self.triage_form:
             all_forms.append(self.triage_form)
@@ -2021,7 +2016,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         """Get a {field_name: field} dict of all optional questions fields."""
 
         fields = OrderedDict()
-        for form in self.get_optional_forms(exclude_staff_only_criterion=False):
+        for form in self.optional_forms:
             for field in form:
                 field_name = form.add_prefix(field.name)
                 if field_name not in fields:

--- a/envergo/moulinette/regulations/evalenv.py
+++ b/envergo/moulinette/regulations/evalenv.py
@@ -229,6 +229,8 @@ class TerrainAssiette(SelfDeclarationMixin, CriterionEvaluator):
 
 
 class OptionalFormMixin:
+    is_staff_only = False
+
     @property
     def prefixed_cleaned_data(self):
         """Return cleaned data but use prefixed keys.
@@ -784,6 +786,7 @@ ICPE_REGIME_HELP_TEXT = (
 
 
 class ICPEForm(OptionalFormMixin, forms.Form):
+    is_staff_only = True
     prefix = "evalenv_icpe"
 
     activate = forms.BooleanField(

--- a/envergo/moulinette/tests/test_staff_only_criteria.py
+++ b/envergo/moulinette/tests/test_staff_only_criteria.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
 from envergo.moulinette.models import MoulinetteAmenagement
+from envergo.moulinette.regulations.evalenv import ICPEForm, OptionalFormMixin
 from envergo.moulinette.tests.factories import (
     ConfigAmenagementFactory,
     CriterionFactory,
@@ -15,6 +16,13 @@ from envergo.users.tests.factories import UserFactory
 pytestmark = pytest.mark.django_db
 
 BASE_PARAMS = "created_surface=500&final_surface=500&lng=-1.54394&lat=47.21381"
+
+ICPE_RESULT_PARAMS = (
+    f"{BASE_PARAMS}"
+    "&evalenv_icpe-activate=on"
+    "&evalenv_icpe-icpe_projet=creation"
+    "&evalenv_icpe-icpe_regime=enregistrement"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -47,26 +55,14 @@ class TestICPEStaffOnlyVisibility:
         assert "Installation classée (ICPE)" in res.content.decode()
 
     def test_non_staff_can_see_icpe_result(self, client):
-        params = (
-            f"{BASE_PARAMS}"
-            "&evalenv_icpe-activate=on"
-            "&evalenv_icpe-icpe_projet=creation"
-            "&evalenv_icpe-icpe_regime=enregistrement"
-        )
-        url = f"{reverse('moulinette_result')}?{params}"
+        url = f"{reverse('moulinette_result')}?{ICPE_RESULT_PARAMS}"
         res = client.get(url)
 
         assert res.status_code == 200
         assert "installation classée (icpe)" in res.content.decode().lower()
 
     def test_staff_can_see_icpe_result(self, staff_client):
-        params = (
-            f"{BASE_PARAMS}"
-            "&evalenv_icpe-activate=on"
-            "&evalenv_icpe-icpe_projet=creation"
-            "&evalenv_icpe-icpe_regime=enregistrement"
-        )
-        url = f"{reverse('moulinette_result')}?{params}"
+        url = f"{reverse('moulinette_result')}?{ICPE_RESULT_PARAMS}"
         res = staff_client.get(url)
 
         assert res.status_code == 200
@@ -92,29 +88,50 @@ class TestICPEStaffOnlyVisibility:
         assert "Installation classée (ICPE)" in res.content.decode()
 
 
+class TestStaffOnlyFormAttribute:
+    def test_optional_form_mixin_defaults_to_not_staff_only(self):
+        assert OptionalFormMixin.is_staff_only is False
+
+    def test_icpe_form_is_staff_only(self):
+        assert ICPEForm.is_staff_only is True
+
+
 class TestStaffOnlyFiltering:
-    def _make_moulinette(self):
+    def make_moulinette(self, **extra):
         data = make_amenagement_data(
             lat=COORDS_BIZOU[0],
             lng=COORDS_BIZOU[1],
             created_surface=500,
             final_surface=500,
+            **extra,
         )
         return MoulinetteAmenagement(data)
 
-    def test_optional_form_classes_excludes_staff_only_by_default(self):
-        moulinette = self._make_moulinette()
+    def test_optional_form_classes_includes_staff_only(self):
+        moulinette = self.make_moulinette()
         form_classes = moulinette.optional_form_classes()
         class_names = [fc.__name__ for fc in form_classes]
-        assert "ICPEForm" not in class_names
-
-    def test_optional_form_classes_includes_staff_only_when_requested(self):
-        moulinette = self._make_moulinette()
-        form_classes = moulinette.optional_form_classes(
-            exclude_staff_only_criterion=False
-        )
-        class_names = [fc.__name__ for fc in form_classes]
         assert "ICPEForm" in class_names
+
+    def test_optional_forms_property_includes_staff_only(self):
+        """The cached property always includes staff-only forms."""
+        moulinette = self.make_moulinette()
+        form_types = [type(f) for f in moulinette.optional_forms]
+        assert ICPEForm in form_types
+
+    def test_get_all_forms_includes_staff_only(self):
+        """get_all_forms() includes staff-only optional forms."""
+        moulinette = self.make_moulinette()
+        form_types = [type(f) for f in moulinette.get_all_forms()]
+        assert ICPEForm in form_types
+
+    def test_optional_fields_includes_staff_only(self):
+        """optional_fields includes fields from staff-only forms."""
+        moulinette = self.make_moulinette()
+        assert any(
+            key.startswith("evalenv_icpe-")
+            for key in moulinette.optional_fields.keys()
+        )
 
 
 class TestCriterionStaffOnlyValidation:
@@ -146,3 +163,46 @@ class TestCriterionStaffOnlyValidation:
             criterion.full_clean()
         except ValidationError:
             pytest.fail("full_clean() raised ValidationError unexpectedly")
+
+
+class TestStaffOnlyViewContext:
+    """The view injects a filtered optional_forms list into the template context."""
+
+    def test_form_page_excludes_staff_only_for_anonymous(self, client):
+        url = reverse("moulinette_form")
+        res = client.get(url)
+
+        optional_forms = res.context["optional_forms"]
+        form_types = [type(f) for f in optional_forms]
+        assert ICPEForm not in form_types
+
+    def test_form_page_includes_staff_only_for_staff(self, staff_client):
+        url = reverse("moulinette_form")
+        res = staff_client.get(url)
+
+        optional_forms = res.context["optional_forms"]
+        form_types = [type(f) for f in optional_forms]
+        assert ICPEForm in form_types
+
+    def test_result_page_includes_staff_only_for_non_staff(self, client):
+        """The result page processes all submitted forms, even for non-staff."""
+        url = f"{reverse('moulinette_result')}?{ICPE_RESULT_PARAMS}"
+        res = client.get(url)
+
+        assert res.status_code == 200
+        content = res.content.decode()
+        assert "Oui, il crée une nouvelle ICPE" in content
+
+
+class TestStaffOnlySummaryRendering:
+    """The _additional_specifications template shows activated staff-only fields."""
+
+    def test_icpe_fields_in_result_summary_for_non_staff(self, client):
+        """ICPE field values appear in the result summary even for non-staff users."""
+        url = f"{reverse('moulinette_result')}?{ICPE_RESULT_PARAMS}"
+        res = client.get(url)
+
+        assert res.status_code == 200
+        assertTemplateUsed(res, "moulinette/_additional_specifications.html")
+        content = res.content.decode()
+        assert "ICPE-E" in content or "enregistrement" in content.lower()

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -98,7 +98,6 @@ class MoulinetteMixin:
 
         user = self.request.user
         is_staff = user.is_authenticated and (user.is_staff or user.is_superuser)
-        exclude_staff_only_criterion = not is_staff
 
         if self.moulinette.is_evaluated():
 
@@ -159,9 +158,10 @@ class MoulinetteMixin:
             self.request.user.is_staff
             and self.request.user.groups.filter(name="Staff ops").exists()
         )
-        context["optional_forms"] = self.moulinette.get_optional_forms(
-            exclude_staff_only_criterion=exclude_staff_only_criterion
-        )
+        optional_forms = self.moulinette.optional_forms
+        if not is_staff:
+            optional_forms = [f for f in optional_forms if not f.is_staff_only]
+        context["optional_forms"] = optional_forms
         context["triage_form"] = self.moulinette.triage_form
 
         context = {**context, **self.moulinette.get_extra_context(self.request)}


### PR DESCRIPTION
Suggestion d'une implémentation alternative pour le filtrage des critères optionnels "staff only". L'idée est de laisser la moulinette en l'état et de faire effectuer le filtrage par la vue.