### PR TITLE
Sécurise les urlmappings

### DIFF
--- a/envergo/urlmappings/forms.py
+++ b/envergo/urlmappings/forms.py
@@ -1,9 +1,36 @@
+from urllib.parse import urlparse
+
 from django import forms
+from django.conf import settings
 
 from envergo.urlmappings.models import UrlMapping
 
 
 class UrlMappingCreateForm(forms.ModelForm):
+    """Form for creating a short URL mapping.
+
+    Only URLs pointing to one of our own domains (amenagement or haie) are
+    accepted, so the shortener cannot be abused as an open redirect.
+    """
+
     class Meta:
         fields = ["url"]
         model = UrlMapping
+
+    def clean_url(self):
+        """Reject URLs whose hostname is not one of our own domains.
+
+        Using urlparse().hostname (rather than substring matching on the raw
+        URL) ensures lookalike domains, subdomains, and URLs that embed an
+        allowed domain in their path or userinfo cannot bypass the check.
+        """
+        url = self.cleaned_data["url"]
+        hostname = urlparse(url).hostname
+        allowed_domains = {
+            settings.ENVERGO_AMENAGEMENT_DOMAIN,
+            settings.ENVERGO_HAIE_DOMAIN,
+        }
+        if hostname not in allowed_domains:
+            raise forms.ValidationError("Cette URL n'est pas autorisée.")
+
+        return url

--- a/envergo/urlmappings/migrations/0005_delete_external_url_mappings.py
+++ b/envergo/urlmappings/migrations/0005_delete_external_url_mappings.py
@@ -1,0 +1,36 @@
+"""Delete URL mappings pointing to external domains.
+
+Before the domain whitelist was added to UrlMappingCreateForm, the shortener
+accepted arbitrary URLs. Any existing mapping whose hostname is not one of our
+own domains is spam and must be purged.
+"""
+
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.db import migrations
+
+
+def delete_external_mappings(apps, schema_editor):
+    UrlMapping = apps.get_model("urlmappings", "UrlMapping")
+    allowed_domains = {
+        settings.ENVERGO_AMENAGEMENT_DOMAIN,
+        settings.ENVERGO_HAIE_DOMAIN,
+    }
+    to_delete = [
+        mapping.pk
+        for mapping in UrlMapping.objects.all()
+        if urlparse(mapping.url).hostname not in allowed_domains
+    ]
+    UrlMapping.objects.filter(pk__in=to_delete).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("urlmappings", "0004_add_contexte_to_moulinette_haie"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_external_mappings, migrations.RunPython.noop),
+    ]

--- a/envergo/urlmappings/tests.py
+++ b/envergo/urlmappings/tests.py
@@ -1,0 +1,118 @@
+import pytest
+from django.urls import reverse
+
+from envergo.urlmappings.models import UrlMapping
+
+pytestmark = pytest.mark.django_db
+
+CREATE_URL = reverse("urlmapping_create")
+
+AMENAGEMENT_DOMAIN = "amenagement.test.gouv.fr"
+HAIE_DOMAIN = "haie.test.gouv.fr"
+
+
+@pytest.fixture(autouse=True)
+def urlmapping_domains(settings):
+    settings.ENVERGO_AMENAGEMENT_DOMAIN = AMENAGEMENT_DOMAIN
+    settings.ENVERGO_HAIE_DOMAIN = HAIE_DOMAIN
+
+
+def test_create_mapping_with_amenagement_domain(client):
+    url = f"https://{AMENAGEMENT_DOMAIN}/moulinette/resultat/?lng=-1.5&lat=47.2"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 201
+    assert UrlMapping.objects.count() == 1
+
+
+def test_create_mapping_with_haie_domain(client):
+    url = f"https://{HAIE_DOMAIN}/haie/resultat/?element=haie&lng=-1.5&lat=47.2"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 201
+    assert UrlMapping.objects.count() == 1
+
+
+def test_create_mapping_with_http_is_accepted(client):
+    """Local dev uses http — both schemes must be allowed."""
+    url = f"http://{AMENAGEMENT_DOMAIN}/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 201
+    assert UrlMapping.objects.count() == 1
+
+
+def test_create_mapping_with_port_is_accepted(client):
+    """Local dev uses non-standard ports."""
+    url = f"http://{AMENAGEMENT_DOMAIN}:8000/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 201
+    assert UrlMapping.objects.count() == 1
+
+
+def test_external_domain_is_rejected(client):
+    url = "https://evil.example.com/spam"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_subdomain_of_allowed_domain_is_rejected(client):
+    url = f"https://evil.{AMENAGEMENT_DOMAIN}/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_domain_lookalike_is_rejected(client):
+    """A domain containing an allowed domain as a suffix must not pass."""
+    url = f"https://not-{AMENAGEMENT_DOMAIN}/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_allowed_domain_in_path_is_rejected(client):
+    """The allowed domain appearing only in the path must not bypass validation."""
+    url = f"https://evil.example.com/{AMENAGEMENT_DOMAIN}/moulinette/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_empty_url_is_rejected(client):
+    res = client.post(CREATE_URL, {"url": ""})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_missing_url_is_rejected(client):
+    res = client.post(CREATE_URL, {})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_userinfo_trick_is_rejected(client):
+    """An attacker can craft a URL with an allowed domain in the userinfo part."""
+    url = f"https://{AMENAGEMENT_DOMAIN}@evil.example.com/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 400
+    assert UrlMapping.objects.count() == 0
+
+
+def test_uppercase_hostname_is_accepted(client):
+    """Hostnames are case-insensitive per RFC — uppercase must be accepted."""
+    domain = AMENAGEMENT_DOMAIN.upper()
+    url = f"https://{domain}/moulinette/resultat/"
+    res = client.post(CREATE_URL, {"url": url})
+
+    assert res.status_code == 201
+    assert UrlMapping.objects.count() == 1


### PR DESCRIPTION
La fonctionnalité d'urlmapping n'est utilisée que pour pointer vers notre propre site.

https://trello.com/c/UiPOCRBj/2387-report-yeswehack-server-side-request-forgery-sur-les-urlmappings