### PR TITLE
Corrige une différence de contenu entre les avis html et txt

### DIFF
--- a/envergo/templates/evaluations/admin/eval_email_soumis.html
+++ b/envergo/templates/evaluations/admin/eval_email_soumis.html
@@ -28,7 +28,7 @@
       <li>
         <strong style="background-color: #ffb7a5;">Le projet est soumis à la Loi sur l'eau</strong>.
         <br />
-        Le porteur de projet doit déposer un dossier de déclaration Loi sur l'eau à la DDT(M).
+        Le porteur de projet doit déposer un dossier de déclaration Loi sur l'eau.
       </li>
     {% elif moulinette.loi_sur_leau.required_actions_soumis %}
       <li>

--- a/envergo/templates/evaluations/admin/eval_email_soumis.txt
+++ b/envergo/templates/evaluations/admin/eval_email_soumis.txt
@@ -9,7 +9,7 @@ Au vu des informations qui nous ont été transmises, il apparaît que :
 {% elif moulinette.eval_env.is_cas_par_cas %}  - Le projet est soumis à examen au cas par cas.
 {% if moulinette.eval_env.result == "cas_par_cas_icpe" %}Le dossier ICPE fait office de demande d'examen au cas par cas.{% else %}Le porteur de projet doit déposer une demande d'examen au cas par cas.{% endif %}
 
-{% endif %}{% if moulinette.loi_sur_leau.result == "soumis" %}  - Le projet est soumis à la Loi sur l'eau.
+{% endif %}{% if moulinette.loi_sur_leau.result == "soumis" or moulinette.loi_sur_leau.result == "soumis_ou_pac" %}  - Le projet est soumis à la Loi sur l'eau.
 Le porteur de projet doit déposer un dossier de déclaration Loi sur l'eau.
 
 {% elif moulinette.loi_sur_leau.required_actions_soumis %}  - Le projet est susceptible d'être soumis à la Loi sur l’eau. Une action du porteur du projet est requise. Celui-ci doit mener les études prouvant que le projet :


### PR DESCRIPTION
https://trello.com/c/l32HYlgd/2431-bug-diff%C3%A9rence-de-contenu-dans-lemail-davis-quand-lse-soumisoupac

When the lse result was "soumis_ou_pac", there was a content difference between the two versions.