### PR TITLE
Cache les données sensibles en debug

### DIFF
--- a/envergo/templates/haie/moulinette/result_debug.html
+++ b/envergo/templates/haie/moulinette/result_debug.html
@@ -100,15 +100,16 @@
       {% endwith %}
     {% endfor %}
 
-    <h2>Catalogue de données</h2>
-
-    <dd>
-      {% for key, value in moulinette.catalog.items %}
-        <dt>{{ key }}</dt>
-        <dd>
-          {{ value|truncatechars:150 }}
-        </dd>
-      {% endfor %}
-    </dd>
+    {% if request.user.is_superuser %}
+      <h2>Catalogue de données</h2>
+      <dd>
+        {% for key, value in moulinette.catalog.items %}
+          <dt>{{ key }}</dt>
+          <dd>
+            {{ value|truncatechars:150 }}
+          </dd>
+        {% endfor %}
+      </dd>
+    {% endif %}
   </section>
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/o2n4zHdl/2405-esp%C3%A8ces-prot%C3%A9g%C3%A9es-sensibles-dump%C3%A9s-dans-la-page-d%C3%A9bug

La fonctionnalité qui dumpe l'intégralité du catalogue dans la page de debug est un peu violente. On la réserve aux superusers pour éviter les fuites de données suprises.