### PR TITLE
Corrige les problèmes de timeout dans la codebase

### DIFF
--- a/bin/start_celery_worker.sh
+++ b/bin/start_celery_worker.sh
@@ -2,4 +2,10 @@
 
 echo "Starting the Celery worker ($DJANGO_SETTINGS_MODULE)"
 
-celery -A config.celery_app worker --loglevel info
+# Time limits are a safety net behind the per-call request timeouts: even an
+# un-timed-out external call can no longer wedge a worker process forever.
+# soft limit lets the task raise SoftTimeLimitExceeded; hard limit kills it.
+# The budget is generous because legitimate import tasks (map / species file
+# processing) run for several minutes; a tighter limit would kill them and,
+# combined with the global retry policy, send them into a retry loop.
+celery -A config.celery_app worker --loglevel info --soft-time-limit 600 --time-limit 900

--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -8,6 +8,30 @@ from django.conf import settings  # noqa
 
 app = Celery("envergo")
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+
+class BaseTaskWithRetry(app.Task):
+    """Default base task: always retry on failure, with capped backoff.
+
+    Tasks routinely depend on flaky third parties (make.com, Mattermost,
+    Démarches Simplifiées, IGN…). Rather than letting a transient failure drop
+    the task on the floor, every task retries with exponential backoff. The
+    capped `max_retries` prevents a genuinely broken (poison) message from
+    retrying forever.
+    """
+
+    autoretry_for = (Exception,)
+    retry_backoff = True
+    retry_backoff_max = 600
+    retry_jitter = True
+    max_retries = 5
+
+
+# Make every task retry by default, unless it overrides these attributes.
+# This must run before autodiscover_tasks() so that every task picked up by
+# the @app.task decorator inherits the retry policy.
+app.Task = BaseTaskWithRetry
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -403,6 +403,20 @@ MAKE_COM_EVALUATION_EDITION_WEBHOOK = env(
 )
 
 
+# Default (connect, read) timeout in seconds for outbound HTTP requests.
+#
+# Every `requests` call must pass a timeout: without one, an unresponsive
+# remote endpoint blocks the calling worker indefinitely (this once froze the
+# whole Celery worker for days). `bin/start_celery_worker.sh` adds a worker
+# time-limit as a second line of defense.
+DEFAULT_HTTP_TIMEOUT = (5, 30)
+
+# (connect, read) timeout in seconds for outbound requests that stream a file
+# (up/downloads). The read budget is larger because transferring a multi-MB
+# body legitimately takes longer than a JSON API response.
+DEFAULT_HTTP_FILE_TIMEOUT = (5, 60)
+
+
 ENVERGO_AMENAGEMENT_DOMAIN = env(
     "DJANGO_ENVERGO_AMENAGEMENT_DOMAIN", default="envergo.beta.gouv.fr"
 )

--- a/envergo/evaluations/tasks.py
+++ b/envergo/evaluations/tasks.py
@@ -1,8 +1,6 @@
 import json
 import logging
 from collections import defaultdict
-from smtplib import SMTPException
-from urllib.error import HTTPError
 
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
@@ -27,7 +25,7 @@ from envergo.utils.tools import get_base_url
 logger = logging.getLogger(__name__)
 
 
-@app.task(autoretry_for=(Exception,))
+@app.task
 def confirm_request_to_admin(request_id, host):
     """Send a Mattermost notification to confirm the evaluation request."""
 
@@ -45,13 +43,7 @@ def confirm_request_to_admin(request_id, host):
     notify(message_body, "amenagement")
 
 
-@app.task(
-    autoretry_for=(
-        HTTPError,
-        SMTPException,
-    ),
-    retry_backoff=True,
-)
+@app.task
 def confirm_request_to_requester(request_id, host):
     """Send a confirmation email to the requester."""
 
@@ -104,10 +96,7 @@ class BetterJsonSerializer(JSONSerializer):
             super().handle_field(obj, field)
 
 
-@app.task(
-    autoretry_for=(HTTPError,),
-    retry_backoff=True,
-)
+@app.task
 def post_evalreq_to_automation(request_id, host):
     """Send request data to Make.com."""
     webhook_url = settings.MAKE_COM_WEBHOOK

--- a/envergo/evaluations/tasks.py
+++ b/envergo/evaluations/tasks.py
@@ -182,6 +182,12 @@ def post_evaluation_to_automation(evaluation_uid):
 
 
 def post_a_model_to_automation(model, webhook_url, **extra_data):
+    """Serialize a model and POST it to a make.com webhook.
+
+    Errors (timeout, connection error, non-2xx status) are raised, not
+    swallowed, so the calling task retries instead of silently dropping the
+    payload (see BaseTaskWithRetry).
+    """
     serialized = BetterJsonSerializer().serialize([model])
     json_data = json.loads(serialized)[0]
     payload = json_data["fields"]
@@ -192,8 +198,12 @@ def post_a_model_to_automation(model, webhook_url, **extra_data):
     logger.info(payload)
 
     if webhook_url:
-        res = post(webhook_url, json=payload)
-        if res.status_code != 200:
+        res = post(webhook_url, json=payload, timeout=settings.DEFAULT_HTTP_TIMEOUT)
+        if not res.ok:
             logger.error(f"Error while posting data to make.com: {res.text}")
+        # Both failures propagate so the task retries instead of dropping the
+        # payload: a timeout/connection error raises at the post() call above,
+        # and an error HTTP status raises here.
+        res.raise_for_status()
     else:
         logger.warning("No make.com webhook configured. Doing nothing.")

--- a/envergo/evaluations/tests/test_tasks.py
+++ b/envergo/evaluations/tests/test_tasks.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch
 
 import pytest
+import requests
 
-from envergo.evaluations.tasks import post_evalreq_to_automation
+from envergo.evaluations.tasks import (
+    post_a_model_to_automation,
+    post_evalreq_to_automation,
+    post_evaluation_to_automation,
+)
 from envergo.evaluations.tests.factories import RequestFactory, RequestFileFactory
 
 pytestmark = pytest.mark.django_db
@@ -191,3 +196,40 @@ def test_request_history_petitioner(mock_post):
     mock_post.assert_called_once()
     payload = mock_post.call_args.kwargs["json"]
     assert "request_history" not in payload
+
+
+@patch("envergo.evaluations.tasks.post")
+def test_make_com_post_uses_timeout(mock_post, settings):
+    """The webhook POST always passes a timeout, so a hung make.com cannot
+    block the worker indefinitely."""
+
+    mock_post.return_value.status_code = 200
+    evalreq = RequestFactory(user_type="petitioner")
+    post_evalreq_to_automation(evalreq.id, "envergo.local")
+
+    assert mock_post.call_args.kwargs["timeout"] == settings.DEFAULT_HTTP_TIMEOUT
+
+
+@patch("envergo.evaluations.tasks.post")
+def test_make_com_post_raises_on_http_error(mock_post):
+    """A failing webhook response propagates, so the task's retry policy kicks
+    in instead of silently dropping the payload."""
+
+    mock_post.return_value.status_code = 500
+    mock_post.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "boom"
+    )
+    evalreq = RequestFactory(user_type="petitioner")
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        post_a_model_to_automation(evalreq, "https://example.com/dummy-webhook/")
+
+
+@pytest.mark.parametrize(
+    "task", [post_evalreq_to_automation, post_evaluation_to_automation]
+)
+def test_automation_tasks_retry_by_default(task):
+    """The shared base task makes outbound tasks retry on any failure."""
+
+    assert task.autoretry_for == (Exception,)
+    assert task.max_retries == 5

--- a/envergo/geodata/management/commands/alti.py
+++ b/envergo/geodata/management/commands/alti.py
@@ -4,6 +4,7 @@ from queue import Queue
 
 import numpy as np
 import requests
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.management.base import BaseCommand
 from pyproj import Transformer
@@ -57,7 +58,7 @@ class RgeAltiClient:
 
         # Time for the api query, yeah!
         url = f"https://wxs.ign.fr/essentiels/alti/rest/elevation.json?lon={longitude_str}&lat={latitude_str}&zonly=true"  # noqa
-        res = requests.get(url)
+        res = requests.get(url, timeout=settings.DEFAULT_HTTP_TIMEOUT)
         data = res.json()
         altis = data["elevations"]
         return altis

--- a/envergo/geodata/management/commands/import_alti.py
+++ b/envergo/geodata/management/commands/import_alti.py
@@ -5,6 +5,7 @@ from queue import Queue
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.management.base import BaseCommand
 from pyproj import Transformer
@@ -58,7 +59,7 @@ class RgeAltiClient:
 
         # Time for the api query, yeah!
         url = f"https://wxs.ign.fr/essentiels/alti/rest/elevation.json?lon={longitude_str}&lat={latitude_str}&zonly=true"  # noqa
-        res = requests.get(url)
+        res = requests.get(url, timeout=settings.DEFAULT_HTTP_TIMEOUT)
         data = res.json()
         altis = data["elevations"]
         return altis

--- a/envergo/geodata/views.py
+++ b/envergo/geodata/views.py
@@ -1,6 +1,7 @@
 import logging
 
 import requests
+from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.serializers import serialize
 from django.http import JsonResponse
@@ -38,10 +39,16 @@ class ParcelsExport(View):
         """Fetch parcel geometry from IGN api."""
 
         url = f"https://geocodage.ign.fr/look4/parcel/search?q={parcelId}&returnTrueGeometry=true"
-        res = requests.get(url)
-        json = res.json()
+        try:
+            res = requests.get(url, timeout=settings.DEFAULT_HTTP_TIMEOUT)
+        except requests.exceptions.RequestException as e:
+            logger.warning(
+                "Error while requesting the IGN parcel geometry api",
+                extra={"parcel": parcelId, "exception": e},
+            )
+            return None
 
-        return json if res.status_code == 200 else None
+        return res.json() if res.status_code == 200 else None
 
     def extract_shape(self, json):
         return shape(json["features"][0]["properties"]["trueGeometry"])

--- a/envergo/hedges/management/commands/update_species_from_taxref.py
+++ b/envergo/hedges/management/commands/update_species_from_taxref.py
@@ -6,6 +6,7 @@ import zipfile
 from tempfile import TemporaryDirectory
 
 import requests
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
@@ -33,7 +34,9 @@ class Command(BaseCommand):
                 file_content = io.BytesIO(f.read())
         else:
             self.stdout.write("Downloading Taxref file")
-            r = requests.get(taxref_url, stream=True)
+            r = requests.get(
+                taxref_url, stream=True, timeout=settings.DEFAULT_HTTP_FILE_TIMEOUT
+            )
             file_content = io.BytesIO(r.content)
 
         with TemporaryDirectory() as tmpdir:

--- a/envergo/hedges/tasks.py
+++ b/envergo/hedges/tasks.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import requests
+from django.conf import settings
 from django.db import IntegrityError
 from django.utils import timezone
 
@@ -101,7 +102,9 @@ def extract_file(field_file):
     """Handle local and remote files."""
 
     if field_file.url.startswith("http"):
-        r = requests.get(field_file.url, stream=True)
+        r = requests.get(
+            field_file.url, stream=True, timeout=settings.DEFAULT_HTTP_FILE_TIMEOUT
+        )
         # utf-8-sig to remove the eventual bom
         content = io.StringIO(r.content.decode("utf-8-sig"))
         return content

--- a/envergo/pages/views.py
+++ b/envergo/pages/views.py
@@ -296,7 +296,7 @@ class Outlinks(TemplateView):
             f"{last_month:%Y-%m-%d},{today:%Y-%m-%d}&method=Actions.getOutlinks&flat=1&token_auth="
             f"{analytics_config["SECURITY_TOKEN"]}&filter_limit=100",
         )
-        data = requests.get(data_url).json()
+        data = requests.get(data_url, timeout=settings.DEFAULT_HTTP_TIMEOUT).json()
 
         links = []
         errors = []
@@ -304,6 +304,9 @@ class Outlinks(TemplateView):
             url = datum["url"]
             label = datum["label"]
             try:
+                # Short, deliberately aggressive timeout: this probes many
+                # third-party links in a loop, so we don't want a single slow
+                # host to stall the whole page.
                 req = requests.head(url, timeout=5)
                 links.append({"label": label, "url": url, "status": req.status_code})
             except Exception as e:

--- a/envergo/petitions/demarches_simplifiees/client.py
+++ b/envergo/petitions/demarches_simplifiees/client.py
@@ -52,6 +52,10 @@ class DemarchesSimplifieesClient:
             headers={
                 "Authorization": f"Bearer {settings.DEMARCHES_SIMPLIFIEES['GRAPHQL_API_BEARER_TOKEN']}"
             },
+            # gql's transport only accepts a single scalar timeout (not the
+            # (connect, read) tuple requests supports), so we pass the read
+            # budget from the shared setting.
+            timeout=settings.DEFAULT_HTTP_TIMEOUT[1],
         )
         self.client = Client(
             transport=self.transport, fetch_schema_from_transport=False
@@ -307,6 +311,7 @@ class DemarchesSimplifieesClient:
                             credentials["url"],
                             data=payload,
                             headers=credentials_headers,
+                            timeout=settings.DEFAULT_HTTP_FILE_TIMEOUT,
                         )
                 except Exception as e:
                     logger.error(

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -438,9 +438,30 @@ class PetitionProjectCreate(FormView):
             )
             return None, None
 
-        response = requests.post(
-            api_url, json=body, headers={"Content-Type": "application/json"}
-        )
+        try:
+            response = requests.post(
+                api_url,
+                json=body,
+                headers={"Content-Type": "application/json"},
+                timeout=settings.DEFAULT_HTTP_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                "Could not reach demarches-simplifiees.fr to pre-fill a dossier",
+                extra={"api_url": api_url, "request_body": body, "exception": e},
+            )
+            self.request.alerts.append(
+                PetitionProjectCreationProblem(
+                    "ds_api_connection_error",
+                    {
+                        "api_url": api_url,
+                        "request_body": body,
+                    },
+                    is_fatal=True,
+                )
+            )
+            return None, None
+
         redirect_url, dossier_number = None, None
         if 200 <= response.status_code < 400:
             data = response.json()

--- a/envergo/templates/haie/petitions/mattermost_project_creation_problem.txt
+++ b/envergo/templates/haie/petitions/mattermost_project_creation_problem.txt
@@ -24,6 +24,14 @@ L'API de Démarches Simplifiées a retourné une erreur lors de la création du 
 ```
 {{ problem.extra.response.text|safe }}
 ```
+{% elif problem.key == "ds_api_connection_error" %}
+L'API de Démarches Simplifiées n'a pas pu être contactée lors de la création du dossier (délai dépassé ou erreur réseau).
+** Requête:**
+* url : {{ problem.extra.api_url }}
+* body :
+```
+{{ problem.extra.request_body|safe }}
+```
 {% elif problem.key == "missing_source_regulation" %}
 La configuration demande de pré-remplir un champ avec la valeur de **{{ problem.extra.source }}** mais la moulinette n'a pas de résultat pour la réglementation **{{ problem.extra.regulation_slug }}**.
 {% elif problem.key == "missing_source_criterion" %}

--- a/envergo/users/views.py
+++ b/envergo/users/views.py
@@ -191,16 +191,21 @@ class NewsletterOptIn(FormView):
             "templateId": int(settings.BREVO["NEWSLETTER_DOUBLE_OPT_IN_TEMPLATE_ID"]),
         }
 
-        response = requests.post(api_url, json=body, headers=headers)
-
-        if 200 <= response.status_code < 400:
-            res = JsonResponse({"status": "ok"})
-        else:
+        try:
+            response = requests.post(
+                api_url,
+                json=body,
+                headers=headers,
+                timeout=settings.DEFAULT_HTTP_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
             logger.error(
                 "Error while creating/updating contact via Brevo API",
                 extra={
-                    "response.status_code": response.status_code,
-                    "response.text": response.text,
+                    "exception": e,
+                    "response.status_code": getattr(e.response, "status_code", None),
+                    "response.text": getattr(e.response, "text", None),
                     "request.url": api_url,
                     "request.body": body,
                 },
@@ -212,6 +217,8 @@ class NewsletterOptIn(FormView):
             )
 
             res = self.form_invalid(form)
+        else:
+            res = JsonResponse({"status": "ok"})
 
         return res
 

--- a/envergo/utils/mattermost.py
+++ b/envergo/utils/mattermost.py
@@ -8,22 +8,31 @@ logger = logging.getLogger(__name__)
 
 
 def notify(msg, site: Literal["haie", "amenagement"]):
-    """Send a simple message in a mattermost channel.
+    """Send a simple message to a mattermost channel, best-effort.
 
-    Which channel is entirely defined in the endpoint settings.
+    Which channel is used is entirely defined by the endpoint settings.
+
+    Notifications are fire-and-forget: a failure to reach Mattermost is logged
+    but never raised. notify is called from both web views and Celery tasks, so
+    raising would either return a 500 to a user or pointlessly retry a whole
+    business task because a non-critical notification could not be delivered.
     """
     endpoint = (
         settings.MATTERMOST_ENDPOINT_HAIE
         if site == "haie"
         else settings.MATTERMOST_ENDPOINT_AMENAGEMENT
     )
-    if endpoint:
-        payload = {"text": msg}
-        r = requests.post(endpoint, json=payload)
-
-        # Make sure we get an error if the notification failed
-        r.raise_for_status()
-    else:
+    if not endpoint:
         logger.warning(
             f"No mattermost endpoint configured. Doing nothing. Message: {msg}"
+        )
+        return
+
+    payload = {"text": msg}
+    try:
+        r = requests.post(endpoint, json=payload, timeout=settings.DEFAULT_HTTP_TIMEOUT)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        logger.warning(
+            "Could not send the mattermost notification", extra={"exception": e}
         )


### PR DESCRIPTION
On ajoute les timeout manquants partout ou le code génère des requêtes http, pour éviter des processus bloqués ad vitam eternam.