### PR TITLE
Sync les dépendences pour le linting entre le local et la ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           python-version: 3.12.8
 
+      # stylelint runs from node_modules (see .pre-commit-config.yaml)
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Install js dependencies
+        run: npm ci
+
       # Run all pre-commit hooks on all the files.
       # Getting only staged files can be tricky in case a new PR is opened
       # since the action is run on a branch in detached head state

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,13 +34,15 @@ repos:
       - id: djlint-reformat-django
       - id: djlint-django
 
-  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
-    rev: 0.0.2
+  # Use the project's own stylelint (locked by package-lock.json) so it can't
+  # drift from the gulp build. Requires `npm ci` beforehand.
+  - repo: local
     hooks:
       - id: stylelint
-        args: [--fix]
-        additional_dependencies:
-          ["stylelint@16.8.1", "stylelint-config-standard-scss@13.1.0"]
+        name: stylelint
+        entry: node_modules/.bin/stylelint --fix
+        language: system
+        files: '\.(css|scss)$'
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -2427,7 +2427,7 @@ main.demos {
     padding: initial;
     margin: initial;
     overflow: visible;
-    clip: auto;
+    clip: auto; /* stylelint-disable-line property-no-deprecated -- overrides DSFR's deprecated `clip: rect()` that hides this label */
     white-space: normal;
     border: initial;
     display: block;

--- a/envergo/static/sass/project_haie.scss
+++ b/envergo/static/sass/project_haie.scss
@@ -1070,7 +1070,6 @@ button.hide-expanded[aria-expanded="true"] {
 
   .comment-col {
     white-space: normal;
-    word-break: break-word;
     overflow-wrap: break-word;
     hyphens: auto;
   }


### PR DESCRIPTION
Sur mon environnement local, lancer `pre-commit --all-files` retourne des centaines de warnings générés par le linter, alors que la ci passe sans problème.

En cause, des dépendances non fixées.

Avec ce fix, le ci et pre-commit utilisent le linter déclaré dans package-lock.json.