### PR TITLE
Passe les données haies en lecture seule

### DIFF
--- a/envergo/hedges/tests/test_views.py
+++ b/envergo/hedges/tests/test_views.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, timedelta
 
 import pytest
@@ -6,6 +7,8 @@ from django.db.backends.postgresql.psycopg_any import DateRange
 from django.urls import reverse
 
 from envergo.contrib.sites.tests.factories import SiteFactory
+from envergo.hedges.models import HedgeData
+from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
 from envergo.moulinette.tests.factories import DCConfigHaieFactory
 from envergo.petitions.tests.factories import PetitionProjectFactory
 
@@ -92,3 +95,29 @@ def test_hedge_conditions_get_returns_405(client):
     url = reverse("hedge_conditions")
     res = client.get(url, {"department": "44"})
     assert res.status_code == 405
+
+
+def test_hedge_input_post_creates_a_new_snapshot(client):
+    """Posting to the id-less url always creates a fresh HedgeData."""
+    payload = [HedgeFactory().toDict()]
+    url = reverse("input_hedges", args=["44", "removal"])
+
+    res = client.post(url, data=json.dumps(payload), content_type="application/json")
+
+    assert res.status_code == 201
+    input_id = res.json()["input_id"]
+    assert HedgeData.objects.filter(id=input_id).exists()
+
+
+def test_hedge_input_post_to_existing_uuid_is_rejected(client):
+    """Updating an existing snapshot via its shareable uuid is forbidden."""
+    hedge_data = HedgeDataFactory()
+    original_data = hedge_data.data
+    tampered = [HedgeFactory(length=999).toDict()]
+    url = reverse("input_hedges", args=["44", "removal", hedge_data.id])
+
+    res = client.post(url, data=json.dumps(tampered), content_type="application/json")
+
+    assert res.status_code == 405
+    hedge_data.refresh_from_db()
+    assert hedge_data.data == original_data

--- a/envergo/hedges/views.py
+++ b/envergo/hedges/views.py
@@ -176,11 +176,14 @@ class HedgeInput(MoulinetteMixin, FormMixin, DetailView):
         return context
 
     def post(self, request, *args, **kwargs):
+        # Snapshots are immutable: the id-based url is display-only. A shared
+        # uuid must not let anyone overwrite hedges attached to a dossier.
+        if kwargs.get("id"):
+            return JsonResponse({"error": "Method not allowed"}, status=405)
+
         try:
             data = json.loads(request.body)
-            hedge_data, created = HedgeData.objects.update_or_create(
-                id=kwargs.get("id"), defaults={"data": data}
-            )
+            hedge_data = HedgeData.objects.create(data=data)
             response_data = {
                 "input_id": str(hedge_data.id),
                 "hedges_to_plant": len(hedge_data.hedges_to_plant()),
@@ -191,8 +194,7 @@ class HedgeInput(MoulinetteMixin, FormMixin, DetailView):
                 "l350_3_to_remove": hedge_data.hedges_to_remove().l350_3().length,
                 "hru_to_remove": hedge_data.hedges_to_remove().hru().length,
             }
-            status_code = 201 if created else 200
-            return JsonResponse(response_data, status=status_code)
+            return JsonResponse(response_data, status=201)
         except json.JSONDecodeError:
             return JsonResponse({"error": "Invalid JSON data"}, status=400)
         except Exception as e:


### PR DESCRIPTION
https://trello.com/c/4U9Fj18s/2468-alert-s%C3%A9cu-yeswehack-possibilit%C3%A9-de-corrompre-les-donn%C3%A9es-haies-dun-dossier-ouvert

Du point de vue du frontend, les haies sont en lecture seule : chaque enregistrement créé un nouvel objet. Mais cette règle n'est pas vérifiée en backend, qui autorise toujours à modifier des haies existantes. Il est donc techniquement possible de modifier des haies, même déjà associées à des dossiers en instruction.