### PR TITLE
Remove N2000 message en cours d'import

### DIFF
--- a/envergo/templates/haie/moulinette/confighaie_settings.html
+++ b/envergo/templates/haie/moulinette/confighaie_settings.html
@@ -70,12 +70,6 @@
         </p>
       </div>
 
-      <h3 class="fr-h5">Natura 2000</h3>
-
-      <p>
-        <em>Carte en cours d'import dans le portail.</em>
-      </p>
-
       {% if grouped_criteria or density_maps %}
 
         {% for regulation, criteria in grouped_criteria.items %}


### PR DESCRIPTION
Hot fix conflit de merge

[Cette PR](https://github.com/MTES-MCT/envergo/pull/1140/changes) a supprimé la mention "Natura 2000 : carte en cours d'import dans le portail"
Mais [ce commit](https://github.com/MTES-MCT/envergo/commit/d8aa553623d435f3ebcc64ccaab288ca09a5c545) l'a remis sans faire exprès.

<img width="720" height="476" alt="image" src="https://github.com/user-attachments/assets/fb3671ff-6576-4c07-84b6-30451426ebd6" />
