### PR TITLE
Sentry batch 20260625

### DIFF
--- a/envergo/static/js/libs/configure-upload-form.js
+++ b/envergo/static/js/libs/configure-upload-form.js
@@ -17,7 +17,7 @@ window.addEventListener('load', function () {
     acceptedFiles: 'image/*,application/pdf,application/zip,application/x-zip-compressed,application/octet-stream,.zip',
     autoProcessQueue: true,
     uploadMultiple: false,
-    parallelUploads: 100,
+    parallelUploads: 1,
     addRemoveLinks: true,
     previewsContainer: previewElt,
     clickable: previewElt,

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -8,7 +8,38 @@
         // Noise from browser extensions (privacy/anti-fingerprinting tools)
         // calling stale postMessage RPC handles. Not actionable on our end.
         // See sentry.incubateur.net/.../285185 (ENVERGO-1BE).
-        ignoreErrors: [/Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+$/],
+        ignoreErrors: [
+          /Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+$/,
+          // Cashback/coupon shopping browser extensions injecting their own
+          // script (response.cashbackReminder), not our code.
+          // See sentry.incubateur.net/.../283316.
+          /response\.cashbackReminder/,
+        ],
+        // Syntax errors thrown by the Crisp chat widget's own bundle, not by
+        // our code. See sentry.incubateur.net/.../272786 (ENVERGO-19F).
+        denyUrls: [/client\.crisp\.chat/],
+        beforeSend: function (event) {
+          // Drop opaque "Script error."-style events: a single frame with no
+          // line/col info, pointing at the page itself rather than a real
+          // script. These come from cross-origin scripts (browser
+          // extensions) the browser intentionally hides details for, not
+          // from our code. See sentry.incubateur.net/.../221261 (ENVERGO-VG).
+          var frames =
+            event.exception &&
+            event.exception.values &&
+            event.exception.values[0] &&
+            event.exception.values[0].stacktrace &&
+            event.exception.values[0].stacktrace.frames;
+          if (
+            frames &&
+            frames.length === 1 &&
+            frames[0].lineno == null &&
+            frames[0].colno == null
+          ) {
+            return null;
+          }
+          return event;
+        },
       });
     };
   </script>

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -7,23 +7,20 @@
         environment: "{{ ENV_NAME }}",
         // Noise from browser extensions (privacy/anti-fingerprinting tools)
         // calling stale postMessage RPC handles. Not actionable on our end.
-        // See sentry.incubateur.net/.../285185 (ENVERGO-1BE).
         ignoreErrors: [
           /Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+$/,
           // Cashback/coupon shopping browser extensions injecting their own
           // script (response.cashbackReminder), not our code.
-          // See sentry.incubateur.net/.../283316.
           /response\.cashbackReminder/,
         ],
         // Syntax errors thrown by the Crisp chat widget's own bundle, not by
-        // our code. See sentry.incubateur.net/.../272786 (ENVERGO-19F).
-        denyUrls: [/client\.crisp\.chat/],
+        // our code.
         beforeSend: function (event) {
           // Drop opaque "Script error."-style events: a single frame with no
           // line/col info, pointing at the page itself rather than a real
           // script. These come from cross-origin scripts (browser
           // extensions) the browser intentionally hides details for, not
-          // from our code. See sentry.incubateur.net/.../221261 (ENVERGO-VG).
+          // from our code.
           var frames =
             event.exception &&
             event.exception.values &&
@@ -37,6 +34,17 @@
             frames[0].colno == null
           ) {
             return null;
+          }
+          // Syntax errors from Crisp's own bundle (not our code) — kept at
+          // info level for visibility.
+          if (
+            frames &&
+            frames.some(function (f) {
+              return f.filename && /client\.crisp\.chat/.test(f.filename);
+            })
+          ) {
+            event.level = "info";
+            return event;
           }
           return event;
         },

--- a/envergo/templates/_sentry.html
+++ b/envergo/templates/_sentry.html
@@ -3,7 +3,13 @@
 {% if SENTRY_KEY %}
   <script>
     window.sentryOnLoad = function () {
-      Sentry.init({ environment: "{{ ENV_NAME }}" });
+      Sentry.init({
+        environment: "{{ ENV_NAME }}",
+        // Noise from browser extensions (privacy/anti-fingerprinting tools)
+        // calling stale postMessage RPC handles. Not actionable on our end.
+        // See sentry.incubateur.net/.../285185 (ENVERGO-1BE).
+        ignoreErrors: [/Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+$/],
+      });
     };
   </script>
   <script src="https://sentry.incubateur.net/js-sdk-loader/{{ SENTRY_KEY }}.min.js"


### PR DESCRIPTION
Traitements des bugs sentry avec le plus d'occurences ces dernieres semaines.

@reviewers Je suis en plein doute concernant les commits 1 et 3. Il s'agit de code indiquant au sdk sentry d'ignorer certaines erreurs car elles ne sont pas actionnable de notre côté. Crisp, crawler/bot, extensions navigateur etc, il y a plein de trucs qui viennent lever des exceptions et bruiter notre tableau de bord sentry. 
Les ignorer permet de réduire le bruit, MAIS 1. on passe peut etre à côté d'info importante et 2. cette course contre les erreurs absurdes est peut etre sans fin.