### PR TITLE
Gestion des dossiers multi-départements

### DIFF
--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -489,6 +489,8 @@ class HedgeData(models.Model):
         if update_fields is None or "data" in update_fields:
             self._length_to_remove = None
             self._length_to_plant = None
+            if hasattr(self, "_departments_lengths"):
+                del self._departments_lengths
             self._length_to_remove = self.length_to_remove()
             self._length_to_plant = self.length_to_plant()
 
@@ -669,43 +671,39 @@ class HedgeData(models.Model):
 
         hedges_to_remove = self.hedges_to_remove()
         if not hedges_to_remove:
-            return []
+            self._departments_lengths = []
+            return self._departments_lengths
 
         to_remove_geom = hedges_to_remove.to_multilinestring()
-        qs = (
+        intersecting_departments = (
             Department.objects.filter(geometry__intersects=to_remove_geom)
             .annotate(
-                clipped=Intersection("geometry", to_remove_geom),
-                hedge_length=Length("clipped"),
+                clipped_hedges=Intersection("geometry", to_remove_geom),
+                hedge_length=Length("clipped_hedges"),
             )
             .defer("geometry")
             .order_by("-hedge_length")
         )
-        self._departments_lengths = [(dept, dept.hedge_length.m) for dept in qs]
+        self._departments_lengths = [
+            (dept, dept.hedge_length.m) for dept in intersecting_departments
+        ]
         return self._departments_lengths
 
     def is_multi_departments(self):
         """Return True if hedges intersect more than one department."""
-
         return len(self.departments_lengths()) > 1
 
     def main_department(self):
-        """Return the Department that contains most of the hedges (in total length).
-
-        Returns None if no department intersects the hedges.
-        """
+        """Return the Department with the most hedge length, or None."""
         lengths = self.departments_lengths()
         if not lengths:
             return None
         return lengths[0][0]
 
     def is_outside_department(self, department):
-        """Return True if most hedges are outside the given department."""
-
+        """Return True if the main department differs from the given one."""
         main = self.main_department()
-        if main is None:
-            return False
-        return main != department
+        return main is not None and main != department
 
     def get_statistics(self):
         hedge_centroid_coords = self.hedges_to_remove().centroid

--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -691,15 +691,22 @@ class HedgeData(models.Model):
         return len(self.departments_lengths()) > 1
 
     def main_department(self):
-        """Return the Department that contains most of the hedges (in total length)."""
+        """Return the Department that contains most of the hedges (in total length).
 
-        main_dept = self.departments_lengths()[0][0]
-        return main_dept
+        Returns None if no department intersects the hedges.
+        """
+        lengths = self.departments_lengths()
+        if not lengths:
+            return None
+        return lengths[0][0]
 
     def is_outside_department(self, department):
         """Return True if most hedges are outside the given department."""
 
-        return self.main_department() != department
+        main = self.main_department()
+        if main is None:
+            return False
+        return main != department
 
 
     def get_statistics(self):

--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import Self
 
 from django.conf import settings
+from django.contrib.gis.db.models.functions import Intersection, Length
 from django.contrib.gis.geos import GEOSGeometry, MultiLineString, Polygon
 from django.contrib.gis.measure import D
 from django.contrib.postgres.fields import ArrayField
@@ -486,7 +487,6 @@ class HedgeData(models.Model):
     def save(self, *args, **kwargs):
         update_fields = kwargs.get("update_fields")
         if update_fields is None or "data" in update_fields:
-            # recompute cached value
             self._length_to_remove = None
             self._length_to_plant = None
             self._length_to_remove = self.length_to_remove()
@@ -655,23 +655,52 @@ class HedgeData(models.Model):
             "Use density_around_centroid or density_around_lines instead of density."
         )
 
-    def has_hedges_outside_department(self, department: Department):
-        """
-        Check if any hedge in the HedgeData instance is outside the given department geometry.
 
-        Args:
-            department: The department model with its geometry prefetched.
+    def departments_lengths(self):
+        """Return the list of departments intersected by the hedges.
 
-        Returns:
-            bool: True if there are hedges outside the department geometry, False otherwise.
+        Return an ordered list of (Department, length) tuples where:
+         - Department is the intersected geodata.models.Department object
+         - length is the total length of hedges intersecting the department.
+
+        Result is ordered by decreasing length.
         """
-        if not department:
-            return True
-        department_geom = GEOSGeometry(department.geometry.wkt)
-        for hedge in self.hedges():
-            if not department_geom.intersects(hedge.geos_geometry):
-                return True
-        return False
+        if hasattr(self, "_departments_lengths"):
+            return self._departments_lengths
+
+        hedges_to_remove = self.hedges_to_remove()
+        if not hedges_to_remove:
+            return []
+
+        to_remove_geom = hedges_to_remove.to_multilinestring()
+        qs = (
+            Department.objects.filter(geometry__intersects=to_remove_geom)
+            .annotate(
+                clipped=Intersection("geometry", to_remove_geom),
+                hedge_length=Length("clipped"),
+            )
+            .defer("geometry")
+            .order_by("-hedge_length")
+        )
+        self._departments_lengths = [(dept, dept.hedge_length.m) for dept in qs]
+        return self._departments_lengths
+
+    def is_multi_departments(self):
+        """Return True if hedges intersect more than one department."""
+
+        return len(self.departments_lengths()) > 1
+
+    def main_department(self):
+        """Return the Department that contains most of the hedges (in total length)."""
+
+        main_dept = self.departments_lengths()[0][0]
+        return main_dept
+
+    def is_outside_department(self, department):
+        """Return True if most hedges are outside the given department."""
+
+        return self.main_department() != department
+
 
     def get_statistics(self):
         hedge_centroid_coords = self.hedges_to_remove().centroid

--- a/envergo/hedges/models.py
+++ b/envergo/hedges/models.py
@@ -655,7 +655,6 @@ class HedgeData(models.Model):
             "Use density_around_centroid or density_around_lines instead of density."
         )
 
-
     def departments_lengths(self):
         """Return the list of departments intersected by the hedges.
 
@@ -707,7 +706,6 @@ class HedgeData(models.Model):
         if main is None:
             return False
         return main != department
-
 
     def get_statistics(self):
         hedge_centroid_coords = self.hedges_to_remove().centroid

--- a/envergo/hedges/tests/test_models.py
+++ b/envergo/hedges/tests/test_models.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError, transaction
 from shapely import centroid
 
 from envergo.geodata.conftest import aisne_map, calvados_map  # noqa
+from envergo.geodata.models import Department
 from envergo.geodata.tests.factories import (
     DepartmentFactory,
     MapFactory,
@@ -1736,3 +1737,178 @@ def test_hedge_length_is_geodesic_meters():
 
     assert hedge.length == pytest.approx(8074.307052980297, rel=1e-9)
     assert hedge.length > 1000
+
+
+# Two adjacent rectangular departments sharing a border at lng=3.0.
+# dept_west covers lng [2.0, 3.0], dept_east covers lng [3.0, 4.0].
+# Both span lat [43.0, 44.0].
+dept_west_geom = MultiPolygon(
+    [Polygon([(2.0, 43.0), (3.0, 43.0), (3.0, 44.0), (2.0, 44.0), (2.0, 43.0)])]
+)
+dept_east_geom = MultiPolygon(
+    [Polygon([(3.0, 43.0), (4.0, 43.0), (4.0, 44.0), (3.0, 44.0), (3.0, 43.0)])]
+)
+
+
+def make_horizontal_hedge(lat, lng_start, lng_end):
+    """Create a TO_REMOVE hedge as a horizontal line at given latitude."""
+    return HedgeFactory(
+        latLngs=[
+            {"lat": lat, "lng": lng_start},
+            {"lat": lat, "lng": lng_end},
+        ],
+    )
+
+
+class TestDepartmentsLengths:
+    """Test multi-department hedge length allocation and derived helpers."""
+
+    def create_departments(self):
+        west = DepartmentFactory(department="44", geometry=dept_west_geom)
+        east = DepartmentFactory(department="34", geometry=dept_east_geom)
+        return west, east
+
+    def test_single_department(self):
+        """All hedges inside one department → single result."""
+        west, east = self.create_departments()
+        hedge = make_horizontal_hedge(43.5, 2.3, 2.7)
+        hd = HedgeDataFactory(hedges=[hedge])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 1
+        dept, length = result[0]
+        assert dept == west
+        assert length > 0
+
+    def test_two_departments_separate_hedges(self):
+        """Two hedges, each in a different department → two results."""
+        west, east = self.create_departments()
+        h_west = make_horizontal_hedge(43.5, 2.3, 2.7)
+        h_east = make_horizontal_hedge(43.5, 3.3, 3.7)
+        hd = HedgeDataFactory(hedges=[h_west, h_east])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 2
+        depts = {dept for dept, _ in result}
+        assert depts == {west, east}
+
+    def test_ordered_by_decreasing_length(self):
+        """Result is sorted by decreasing total length per department."""
+        west, east = self.create_departments()
+        h_w1 = make_horizontal_hedge(43.5, 2.3, 2.4)
+        h_w2 = make_horizontal_hedge(43.6, 2.3, 2.4)
+        h_east = make_horizontal_hedge(43.5, 3.1, 3.9)
+        hd = HedgeDataFactory(hedges=[h_w1, h_w2, h_east])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 2
+        assert result[0][0] == east, "East has the longest total and should come first"
+        assert result[0][1] > result[1][1]
+
+    def test_hedge_crossing_border_is_split(self):
+        """A hedge crossing the border is allocated proportionally to each side."""
+        west, east = self.create_departments()
+        hedge = make_horizontal_hedge(43.5, 2.5, 3.5)
+        hd = HedgeDataFactory(hedges=[hedge])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 2
+        lengths = {dept: length for dept, length in result}
+        assert west in lengths
+        assert east in lengths
+        total = lengths[west] + lengths[east]
+        assert abs(lengths[west] / total - 0.5) < 0.1
+        assert abs(lengths[east] / total - 0.5) < 0.1
+
+    def test_hedge_crossing_border_asymmetric(self):
+        """A hedge crossing the border unevenly allocates proportionally."""
+        west, east = self.create_departments()
+        # lng 2.0 → 3.5: 2/3 in west, 1/3 in east
+        hedge = make_horizontal_hedge(43.5, 2.0, 3.5)
+        hd = HedgeDataFactory(hedges=[hedge])
+
+        result = hd.departments_lengths()
+
+        lengths = {dept: length for dept, length in result}
+        ratio = lengths[west] / lengths[east]
+        assert 1.5 < ratio < 2.5
+
+    def test_departments_deduplicated(self):
+        """Multiple hedges in the same department produce a single entry."""
+        west, east = self.create_departments()
+        h1 = make_horizontal_hedge(43.5, 2.2, 2.4)
+        h2 = make_horizontal_hedge(43.6, 2.5, 2.8)
+        h3 = make_horizontal_hedge(43.7, 2.1, 2.3)
+        hd = HedgeDataFactory(hedges=[h1, h2, h3])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 1
+        assert result[0][0] == west
+
+    def test_only_hedges_to_remove_are_counted(self):
+        """Hedges marked TO_PLANT are excluded from the computation."""
+        west, east = self.create_departments()
+        h_remove = make_horizontal_hedge(43.5, 2.3, 2.7)
+        h_plant = HedgeFactory(
+            to_plant=True,
+            latLngs=[
+                {"lat": 43.5, "lng": 3.3},
+                {"lat": 43.5, "lng": 3.7},
+            ],
+        )
+        hd = HedgeDataFactory(hedges=[h_remove, h_plant])
+
+        result = hd.departments_lengths()
+
+        assert len(result) == 1
+        assert result[0][0] == west
+
+    def test_lengths_are_in_meters(self):
+        """Returned lengths should be in meters, not degrees."""
+        west, east = self.create_departments()
+        hedge = make_horizontal_hedge(43.5, 2.3, 2.7)
+        hd = HedgeDataFactory(hedges=[hedge])
+
+        result = hd.departments_lengths()
+
+        dept, length = result[0]
+        # 0.4° longitude at lat ~43.5 ≈ 32 km
+        assert length > 1000, "Length should be in meters, not degrees"
+        assert length < 100_000, "Length should be reasonable"
+
+    def test_is_multi_departments_false(self):
+        DepartmentFactory(department="44", geometry=dept_west_geom)
+        hedge = make_horizontal_hedge(43.5, 2.3, 2.7)
+        hd = HedgeDataFactory(hedges=[hedge])
+
+        assert not hd.is_multi_departments()
+
+    def test_is_multi_departments_true(self):
+        self.create_departments()
+        h1 = make_horizontal_hedge(43.5, 2.3, 2.7)
+        h2 = make_horizontal_hedge(43.5, 3.3, 3.7)
+        hd = HedgeDataFactory(hedges=[h1, h2])
+
+        assert hd.is_multi_departments()
+
+    def test_main_department(self):
+        west, east = self.create_departments()
+        h_short = make_horizontal_hedge(43.5, 2.4, 2.5)
+        h_long = make_horizontal_hedge(43.5, 3.1, 3.9)
+        hd = HedgeDataFactory(hedges=[h_short, h_long])
+
+        assert hd.main_department() == east
+
+    def test_is_outside_department(self):
+        west, east = self.create_departments()
+        h_short = make_horizontal_hedge(43.5, 2.4, 2.5)
+        h_long = make_horizontal_hedge(43.5, 3.1, 3.9)
+        hd = HedgeDataFactory(hedges=[h_short, h_long])
+
+        assert hd.is_outside_department(west)
+        assert not hd.is_outside_department(east)

--- a/envergo/hedges/tests/test_models.py
+++ b/envergo/hedges/tests/test_models.py
@@ -1867,19 +1867,6 @@ class TestDepartmentsLengths:
         assert len(result) == 1
         assert result[0][0] == west
 
-    def test_lengths_are_in_meters(self):
-        """Returned lengths should be in meters, not degrees."""
-        west, east = self.create_departments()
-        hedge = make_horizontal_hedge(43.5, 2.3, 2.7)
-        hd = HedgeDataFactory(hedges=[hedge])
-
-        result = hd.departments_lengths()
-
-        dept, length = result[0]
-        # 0.4° longitude at lat ~43.5 ≈ 32 km
-        assert length > 1000, "Length should be in meters, not degrees"
-        assert length < 100_000, "Length should be reasonable"
-
     def test_is_multi_departments_false(self):
         DepartmentFactory(department="44", geometry=dept_west_geom)
         hedge = make_horizontal_hedge(43.5, 2.3, 2.7)

--- a/envergo/hedges/tests/test_models.py
+++ b/envergo/hedges/tests/test_models.py
@@ -6,7 +6,6 @@ from django.db import IntegrityError, transaction
 from shapely import centroid
 
 from envergo.geodata.conftest import aisne_map, calvados_map  # noqa
-from envergo.geodata.models import Department
 from envergo.geodata.tests.factories import (
     DepartmentFactory,
     MapFactory,

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2868,12 +2868,15 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         """Fetch / compute data required for further computations."""
 
         data = super().get_catalog_data()
-        # TODO check if this goes in extra context
         if "haies" in data:
             hedges = data["haies"]
-            data["has_hedges_outside_department"] = (
-                hedges.has_hedges_outside_department(self.department)
-            )
+            data["main_department"] = hedges.main_department()
+            data["is_multi_departments"] = hedges.is_multi_departments()
+            data["is_outside_department"] = hedges.is_outside_department(self.department)
+
+            main_department_simulation_url = ""
+            data["main_department_simulation_url"] = main_department_simulation_url
+
             data["hedges_by_category"] = hedges.get_hedges_by_category(
                 self.config.single_procedure
             )

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2874,9 +2874,6 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             data["is_multi_departments"] = hedges.is_multi_departments()
             data["is_outside_department"] = hedges.is_outside_department(self.department)
 
-            main_department_simulation_url = ""
-            data["main_department_simulation_url"] = main_department_simulation_url
-
             data["hedges_by_category"] = hedges.get_hedges_by_category(
                 self.config.single_procedure
             )

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2873,7 +2873,9 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             data["departments_lengths"] = hedges.departments_lengths()
             data["main_department"] = hedges.main_department()
             data["is_multi_departments"] = hedges.is_multi_departments()
-            data["is_outside_department"] = hedges.is_outside_department(self.department)
+            data["is_outside_department"] = hedges.is_outside_department(
+                self.department
+            )
 
             data["hedges_by_category"] = hedges.get_hedges_by_category(
                 self.config.single_procedure

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2870,6 +2870,7 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         data = super().get_catalog_data()
         if "haies" in data:
             hedges = data["haies"]
+            data["departments_lengths"] = hedges.departments_lengths()
             data["main_department"] = hedges.main_department()
             data["is_multi_departments"] = hedges.is_multi_departments()
             data["is_outside_department"] = hedges.is_outside_department(self.department)

--- a/envergo/moulinette/tests/test_evalenv.py
+++ b/envergo/moulinette/tests/test_evalenv.py
@@ -257,7 +257,7 @@ def test_evalenv_non_soumis_no_optional_criteria(admin_client):
     res = admin_client.get(f"{url}?{params}")
 
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     content = res.content.decode()
     assert (
         "Le projet n’est pas soumis à évaluation environnementale au titre des seuils "
@@ -296,7 +296,7 @@ def test_evalenv_non_soumis_optional_criteria(admin_client):
     res = admin_client.get(f"{url}?{params}")
 
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     content = res.content.decode()
     assert (
         "Le projet n’est pas soumis à évaluation environnementale au titre des seuils "
@@ -321,7 +321,7 @@ def test_evalenv_rubrique44(admin_client):
     )
     res = admin_client.get(f"{url}?{params}")
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     assert (
         "Le projet mène à l’existence d’un équipement sportif, de loisirs, ou lié à une activité culturelle, d’une "
         "capacité d’accueil de plus de 1000 personnes" in res.content.decode()
@@ -335,7 +335,7 @@ def test_evalenv_rubrique44(admin_client):
     )
     res = admin_client.get(f"{url}?{params}")
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     assert (
         "Le projet porte sur un équipement sportif, de loisirs, ou lié à une activité culturelle, mais dont la capacité"
         " d’accueil est inférieure à 1000 personnes" in res.content.decode()
@@ -349,7 +349,7 @@ def test_evalenv_rubrique44(admin_client):
     )
     res = admin_client.get(f"{url}?{params}")
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     assert (
         "Le projet ne concerne pas un équipement sportif, de loisirs, ou d’activités culturelles."
         in res.content.decode()
@@ -525,4 +525,4 @@ class TestICPEFormValidation:
         res = _get_icpe_result(staff_client, "creation", "enregistrement")
 
         assert res.status_code == 200
-        assertTemplateUsed(res, "moulinette/result.html")
+        assertTemplateUsed(res, "amenagement/moulinette/result.html")

--- a/envergo/moulinette/tests/test_optional_criteria.py
+++ b/envergo/moulinette/tests/test_optional_criteria.py
@@ -81,7 +81,7 @@ def test_user_see_optional_criterion_result(client):
     res = client.get(full_url)
 
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
 
     # The criterion is activated
     assert "Aire de stationnement" in res.content.decode()

--- a/envergo/moulinette/tests/test_staff_only_criteria.py
+++ b/envergo/moulinette/tests/test_staff_only_criteria.py
@@ -66,7 +66,7 @@ class TestICPEStaffOnlyVisibility:
         res = staff_client.get(url)
 
         assert res.status_code == 200
-        assertTemplateUsed(res, "moulinette/result.html")
+        assertTemplateUsed(res, "amenagement/moulinette/result.html")
         assert "installation classée (icpe)" in res.content.decode().lower()
 
     def test_staff_haie_only_can_see_icpe_form(self, client):

--- a/envergo/moulinette/tests/test_views.py
+++ b/envergo/moulinette/tests/test_views.py
@@ -103,7 +103,7 @@ def test_moulinette_result_with_deactivated_config_admin_access(client, admin_us
     res = client.get(full_url)
 
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
     assert ADMIN_MSG in res.content.decode()
 
 
@@ -116,7 +116,7 @@ def test_moulinette_result_with_activated_config(client):
     res = client.get(full_url)
 
     assert res.status_code == 200
-    assertTemplateUsed(res, "moulinette/result.html")
+    assertTemplateUsed(res, "amenagement/moulinette/result.html")
 
 
 def test_moulinette_result_without_params_redirects_to_home(client):

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -8,7 +8,9 @@ from django.db.backends.postgresql.psycopg_any import DateRange
 from django.urls import reverse
 
 from envergo.analytics.models import Event
-from envergo.geodata.tests.factories import DepartmentFactory
+from django.contrib.gis.geos import MultiPolygon
+
+from envergo.geodata.tests.factories import DepartmentFactory, calvados_polygon
 from envergo.hedges.models import HedgeCategory
 from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
 from envergo.moulinette.tests.factories import (
@@ -433,6 +435,9 @@ def test_result_p_view_with_hedges_to_remove_outside_department(client):
 
     # GIVEN a moulinette with at least an hedge to remove outside the department
     DCConfigHaieFactory()
+    DepartmentFactory(
+        department="14", geometry=MultiPolygon([calvados_polygon])
+    )
     hedge_14 = HedgeFactory(
         latLngs=[
             {"lat": 49.37830760743562, "lng": 0.10241746902465822},
@@ -460,7 +465,7 @@ def test_result_p_view_with_hedges_to_remove_outside_department(client):
     res = client.get(f"{url}?{query}")
 
     # THEN the result page is displayed with a warning
-    assert res.context["has_hedges_outside_department"]
+    assert res.context["is_outside_department"]
     assert "Le projet est hors du département sélectionné" in res.content.decode()
 
     # Given hedges in department 44 and accross the department border
@@ -484,7 +489,7 @@ def test_result_p_view_with_hedges_to_remove_outside_department(client):
     res = client.get(f"{url}?{query}")
 
     # THEN the result page is displayed without warning
-    assert not res.context["has_hedges_outside_department"]
+    assert not res.context["is_outside_department"]
     assert "Le projet est hors du département sélectionné" not in res.content.decode()
 
 

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -4,12 +4,11 @@ from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
+from django.contrib.gis.geos import MultiPolygon
 from django.db.backends.postgresql.psycopg_any import DateRange
 from django.urls import reverse
 
 from envergo.analytics.models import Event
-from django.contrib.gis.geos import MultiPolygon
-
 from envergo.geodata.tests.factories import DepartmentFactory, calvados_polygon
 from envergo.hedges.models import HedgeCategory
 from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
@@ -435,9 +434,7 @@ def test_result_p_view_with_hedges_to_remove_outside_department(client):
 
     # GIVEN a moulinette with at least an hedge to remove outside the department
     DCConfigHaieFactory()
-    DepartmentFactory(
-        department="14", geometry=MultiPolygon([calvados_polygon])
-    )
+    DepartmentFactory(department="14", geometry=MultiPolygon([calvados_polygon]))
     hedge_14 = HedgeFactory(
         latLngs=[
             {"lat": 49.37830760743562, "lng": 0.10241746902465822},

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -508,7 +508,7 @@ class MoulinetteResultMixin:
         if moulinette:
             context["base_result"] = moulinette.get_result_template()
         else:
-            context["base_result"] = "moulinette/base_result.html"
+            context["base_result"] = "moulinette/result_layout.html"
 
         if moulinette and is_debug:
             debug_context_data = moulinette.get_debug_context()
@@ -622,13 +622,15 @@ class MoulinetteHaieResult(
             context["CityHallSubmission"] = CityHallSubmission
             context["AaL3503Handling"] = AaL3503Handling
 
-            # Compute url corresponding to the department with the most hedges inside
-            root_url = self.request.build_absolute_uri(reverse("moulinette_form"))
-            querystring = self.request.GET.urlencode()
-            moulinette_url = f'{root_url}?{querystring}'
-            dept_param = {"department": hedge_data.main_department().department}
-            main_department_simulation_url = update_qs(moulinette_url, dept_param)
-            context["main_department_simulation_url"] = main_department_simulation_url
+            main_dept = hedge_data.main_department()
+            if main_dept:
+                root_url = self.request.build_absolute_uri(reverse("moulinette_form"))
+                querystring = self.request.GET.urlencode()
+                moulinette_url = f"{root_url}?{querystring}"
+                dept_param = {"department": main_dept.department}
+                context["main_department_simulation_url"] = update_qs(
+                    moulinette_url, dept_param
+                )
 
         return context
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -622,6 +622,14 @@ class MoulinetteHaieResult(
             context["CityHallSubmission"] = CityHallSubmission
             context["AaL3503Handling"] = AaL3503Handling
 
+            # Compute url corresponding to the department with the most hedges inside
+            root_url = self.request.build_absolute_uri(reverse("moulinette_form"))
+            querystring = self.request.GET.urlencode()
+            moulinette_url = f'{root_url}?{querystring}'
+            dept_param = {"department": hedge_data.main_department().department}
+            main_department_simulation_url = update_qs(moulinette_url, dept_param)
+            context["main_department_simulation_url"] = main_department_simulation_url
+
         return context
 
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -622,14 +622,12 @@ class MoulinetteHaieResult(
             context["CityHallSubmission"] = CityHallSubmission
             context["AaL3503Handling"] = AaL3503Handling
 
-            main_dept = hedge_data.main_department()
-            if main_dept:
-                root_url = self.request.build_absolute_uri(reverse("moulinette_form"))
-                querystring = self.request.GET.urlencode()
-                moulinette_url = f"{root_url}?{querystring}"
-                dept_param = {"department": main_dept.department}
+            main_department = hedge_data.main_department()
+            if main_department:
+                form_url = self.request.build_absolute_uri(reverse("moulinette_form"))
+                form_url = update_qs(form_url, self.request.GET)
                 context["main_department_simulation_url"] = update_qs(
-                    moulinette_url, dept_param
+                    form_url, {"department": main_department.department}
                 )
 
         return context

--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -6,6 +6,7 @@ import pytest
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.gis.geos import MultiPolygon
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.backends.postgresql.psycopg_any import DateRange
 from django.test import RequestFactory, override_settings
@@ -15,8 +16,6 @@ from django.utils.functional import cached_property
 
 from envergo.analytics.models import Event
 from envergo.geodata.conftest import france_map, loire_atlantique_map  # noqa
-from django.contrib.gis.geos import MultiPolygon
-
 from envergo.geodata.tests.factories import (
     Department34Factory,
     DepartmentFactory,
@@ -1347,9 +1346,7 @@ def test_instructor_view_multi_departments_alert(client, haie_instructor_44):
 
     client.force_login(haie_instructor_44)
     DCConfigHaieFactory()
-    DepartmentFactory(
-        department="14", geometry=MultiPolygon([calvados_polygon])
-    )
+    DepartmentFactory(department="14", geometry=MultiPolygon([calvados_polygon]))
 
     # GIVEN hedges in department 14 while the project is declared in department 44
     hedge_14 = HedgeFactory(

--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -15,7 +15,13 @@ from django.utils.functional import cached_property
 
 from envergo.analytics.models import Event
 from envergo.geodata.conftest import france_map, loire_atlantique_map  # noqa
-from envergo.geodata.tests.factories import Department34Factory
+from django.contrib.gis.geos import MultiPolygon
+
+from envergo.geodata.tests.factories import (
+    Department34Factory,
+    DepartmentFactory,
+    calvados_polygon,
+)
 from envergo.hedges.models import TO_PLANT, HedgeTypeBase
 from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
 from envergo.moulinette.tests.factories import (
@@ -267,6 +273,7 @@ def test_petition_project_detail(mock_post, client, site, conditionnalite_pac_cr
     mock_post.return_value = mock_response
 
     DCConfigHaieFactory()
+    Department34Factory()
     project = PetitionProjectFactory()
 
     petition_project_url = reverse(
@@ -281,7 +288,7 @@ def test_petition_project_detail(mock_post, client, site, conditionnalite_pac_cr
         category="simulateur", event="consultation", metadata__user_type="anonymous"
     )
     # default PetitionProjectFactory has hedges near Aniane but is declared in department 44
-    assert response.context["has_hedges_outside_department"]
+    assert response.context["is_outside_department"]
     assert "Le projet est hors du département sélectionné" in response.content.decode()
 
     # Given hedges in department 44 and across the department border
@@ -308,7 +315,7 @@ def test_petition_project_detail(mock_post, client, site, conditionnalite_pac_cr
     response = client.get(petition_project_url)
 
     # THEN I should see that there is no hedges to remove outside the department
-    assert not response.context["has_hedges_outside_department"]
+    assert not response.context["is_outside_department"]
     assert (
         "Le projet est hors du département sélectionné" not in response.content.decode()
     )
@@ -1341,6 +1348,9 @@ def test_instructor_view_with_hedges_outside_department(client, haie_instructor_
 
     client.force_login(haie_instructor_44)
     DCConfigHaieFactory()
+    DepartmentFactory(
+        department="14", geometry=MultiPolygon([calvados_polygon])
+    )
     hedge_14 = HedgeFactory(
         latLngs=[
             {"lat": 49.37830760743562, "lng": 0.10241746902465822},
@@ -1357,7 +1367,7 @@ def test_instructor_view_with_hedges_outside_department(client, haie_instructor_
     res = client.get(project_url)
 
     # THEN the result page is displayed with a warning
-    assert res.context["has_hedges_outside_department"]
+    assert res.context["is_outside_department"]
     assert "Le projet est hors du département sélectionné" in res.content.decode()
 
     # Given hedges in department 44 and accross the department border
@@ -1382,7 +1392,7 @@ def test_instructor_view_with_hedges_outside_department(client, haie_instructor_
     res = client.get(project_url)
 
     # THEN the result page is displayed without warning
-    assert not res.context["has_hedges_outside_department"]
+    assert not res.context["is_outside_department"]
     assert "Le projet est hors du département sélectionné" not in res.content.decode()
 
 

--- a/envergo/petitions/tests/test_views.py
+++ b/envergo/petitions/tests/test_views.py
@@ -1342,58 +1342,66 @@ def test_petition_project_instructor_notes_form(
     )
 
 
-def test_instructor_view_with_hedges_outside_department(client, haie_instructor_44):
-    """Test if a warning is displayed when some hedges are outside department"""
-    # GIVEN a moulinette with at least an hedge to remove outside the department
+def test_instructor_view_multi_departments_alert(client, haie_instructor_44):
+    """Test the multi-department alert on the instructor view."""
 
     client.force_login(haie_instructor_44)
     DCConfigHaieFactory()
     DepartmentFactory(
         department="14", geometry=MultiPolygon([calvados_polygon])
     )
+
+    # GIVEN hedges in department 14 while the project is declared in department 44
     hedge_14 = HedgeFactory(
         latLngs=[
             {"lat": 49.37830760743562, "lng": 0.10241746902465822},
             {"lat": 49.37828490574639, "lng": 0.10244965553283693},
         ]
-    )  # this hedge is in department 14
-    hedges = HedgeDataFactory(hedges=[hedge_14])
-    project = PetitionProjectFactory(reference="GHI789", hedge_data=hedges)
-
-    # WHEN requesting the result plantation page
-    project_url = reverse(
-        "petition_project_instructor_view", kwargs={"reference": project.reference}
     )
-    res = client.get(project_url)
-
-    # THEN the result page is displayed with a warning
-    assert res.context["is_outside_department"]
-    assert "Le projet est hors du département sélectionné" in res.content.decode()
-
-    # Given hedges in department 44 and accross the department border
+    # Add a hedge in department 44 so we have hedges in both departments
     hedge_44 = HedgeFactory(
         latLngs=[
             {"lat": 47.202984120693635, "lng": -1.7100316286087038},
             {"lat": 47.201198235567496, "lng": -1.7097365856170657},
         ]
     )
-    hedge_44_85 = HedgeFactory(
+    hedges = HedgeDataFactory(hedges=[hedge_14, hedge_44])
+    project = PetitionProjectFactory(reference="GHI789", hedge_data=hedges)
+
+    project_url = reverse(
+        "petition_project_instructor_view", kwargs={"reference": project.reference}
+    )
+    res = client.get(project_url)
+
+    # THEN the multi-department alert is displayed with department list
+    assert res.context["is_multi_departments"]
+    content = res.content.decode()
+    assert "Le projet se situe sur plusieurs départements" in content
+    assert "Calvados" in content
+    assert "Loire-Atlantique" in content
+
+
+def test_instructor_view_single_department_no_alert(client, haie_instructor_44):
+    """No multi-department alert when all hedges are in the declared department."""
+
+    client.force_login(haie_instructor_44)
+    DCConfigHaieFactory()
+
+    hedge_44 = HedgeFactory(
         latLngs=[
-            {"lat": 47.05281499678513, "lng": -1.2435150146484377},
-            {"lat": 47.103783870991634, "lng": -1.1837768554687502},
+            {"lat": 47.202984120693635, "lng": -1.7100316286087038},
+            {"lat": 47.201198235567496, "lng": -1.7097365856170657},
         ]
     )
-    hedges = HedgeDataFactory(hedges=[hedge_44, hedge_44_85])
+    hedges = HedgeDataFactory(hedges=[hedge_44])
     project = PetitionProjectFactory(reference="JKL101", hedge_data=hedges)
     project_url = reverse(
         "petition_project_instructor_view", kwargs={"reference": project.reference}
     )
-    # WHEN requesting the result plantation page
     res = client.get(project_url)
 
-    # THEN the result page is displayed without warning
-    assert not res.context["is_outside_department"]
-    assert "Le projet est hors du département sélectionné" not in res.content.decode()
+    assert not res.context["is_multi_departments"]
+    assert "Le projet se situe sur plusieurs départements" not in res.content.decode()
 
 
 @patch("envergo.petitions.views.notify")

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -892,7 +892,6 @@ class PetitionProjectInstructorMixin(SingleObjectMixin):
 
         context.update(get_context_from_dn(self.object))
         context.update(self.object.moulinette_data)
-        context.update(self.object.get_moulinette().get_extra_context(self.request))
 
         plantation_url = reverse(
             "input_hedges",

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -891,12 +891,8 @@ class PetitionProjectInstructorMixin(SingleObjectMixin):
         )
 
         context.update(get_context_from_dn(self.object))
-
         context.update(self.object.moulinette_data)
-        if "haies" in context:
-            context["has_hedges_outside_department"] = context[
-                "haies"
-            ].has_hedges_outside_department(self.object.department)
+        context.update(self.object.get_moulinette().get_extra_context(self.request))
 
         plantation_url = reverse(
             "input_hedges",

--- a/envergo/petitions/views.py
+++ b/envergo/petitions/views.py
@@ -1081,6 +1081,7 @@ class PetitionProjectInstructorView(BasePetitionProjectInstructorView, DetailVie
         context = super().get_context_data(**kwargs)
         moulinette = self.object.get_moulinette()
         context["moulinette"] = moulinette
+        context.update(moulinette.catalog)
 
         context.update(get_project_context(self.object, context["moulinette"]))
 

--- a/envergo/templates/amenagement/moulinette/result.html
+++ b/envergo/templates/amenagement/moulinette/result.html
@@ -1,4 +1,4 @@
-{% extends 'moulinette/result.html' %}
+{% extends 'amenagement/moulinette/result_base.html' %}
 
 {% load utils %}
 
@@ -43,7 +43,7 @@
   {% include 'evaluations/_specifications.html' with params=moulinette.raw_data address=address coords=coords %}
 {% endblock %}
 
-{% block after-title-content %}
+{% block action_buttons %}
   <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--center hide-print">
     <li>{% include '_share_url_btn.html' %}</li>
     <li>

--- a/envergo/templates/amenagement/moulinette/result_base.html
+++ b/envergo/templates/amenagement/moulinette/result_base.html
@@ -2,9 +2,6 @@
 
 {% load evaluations static l10n %}
 
-{% block top-bar %}{# no top bar on result pages#}{% endblock %}
-
-{% block messages %}{# messages are displayed in the result container #}{% endblock %}
 {% block result %}
   {% if config and not config.is_activated %}
     <div class="fr-alert fr-alert--info fr-alert--small fr-mb-3w">

--- a/envergo/templates/amenagement/moulinette/result_base.html
+++ b/envergo/templates/amenagement/moulinette/result_base.html
@@ -1,4 +1,4 @@
-{% extends 'moulinette/base_result.html' %}
+{% extends 'moulinette/result_layout.html' %}
 
 {% load evaluations static l10n %}
 
@@ -13,7 +13,7 @@
     </div>
   {% endif %}
   <h1 class="fr-mb-5w">Simulation réglementaire</h1>
-  {% block after-title-content %}{% endblock %}
+  {% block action_buttons %}{% endblock %}
 
   <h2 class="fr-h3">Réglementations environnementales</h2>
 

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -14,7 +14,7 @@
     {% else %}
       <p>La décision de l'administration pourra différer du résultat du simulateur.</p>
       <p>
-        <a href="{% url 'contact_us' %}">Contactez nous pour toute question.</a>
+        N'hésitez pas à <a href="{% url 'contact_us' %}">contacter le guichet unique</a> pour toute question.
       </p>
     {% endif %}
   </div>

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -1,0 +1,22 @@
+{% if is_outside_department %}
+  <div class="fr-alert fr-alert--warning fr-mb-4w">
+    <h3 class="fr-alert__title">Le projet est hors du département sélectionné</h3>
+    <p>
+      Une majorité du linéaire de haies saisi est situé hors du département choisi pour cette simulation – {{ department_display }}.
+    </p>
+    {% if relaunch_url %}
+      <p>
+        Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
+      </p>
+      <p>
+        <a href="{{ relaunch_url }}"
+           class="fr-btn fr-btn--primary">Relancer la simulation</a>
+      </p>
+    {% else %}
+      <p>La décision de l'administration pourra différer du résultat du simulateur.</p>
+      <p>
+        <a href="{% url 'contact_us' %}">Contactez nous pour toute question.</a>
+      </p>
+    {% endif %}
+  </div>
+{% endif %}

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -14,7 +14,7 @@
     {% else %}
       <p>La décision de l'administration pourra différer du résultat du simulateur.</p>
       <p>
-        N'hésitez pas à <a href="{% url 'contact_us' %}">contacter le guichet unique</a> pour toute question.
+        N'hésitez pas à <a href="{% url 'contact_us' %}?department={{ department.department }}#contact-accordion-3-dossier">contacter le guichet unique</a> pour toute question.
       </p>
     {% endif %}
   </div>

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -6,7 +6,7 @@
     </p>
     {% if relaunch_url %}
       <p>
-        Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
+        Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département – {{ main_department }}.
       </p>
       <p>
         <a href="{{ relaunch_url }}" class="fr-btn fr-btn--secondary">Relancer la simulation</a>

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -9,7 +9,7 @@
         Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
       </p>
       <p>
-        <a href="{{ relaunch_url }}" class="fr-btn fr-btn--primary">Relancer la simulation</a>
+        <a href="{{ relaunch_url }}" class="fr-btn fr-btn--secondary">Relancer la simulation</a>
       </p>
     {% else %}
       <p>La décision de l'administration pourra différer du résultat du simulateur.</p>

--- a/envergo/templates/haie/moulinette/_department_alert.html
+++ b/envergo/templates/haie/moulinette/_department_alert.html
@@ -9,8 +9,7 @@
         Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
       </p>
       <p>
-        <a href="{{ relaunch_url }}"
-           class="fr-btn fr-btn--primary">Relancer la simulation</a>
+        <a href="{{ relaunch_url }}" class="fr-btn fr-btn--primary">Relancer la simulation</a>
       </p>
     {% else %}
       <p>La décision de l'administration pourra différer du résultat du simulateur.</p>

--- a/envergo/templates/haie/moulinette/petition_project.html
+++ b/envergo/templates/haie/moulinette/petition_project.html
@@ -4,7 +4,7 @@
 
 {% load static %}
 
-{% block before-title-content %}
+{% block action_buttons %}
   <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--right fr-mb-3w hide-print">
     <li>{% include '_share_url_btn.html' %}</li>
     {% if demarche_numerique_state != "draft" %}
@@ -50,8 +50,13 @@
   </p>
 {% endblock %}
 
-{% block moulinette_result %}
+{% block department_alert %}
+  {% include 'haie/moulinette/_department_alert.html' with department_display=config.department %}
+{% endblock %}
 
+{% block sensitive_areas %}{% endblock %}
+
+{% block result_summary %}
   {% if user.is_instructor %}
     <h3 class="fr-mt-4w">Vous souhaitez faire une simulation alternative ?</h3>
 
@@ -90,8 +95,6 @@
   <h3 class="fr-mt-4w">Résultats de la simulation réglementaire</h3>
   {{ block.super }}
 {% endblock %}
-
-{% block sensitive_areas %}{% endblock %}
 
 {% block project_summary %}
   {{ block.super }}

--- a/envergo/templates/haie/moulinette/petition_project.html
+++ b/envergo/templates/haie/moulinette/petition_project.html
@@ -56,7 +56,7 @@
 
 {% block sensitive_areas %}{% endblock %}
 
-{% block result_summary %}
+{% block dossier_actions %}
   {% if user.is_instructor %}
     <h3 class="fr-mt-4w">Vous souhaitez faire une simulation alternative ?</h3>
 
@@ -93,7 +93,6 @@
   {% endif %}
 
   <h3 class="fr-mt-4w">Résultats de la simulation réglementaire</h3>
-  {{ block.super }}
 {% endblock %}
 
 {% block project_summary %}

--- a/envergo/templates/haie/moulinette/result.html
+++ b/envergo/templates/haie/moulinette/result.html
@@ -52,8 +52,7 @@
   {% endif %}
 {% endblock %}
 
-{% block before-title-content %}
-  {{ block.super }}
+{% block alternative_alert %}
   {% if is_alternative %}
     <div class="fr-alert fr-alert--info fr-mb-3w">
       <h3 class="fr-alert__title">Nouvelle simulation alternative pour ce dossier</h3>
@@ -70,6 +69,7 @@
     </div>
   {% endif %}
 {% endblock %}
+
 
 {% block main_form_field %}
   {% if field.name == "haies" %}

--- a/envergo/templates/haie/moulinette/result.html
+++ b/envergo/templates/haie/moulinette/result.html
@@ -70,7 +70,6 @@
   {% endif %}
 {% endblock %}
 
-
 {% block main_form_field %}
   {% if field.name == "haies" %}
     <li>{{ field|display_remove_only_haies_field }}</li>

--- a/envergo/templates/haie/moulinette/result_base.html
+++ b/envergo/templates/haie/moulinette/result_base.html
@@ -47,14 +47,18 @@
 
   {% include 'haie/moulinette/_department_doctrine_button.html' %}
 
-  {% if has_hedges_outside_department %}
+  {% if is_outside_department %}
     <div class="fr-alert fr-alert--warning fr-mb-4w">
       <h3 class="fr-alert__title">Le projet est hors du département sélectionné</h3>
       <p>
-        Au moins un des linéaires saisi est situé hors du département choisi pour cette simulation – {{ moulinette.department }}.
+        Une majorité du linéaire de haies saisi est situé hors du département choisi pour cette simulation – {{ moulinette.department }}.
       </p>
       <p>
-        Vous pouvez poursuivre la simulation si le projet est en majorité situé dans ce département, mais la décision de l'administration pourra différer du résultat du simulateur. <a href="{% url 'contact_us' %}{% if department %}?department={{ department.department }}{% endif %}{{ contact_dossier_anchor }}">Contactez-nous</a> pour toute question.
+        Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
+      </p>
+      <p>
+        <a href="{{ main_department_simulation_url }}"
+           class="fr-btn fr-btn--primary">Relancer la simulation</a>
       </p>
     </div>
   {% endif %}

--- a/envergo/templates/haie/moulinette/result_base.html
+++ b/envergo/templates/haie/moulinette/result_base.html
@@ -56,12 +56,12 @@
 
   {% block result_foreword %}{% endblock %}
 
-  {% block sensitive_areas %}
-    {% include 'haie/moulinette/_sensitive_areas.html' %}
-  {% endblock %}
-
   {% block department_alert %}
     {% include 'haie/moulinette/_department_alert.html' with department_display=moulinette.department relaunch_url=main_department_simulation_url %}
+  {% endblock %}
+
+  {% block sensitive_areas %}
+    {% include 'haie/moulinette/_sensitive_areas.html' %}
   {% endblock %}
 
   {% block result_summary %}{% endblock %}

--- a/envergo/templates/haie/moulinette/result_base.html
+++ b/envergo/templates/haie/moulinette/result_base.html
@@ -1,6 +1,9 @@
-{% extends 'moulinette/result.html' %}
+{% extends 'moulinette/result_layout.html' %}
 
 {% load static moulinette %}
+
+{% block top-bar %}{% endblock %}
+{% block messages %}{% endblock %}
 
 {% block header %}
   <header role="banner" class="fr-header header-sticky header-slim">
@@ -29,44 +32,41 @@
 {% endblock %}
 
 {% block result %}
-  {% if config and not config.is_activated %}
-    <div class="fr-alert fr-alert--info fr-alert--small fr-mb-3w">
-      Le simulateur n'est pas activé dans ce département ({{ moulinette.department.department }}). Vous voyez
-      cette page grâce à votre statut d'admin.
-    </div>
-  {% endif %}
+  {% block admin_alert %}
+    {% if config and not config.is_activated %}
+      <div class="fr-alert fr-alert--info fr-alert--small fr-mb-3w">
+        Le simulateur n'est pas activé dans ce département ({{ moulinette.department.department }}). Vous voyez
+        cette page grâce à votre statut d'admin.
+      </div>
+    {% endif %}
+  {% endblock %}
 
-  {% block before-title-content %}
+  {% block action_buttons %}
     {% if not is_alternative %}
       <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left fr-btns-group--right fr-mb-3w hide-print">
         <li>{% include '_share_url_btn.html' %}</li>
       </ul>
     {% endif %}
+    {% block alternative_alert %}{% endblock %}
   {% endblock %}
+
   {% block result_title %}<h1>Simulation réglementaire</h1>{% endblock %}
 
   {% include 'haie/moulinette/_department_doctrine_button.html' %}
 
-  {% if is_outside_department %}
-    <div class="fr-alert fr-alert--warning fr-mb-4w">
-      <h3 class="fr-alert__title">Le projet est hors du département sélectionné</h3>
-      <p>
-        Une majorité du linéaire de haies saisi est situé hors du département choisi pour cette simulation – {{ moulinette.department }}.
-      </p>
-      <p>
-        Pour poursuivre la demande, il est vivement recommandé de relancer la simulation dans le bon département — {{ main_department }}.
-      </p>
-      <p>
-        <a href="{{ main_department_simulation_url }}"
-           class="fr-btn fr-btn--primary">Relancer la simulation</a>
-      </p>
-    </div>
-  {% endif %}
   {% block result_foreword %}{% endblock %}
 
   {% block sensitive_areas %}
     {% include 'haie/moulinette/_sensitive_areas.html' %}
   {% endblock %}
+
+  {% block department_alert %}
+    {% include 'haie/moulinette/_department_alert.html' with department_display=moulinette.department relaunch_url=main_department_simulation_url %}
+  {% endblock %}
+
+  {% block result_summary %}{% endblock %}
+
+  {% block result_disclaimer %}{% endblock %}
 
   {% if moulinette.is_multi_category %}
     <section>

--- a/envergo/templates/haie/moulinette/result_base.html
+++ b/envergo/templates/haie/moulinette/result_base.html
@@ -2,9 +2,6 @@
 
 {% load static moulinette %}
 
-{% block top-bar %}{% endblock %}
-{% block messages %}{% endblock %}
-
 {% block header %}
   <header role="banner" class="fr-header header-sticky header-slim">
     {% include 'haie/_slim_header.html' %}
@@ -54,7 +51,7 @@
 
   {% include 'haie/moulinette/_department_doctrine_button.html' %}
 
-  {% block result_foreword %}{% endblock %}
+  {% block plantation_evaluation %}{% endblock %}
 
   {% block department_alert %}
     {% include 'haie/moulinette/_department_alert.html' with department_display=moulinette.department relaunch_url=main_department_simulation_url %}
@@ -64,9 +61,7 @@
     {% include 'haie/moulinette/_sensitive_areas.html' %}
   {% endblock %}
 
-  {% block result_summary %}{% endblock %}
-
-  {% block result_disclaimer %}{% endblock %}
+  {% block dossier_actions %}{% endblock %}
 
   {% if moulinette.is_multi_category %}
     <section>

--- a/envergo/templates/haie/moulinette/result_plantation.html
+++ b/envergo/templates/haie/moulinette/result_plantation.html
@@ -2,8 +2,7 @@
 
 {% load static moulinette %}
 
-{% block before-title-content %}
-  {{ block.super }}
+{% block alternative_alert %}
   {% if is_alternative %}
     <div class="fr-alert fr-alert--info fr-mb-3w">
 

--- a/envergo/templates/haie/moulinette/result_plantation.html
+++ b/envergo/templates/haie/moulinette/result_plantation.html
@@ -38,7 +38,7 @@
   {% endif %}
 {% endblock %}
 
-{% block result_foreword %}
+{% block plantation_evaluation %}
   {% show_haie_plantation_evaluation moulinette plantation_evaluation %}
 {% endblock %}
 

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -16,21 +16,24 @@
 
     {% include 'haie/moulinette/_department_doctrine_button.html' with config=moulinette.config %}
 
-    {% if is_outside_department %}
+    {% if is_multi_departments %}
       <div class="fr-alert fr-alert--warning fr-mb-4w">
-        <h3 class="fr-alert__title">Le projet est hors du département sélectionné</h3>
+        <h3 class="fr-alert__title">Le projet se situe sur plusieurs départements</h3>
+
+        <p>Les haies saisies sont situées dans les départements suivants :</p>
+
+        <ul>
+          {% for dept, length in departments_lengths %}
+            <li>
+              {{ dept }} — {{ length|floatformat:0 }} m
+            {% endfor %}
+          </li>
+        </ul>
+
+        <p>La décision relative au projet devra être prise conjointement par les préfets intéressés.</p>
+
         <p>
-          Au moins un des linéaires saisis est situé hors du département choisi pour la simulation réalisée par le
-          demandeur – {{ config.department }}.
-        </p>
-        <p>
-          Le simulateur n’est pas paramétré pour gérer les règles combinées de plusieurs départements.
-          L’instruction de la demande et l'élaboration de la décision unique peuvent nécessiter de se coordonner avec
-          les services des préfectures concernées.
-        </p>
-        <p>
-          Le demandeur a été averti en ce sens (voir <a href="{% url 'petition_project' petition_project.reference %}">le
-          résultat de la simulation</a>) avant qu'il dépose sa demande.
+          S’il s’avère qu’un transfert du dossier entre départements est nécessaire, <a href="{% url 'contact_us' %}">contactez l’équipe technique</a>.
         </p>
       </div>
     {% endif %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -23,7 +23,7 @@
         <p>Les haies saisies sont situées dans les départements suivants :</p>
 
         <ul>
-          {% for dept, length in departments_lengths %}<li>{{ dept }} — {{ length|floatformat:0 }} m</li>{% endfor %}
+          {% for dept, length in departments_lengths %}<li>{{ dept }} – {{ length|floatformat:0 }} m</li>{% endfor %}
         </ul>
 
         <p>La décision relative au projet devra être prise conjointement par les préfets intéressés.</p>

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -29,7 +29,7 @@
         <p>La décision relative au projet devra être prise conjointement par les préfets intéressés.</p>
 
         <p>
-          S’il s’avère qu’un transfert du dossier entre départements est nécessaire, <a href="{% url 'contact_us' %}">contactez l’équipe technique</a>.
+          S’il s’avère qu’un transfert du dossier entre départements est nécessaire, <a href="{% url 'contact_us' %}#contact-accordion-2-equipe">contactez l’équipe technique</a>.
         </p>
       </div>
     {% endif %}

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -16,7 +16,7 @@
 
     {% include 'haie/moulinette/_department_doctrine_button.html' with config=moulinette.config %}
 
-    {% if has_hedges_outside_department %}
+    {% if is_outside_department %}
       <div class="fr-alert fr-alert--warning fr-mb-4w">
         <h3 class="fr-alert__title">Le projet est hors du département sélectionné</h3>
         <p>

--- a/envergo/templates/haie/petitions/instructor_view.html
+++ b/envergo/templates/haie/petitions/instructor_view.html
@@ -23,11 +23,7 @@
         <p>Les haies saisies sont situées dans les départements suivants :</p>
 
         <ul>
-          {% for dept, length in departments_lengths %}
-            <li>
-              {{ dept }} — {{ length|floatformat:0 }} m
-            {% endfor %}
-          </li>
+          {% for dept, length in departments_lengths %}<li>{{ dept }} — {{ length|floatformat:0 }} m</li>{% endfor %}
         </ul>
 
         <p>La décision relative au projet devra être prise conjointement par les préfets intéressés.</p>

--- a/envergo/templates/moulinette/base.html
+++ b/envergo/templates/moulinette/base.html
@@ -1,3 +1,0 @@
-{% extends 'base.html' %}
-
-{% block title %}Simulation réglementaire du projet{% endblock %}

--- a/envergo/templates/moulinette/debug_result.html
+++ b/envergo/templates/moulinette/debug_result.html
@@ -1,3 +1,0 @@
-{% extends 'moulinette/result.html' %}
-
-{% block form-col %}{% endblock %}

--- a/envergo/templates/moulinette/home.html
+++ b/envergo/templates/moulinette/home.html
@@ -1,4 +1,4 @@
-{% extends "moulinette/base.html" %}
+{% extends "base.html" %}
 
 {% load leaflet_tags static moulinette %}
 

--- a/envergo/templates/moulinette/result_layout.html
+++ b/envergo/templates/moulinette/result_layout.html
@@ -1,6 +1,8 @@
-{% extends 'moulinette/base.html' %}
+{% extends 'base.html' %}
 
 {% load evaluations static l10n %}
+
+{% block title %}Simulation réglementaire du projet{% endblock %}
 
 {% block header %}{% endblock %}
 

--- a/envergo/templates/moulinette/result_layout.html
+++ b/envergo/templates/moulinette/result_layout.html
@@ -6,6 +6,10 @@
 
 {% block header %}{% endblock %}
 
+{% block top-bar %}{# no top bar on result pages #}{% endblock %}
+
+{% block messages %}{# messages are displayed in the result container #}{% endblock %}
+
 {% block body-classes %}moulinette-result-body{% endblock %}
 
 {% block container %}


### PR DESCRIPTION
https://trello.com/c/tBDJ5cpQ/2459-gestion-des-projets-multi-d%C3%A9partements

Note : cette PR embarque un gros refactoring de toute l'architecture des templates de résultat de la Moulinette.

En effet, les templates de résultat moulinette étaient devenus difficilement maintenables :

 - la hiérarchie était alambiquée, avec beaucoup d'héritage de templates, avec certains templates redéfinissant 98% des blocs ;
 - des blocs qui commençaient à contenir tout et n'importe quoi sans logique ;
 - des templates appelant parfois `{{ block.super }}` et parfois pas, rendant impossible de savoir ce qui allait s'afficher et dans quels cas ;
 - des templates inutiles ou avec un seul titre ;
 - une asymétrie entre les hiérarchies d'héritage côté aménagement et haie.

J'ai essayé de corriger tout ça.

La nouvelle architecture :

```
● moulinette/result_layout.html
  ├── amenagement/moulinette/result_base.html
  │   ├── amenagement/moulinette/result.html
  │   │   └── amenagement/moulinette/result_debug.html
  │   ├── amenagement/moulinette/result_available_soon.html
  │   └── amenagement/moulinette/result_non_disponible.html
  └── haie/moulinette/result_base.html
      ├── haie/moulinette/result.html
      │   ├── haie/moulinette/triage_result.html
      │   │   ├── haie/moulinette/triage_projet_result.html
      │   │   └── haie/moulinette/triage_entretien_result.html
      │   └── haie/moulinette/result_debug.html
      ├── haie/moulinette/result_plantation.html
      │   └── haie/moulinette/petition_project.html
      ├── haie/moulinette/result_available_soon.html
      └── haie/moulinette/result_non_disponible.html
```