### PR TITLE
Hotfix : Supprimer un bloc spécifique régime unique de la home page

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -437,6 +437,10 @@ MAX_HEDGES_DRAWING_TO_REMOVE_TOTAL_LENGTH = env.int(
 
 HOME_MAX_DEPARTMENT_TILES = env.int("HOME_MAX_DEPARTMENT_TILES", default=6)
 
+HAIE_SINGLE_PROCEDURE_ACTIVATED = env.bool(
+    "DJANGO_HAIE_SINGLE_PROCEDURE_ACTIVATED", default=False
+)
+
 DEMARCHES_SIMPLIFIEES = {
     # Documentation API de pré-remplissage :
     # https://doc.demarche.numerique.gouv.fr/pour-aller-plus-loin/api-de-preremplissage

--- a/envergo/pages/views.py
+++ b/envergo/pages/views.py
@@ -113,6 +113,9 @@ class HomeHaieView(DepartmentSearchMixin, TemplateView):
         )
         context["activated_configs"] = configs
         context["max_department_tiles"] = settings.HOME_MAX_DEPARTMENT_TILES
+        context["is_single_procedure_activated"] = (
+            settings.HAIE_SINGLE_PROCEDURE_ACTIVATED
+        )
         return context
 
 

--- a/envergo/templates/haie/pages/home.html
+++ b/envergo/templates/haie/pages/home.html
@@ -120,38 +120,40 @@
     </div>
   </section>
 
-  <!-- <section id="etapes" class="fr-py-5w fr-mb-5w">
-    <div class="fr-container">
-      <h2 class="fr-h3 fr-mb-3w" style="text-align: center;">Une réponse unique en 3 étapes</h2>
-      <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-12 fr-col-md-4">
-          <div class="fr-card fr-card--no-arrow fr-p-3w">
-            <span class="fr-icon-settings-5-line etape-icon" aria-hidden="true"></span>
-            <h3 class="fr-card__title fr-h6">1. Simulation</h3>
-            <p class="fr-card__desc">
-              Identifiez en quelques minutes les règles applicables à votre projet et la replantation attendue.
-            </p>
+  {% if is_single_procedure_activated %}
+    <section id="etapes" class="fr-py-5w fr-mb-5w">
+      <div class="fr-container">
+        <h2 class="fr-h3 fr-mb-3w" style="text-align: center;">Une réponse unique en 3 étapes</h2>
+        <div class="fr-grid-row fr-grid-row--gutters">
+          <div class="fr-col-12 fr-col-md-4">
+            <div class="fr-card fr-card--no-arrow fr-p-3w">
+              <span class="fr-icon-settings-5-line etape-icon" aria-hidden="true"></span>
+              <h3 class="fr-card__title fr-h6">1. Simulation</h3>
+              <p class="fr-card__desc">
+                Identifiez en quelques minutes les règles applicables à votre projet et la replantation attendue.
+              </p>
+            </div>
           </div>
-        </div>
-        <div class="fr-col-12 fr-col-md-4">
-          <div class="fr-card fr-card--no-arrow fr-p-3w">
-            <span class="fr-icon-folder-2-line etape-icon" aria-hidden="true"></span>
-            <h3 class="fr-card__title fr-h6">2. Dépôt du dossier</h3>
-            <p class="fr-card__desc">
-              Complétez votre dossier et déposez-le simplement via le portail sur la base des informations de la simulation, sans ressaisie.
-            </p>
+          <div class="fr-col-12 fr-col-md-4">
+            <div class="fr-card fr-card--no-arrow fr-p-3w">
+              <span class="fr-icon-folder-2-line etape-icon" aria-hidden="true"></span>
+              <h3 class="fr-card__title fr-h6">2. Dépôt du dossier</h3>
+              <p class="fr-card__desc">
+                Complétez votre dossier et déposez-le simplement via le portail sur la base des informations de la simulation, sans ressaisie.
+              </p>
+            </div>
           </div>
-        </div>
-        <div class="fr-col-12 fr-col-md-4">
-          <div class="fr-card fr-card--no-arrow fr-p-3w">
-            <span class="fr-icon-checkbox-circle-line etape-icon" aria-hidden="true"></span>
-            <h3 class="fr-card__title fr-h6">3. Réponse de l'administration</h3>
-            <p class="fr-card__desc">Pour les dossiers les plus simples, la durée d'instruction est de deux mois.</p>
+          <div class="fr-col-12 fr-col-md-4">
+            <div class="fr-card fr-card--no-arrow fr-p-3w">
+              <span class="fr-icon-checkbox-circle-line etape-icon" aria-hidden="true"></span>
+              <h3 class="fr-card__title fr-h6">3. Réponse de l'administration</h3>
+              <p class="fr-card__desc">Pour les dossiers les plus simples, la durée d'instruction est de deux mois.</p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section> -->
+    </section>
+  {% endif %}
 
   <section id="quand-demander" class="fr-mb-5w">
     <div class="fr-container">

--- a/envergo/templates/haie/pages/home.html
+++ b/envergo/templates/haie/pages/home.html
@@ -120,7 +120,7 @@
     </div>
   </section>
 
-  <section id="etapes" class="fr-py-5w fr-mb-5w">
+  <!-- <section id="etapes" class="fr-py-5w fr-mb-5w">
     <div class="fr-container">
       <h2 class="fr-h3 fr-mb-3w" style="text-align: center;">Une réponse unique en 3 étapes</h2>
       <div class="fr-grid-row fr-grid-row--gutters">
@@ -151,7 +151,7 @@
         </div>
       </div>
     </div>
-  </section>
+  </section> -->
 
   <section id="quand-demander" class="fr-mb-5w">
     <div class="fr-container">

--- a/envergo/templates/haie/pages/home.html
+++ b/envergo/templates/haie/pages/home.html
@@ -76,10 +76,10 @@
         <div class="simulateur-header">
           <h3>Simuler un projet de travaux sur haie</h3>
           <p>
-            Simulez ici votre projet pour connaître les règles de protection et la
+            Simulez votre projet pour connaître les règles de protection et la
             replantation attendue.
             <br>
-            Puis déposez votre demande d'autorisation.
+            Vous pourrez ensuite déposer votre dossier.
           </p>
           <br>
         </div>

--- a/envergo/templates/haie/pages/home.html
+++ b/envergo/templates/haie/pages/home.html
@@ -146,7 +146,7 @@
           <div class="fr-card fr-card--no-arrow fr-p-3w">
             <span class="fr-icon-checkbox-circle-line etape-icon" aria-hidden="true"></span>
             <h3 class="fr-card__title fr-h6">3. Réponse de l'administration</h3>
-            <p class="fr-card__desc">Recevez une réponse unique et définitive dans un délai maximal de deux mois.</p>
+            <p class="fr-card__desc">Pour les dossiers les plus simples, la durée d'instruction est de deux mois.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Petite erreur de synchro avec Alexis : on a poussé en prod un bloc qui n'a de sens que pour le régime unique.

Soit on commente comme proposé.

Mieux (et ça nous resservira) : peut-on introduire une variable d'environnement globale qui nous permette de feature flagguer des trucs pour après l'entrée en vigueur ? (un booleen : `is_singleprocedure_activated` ou un truc du genre)
Je pense notamment à un bloc sur la procédure d'urgence aussi.

https://trello.com/c/3CGR3j1y/2515-supprimer-un-bloc-sp%C3%A9cifique-r%C3%A9gime-unique-de-la-home-page

Et donc : cette PR affiche un texte sur la home page seulement si on est dans le régime unique, et un setting est créé pour ça.