### PR TITLE
Hotfix : corrige la catégorie manquante pour le dépôt de dossier

### DIFF
--- a/envergo/templates/haie/moulinette/plantation_result/hru/soumis.html
+++ b/envergo/templates/haie/moulinette/plantation_result/hru/soumis.html
@@ -42,11 +42,10 @@
     <p>
       Prochaine étape :
       <button class="fr-btn fr-btn--primary"
-        type="button"
-        data-fr-opened="false"
-        data-category="{{ category.value }}
-        aria-controls="demarches-simplifiees-modal">Déposer une demande d'autorisation
-      </button>
+              type="button"
+              data-fr-opened="false"
+              data-category="{{ category.value }}"
+              aria-controls="demarches-simplifiees-modal">Déposer une demande d'autorisation</button>
     </p>
   {% else %}
     <h6>

--- a/envergo/templates/haie/moulinette/plantation_result/hru/soumis.html
+++ b/envergo/templates/haie/moulinette/plantation_result/hru/soumis.html
@@ -42,9 +42,11 @@
     <p>
       Prochaine étape :
       <button class="fr-btn fr-btn--primary"
-              type="button"
-              data-fr-opened="false"
-              aria-controls="demarches-simplifiees-modal">Déposer une demande d'autorisation</button>
+        type="button"
+        data-fr-opened="false"
+        data-category="{{ category.value }}
+        aria-controls="demarches-simplifiees-modal">Déposer une demande d'autorisation
+      </button>
     </p>
   {% else %}
     <h6>


### PR DESCRIPTION
Le dépôt de dossier était rendu impossible, le champs `_category` n'était pas initialisé en cliquant sur le bouton