### PR TITLE
Supprime l'alerte info

### DIFF
--- a/e2e/haie/petitions/procedure_modal.spec.ts
+++ b/e2e/haie/petitions/procedure_modal.spec.ts
@@ -121,15 +121,4 @@ test.describe('Procedure modal — dynamic form', () => {
     await stage.selectOption('closed');
     await expect(message).toHaveValue(typed);
   });
-
-  test('a Démarches Simplifiées state change is announced', async ({ page }) => {
-    const stage = page.locator('#id_stage');
-    const notice = page.locator('#state-change-notice');
-
-    // en_construction → en_instruction: the applicant loses edit rights.
-    await stage.selectOption('instruction_d');
-    await expect(notice).toBeVisible();
-    await expect(notice).toContainText('Démarche Numérique');
-    await expect(notice).toContainText('ne sera donc plus modifiable par le demandeur');
-  });
 });

--- a/envergo/petitions/forms.py
+++ b/envergo/petitions/forms.py
@@ -382,8 +382,7 @@ def request_for_info_message(petition_project, is_regime_unique):
     else:
         ru_fragment = ""
 
-    message = dedent(
-        f"""
+    message = dedent(f"""
         Bonjour,
 
         Il apparaît que des informations sont manquantes pour instruire votre demande.
@@ -398,8 +397,7 @@ def request_for_info_message(petition_project, is_regime_unique):
         {ru_fragment}
         Cordialement,
         Le guichet unique de la haie – {petition_project.department}
-    """
-    )
+    """)
     return message.strip()
 
 

--- a/envergo/static/js/libs/state_change_modal.js
+++ b/envergo/static/js/libs/state_change_modal.js
@@ -3,7 +3,6 @@
  *
  * Three independent concerns react to the stage and decision <select>s:
  *  - the per-stage objective help text,
- *  - the Démarches Simplifiées state-change notice,
  *  - the closing fields (simulation check, prefectural order, applicant
  *    message) plus the message template pre-filled from the decision.
  *
@@ -21,12 +20,6 @@
     TACIT: "tacit_agreement",
     EXPRESS: "express_agreement",
     OPPOSITION: "opposition",
-  };
-
-  // DS states whose transition is worth an extra word of warning.
-  const DS_STATE = {
-    UNDER_INSTRUCTION: "en_instruction",
-    UNDER_CONSTRUCTION: "en_construction",
   };
 
   // Closing fields and the decisions that make them mandatory. A field is
@@ -60,7 +53,6 @@
   const show = (elt, visible) => {
     if (elt) elt.style.display = visible ? "block" : "none";
   };
-  const readJson = (id) => JSON.parse(document.getElementById(id).textContent);
 
   class StateChangeModal {
     constructor(form) {
@@ -69,15 +61,6 @@
       this.decisionInput = form.querySelector("#id_decision");
       this.dueDateInput = form.querySelector("#id_due_date");
       this.applicantMessageInput = form.querySelector("#id_applicant_message");
-
-      // Démarches Simplifiées state-change notice.
-      this.stateChangeNotice = document.getElementById("state-change-notice");
-      this.stateChangeText = document.getElementById("state-change-transition-text");
-      this.currentDsState = form.dataset.currentDsStatus;
-      this.currentStage = readJson("current-stage");
-      this.dsStateByStageDecision = readJson("ds-status-mapping");
-      this.dsStateLabels = readJson("ds-status-labels");
-      this.forbiddenTransitions = readJson("forbidden-transitions");
     }
 
     /**
@@ -117,7 +100,6 @@
     sync() {
       this.syncStageObjective();
       this.syncClosingFields();
-      this.syncStateChangeNotice();
     }
 
     /**
@@ -150,28 +132,6 @@
       });
     }
 
-    /**
-     * Warn the instructor when saving will change the Démarches Simplifiées
-     * state.
-     *
-     * Shown only for a real, allowed transition: the target state differs from
-     * the current one and the stage move is not forbidden.
-     */
-    syncStateChangeNotice() {
-      const nextDsState = (this.dsStateByStageDecision[this.stage] || {})[this.decision];
-      const changes =
-        nextDsState &&
-        nextDsState !== this.currentDsState &&
-        !this.isForbidden(this.currentStage, this.stage);
-
-      show(this.stateChangeNotice, changes);
-      if (!changes) return;
-
-      this.stateChangeText.textContent =
-        `Le dossier passe de l'état « ${this.dsLabel(this.currentDsState)} » ` +
-        `à « ${this.dsLabel(nextDsState)} » sur Démarche Numérique.` +
-        this.dsTransitionHint(nextDsState);
-    }
 
     /**
      * Pre-fill the applicant message from the selected decision's template.
@@ -202,28 +162,6 @@
       }
     }
 
-    isForbidden(from, to) {
-      return this.forbiddenTransitions.some(([f, t]) => f === from && t === to);
-    }
-
-    dsLabel(state) {
-      return this.dsStateLabels[state] || state;
-    }
-
-    /**
-     * Spell out what a DS state change means for the applicant: passing to
-     * instruction locks their editing, returning to construction unlocks it.
-     * Empty for transitions with no such effect.
-     */
-    dsTransitionHint(nextDsState) {
-      if (nextDsState === DS_STATE.UNDER_INSTRUCTION) {
-        return " Il ne sera donc plus modifiable par le demandeur.";
-      }
-      if (nextDsState === DS_STATE.UNDER_CONSTRUCTION) {
-        return " Il sera donc à nouveau modifiable par le demandeur.";
-      }
-      return "";
-    }
   }
 
   exports.StateChangeModal = StateChangeModal;

--- a/envergo/templates/haie/petitions/_state_change_modal.html
+++ b/envergo/templates/haie/petitions/_state_change_modal.html
@@ -13,14 +13,11 @@
           </div>
           <div class="fr-modal__content">
             <h2 id="state-change-modal-title" class="fr-modal__title">Modification de l'état du dossier</h2>
-            {{ dn_status_mapping|json_script:"ds-status-mapping" }}
-            {{ dn_status_labels|json_script:"ds-status-labels" }}
             <form method="post"
                   action=""
                   novalidate
                   enctype="multipart/form-data"
-                  class="fr-mb-3w"
-                  data-current-ds-status="{{ petition_project.demarche_numerique_state }}">
+                  class="fr-mb-3w">
               {% csrf_token %}
               <input type="hidden" name="action" value="state_change">
               {% include '_form_snippet.html' with form=state_change_form %}
@@ -32,11 +29,6 @@
                   <p>Le nouveau document de décision remplacera celui actuellement attaché au dossier.</p>
                 </div>
               {% endif %}
-              <div id="state-change-notice"
-                   class="fr-alert fr-alert--info fr-mb-2w"
-                   style="display: none">
-                <p id="state-change-transition-text"></p>
-              </div>
               <button type="submit" class="fr-btn">Enregistrer</button>
             </form>
             {% for decision in DECISIONS %}

--- a/envergo/templates/haie/petitions/_state_change_modal.html
+++ b/envergo/templates/haie/petitions/_state_change_modal.html
@@ -36,9 +36,6 @@
                    class="fr-alert fr-alert--info fr-mb-2w"
                    style="display: none">
                 <p id="state-change-transition-text"></p>
-                <p>
-                  <strong>Le demandeur sera notifié de la mise à jour du statut de son dossier.</strong>
-                </p>
               </div>
               <button type="submit" class="fr-btn">Enregistrer</button>
             </form>


### PR DESCRIPTION
https://trello.com/c/C3hyFtGd/2475-supprimer-lalerte-info-qui-indique-que-le-demandeur-est-notifi%C3%A9-dun-changement-de-statut-dn

La PR originale est ici : https://github.com/MTES-MCT/envergo/pull/1200/commits

mais l'historique est tout cassé. J'ai juste re-créé une branche proprement fusionnable.