### PR TITLE
Corrige une erreur 500 liée à des géométries invalides

### DIFF
--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -43,8 +43,8 @@ def hedge_density_fixture():
 EXPECTED_AROUND_POINT = {
     200: {"density": 0.0, "length": 0.0, "area_ha": 12.485780609039368},
     400: {
-        "density": 20.041485812958307,
-        "length": 1000.9343797592853,
+        "density": 20.04085317702949,
+        "length": 1000.902783945812,
         "area_ha": 49.943122436167236,
     },
     5000: {
@@ -180,9 +180,9 @@ def test_query_hedge_length_excludes_forest_portion():
     ]
     truncated = Polygon(outer, forest, srid=4326)
 
-    # Expected: only the western half (3.50→3.55) is counted.
-    # Pinned from ST_LengthSpheroid on that segment.
-    expected_length = 3635.0917235660813
+    # Only the western half (3.50→3.55) counts: exactly ST_LengthSpheroid
+    # on that segment.
+    expected_length = 3635.0942003379914
 
     actual_length = query_hedge_length(truncated, circle)
     assert actual_length == pytest.approx(expected_length, **APPROX)
@@ -245,6 +245,70 @@ def test_query_hedges_display_geojson_handles_non_noded_difference(
 
     # Returns without raising; result may be None when nothing intersects.
     query_hedges_display_geojson(truncated, circle)
+
+
+# Regression fixture for the 2026-07 staging TopologyException ("Input geom 1
+# is invalid: Too few points in geometry component"). trim_land's union of
+# near-coincident tiles leaves micrometer-wide crack rings whose vertices
+# collapse in the WKT roundtrip, so the buffer reaches query_hedge_length
+# invalid. The hole is a real crack ring from the incident, in a simple shell.
+CRACK_TRUNCATED = (
+    "SRID=4326;POLYGON ((-0.90 48.95, -0.79 48.95, -0.79 49.06, "
+    "-0.90 49.06, -0.90 48.95), "
+    "(-0.873686783197342 48.97633255528753, "
+    "-0.873686783197342 48.97633255528753, "
+    "-0.873686783214866 48.9763325555225, "
+    "-0.873686783197342 48.97633255528753))"
+)
+CRACK_CIRCLE = (
+    "SRID=4326;POLYGON ((-0.90 48.95, -0.79 48.95, -0.79 49.06, "
+    "-0.90 49.06, -0.90 48.95))"
+)
+
+# Crosses the circle's west edge at the crack's latitude → forces the
+# slow-path ST_Intersection against the invalid buffer (the crash path).
+CRACK_HEDGE = MultiLineString(
+    [LineString([(-0.92, 48.97633255528753), (-0.85, 48.97633255528753)])]
+)
+
+# ST_LengthSpheroid of the in-buffer portion (-0.90 → -0.85). Only the
+# planar-4326 clip yields this exactly; the geography (UTM) overload drifts
+# ~5 cm on recent GEOS and raises the production error on older GEOS.
+CRACK_EXPECTED_LENGTH = 3660.3227769668383
+
+
+@pytest.fixture
+def crack_geometries():
+    """Return (truncated_buffer, untruncated_circle) from the 2026-07 incident."""
+    truncated = GEOSGeometry(CRACK_TRUNCATED)
+    circle = GEOSGeometry(CRACK_CIRCLE)
+    # The fixture is only meaningful while the buffer stays invalid.
+    assert not truncated.valid
+    return truncated, circle
+
+
+def test_query_hedge_length_handles_collapsed_crack_ring(crack_geometries):
+    """No TopologyException on the invalid buffer, and planar-4326 clip
+    semantics (the geography/UTM detour returned 3660.374)."""
+    truncated, circle = crack_geometries
+    LineFactory(geometry=CRACK_HEDGE)
+
+    length = query_hedge_length(truncated, circle)
+
+    assert length == pytest.approx(CRACK_EXPECTED_LENGTH, **APPROX)
+
+
+def test_query_hedges_display_geojson_handles_collapsed_crack_ring(
+    crack_geometries,
+):
+    """Same collapsed-ring flaw, same fix, in the display query."""
+    truncated, circle = crack_geometries
+    LineFactory(geometry=CRACK_HEDGE)
+
+    display = query_hedges_display_geojson(truncated, circle)
+
+    assert display is not None
+    assert display["type"] == "MultiLineString"
 
 
 @pytest.mark.parametrize(

--- a/envergo/geodata/tests/test_utils.py
+++ b/envergo/geodata/tests/test_utils.py
@@ -247,12 +247,9 @@ def test_query_hedges_display_geojson_handles_non_noded_difference(
     query_hedges_display_geojson(truncated, circle)
 
 
-# Regression fixture for the 2026-07 staging TopologyException ("Input geom 1
-# is invalid: Too few points in geometry component"). trim_land's union of
-# near-coincident tiles leaves micrometer-wide crack rings whose vertices
-# collapse in the WKT roundtrip, so the buffer reaches query_hedge_length
-# invalid. The hole is a real crack ring from the incident, in a simple shell.
-CRACK_TRUNCATED = (
+# Land-trimmed buffer with a degenerate hole (first two vertices identical,
+# only 2 distinct points). Captured from a real buffer — see trim_land.
+DEGENERATE_HOLE_BUFFER = (
     "SRID=4326;POLYGON ((-0.90 48.95, -0.79 48.95, -0.79 49.06, "
     "-0.90 49.06, -0.90 48.95), "
     "(-0.873686783197342 48.97633255528753, "
@@ -260,50 +257,51 @@ CRACK_TRUNCATED = (
     "-0.873686783214866 48.9763325555225, "
     "-0.873686783197342 48.97633255528753))"
 )
-CRACK_CIRCLE = (
+
+# Same outline without the hole, used as the raw circle.
+DEGENERATE_HOLE_CIRCLE = (
     "SRID=4326;POLYGON ((-0.90 48.95, -0.79 48.95, -0.79 49.06, "
     "-0.90 49.06, -0.90 48.95))"
 )
 
-# Crosses the circle's west edge at the crack's latitude → forces the
-# slow-path ST_Intersection against the invalid buffer (the crash path).
-CRACK_HEDGE = MultiLineString(
+# Straddles the circle's west edge at the hole's latitude, forcing
+# the slow-path clip against the degenerate hole.
+DEGENERATE_HOLE_HEDGE = MultiLineString(
     [LineString([(-0.92, 48.97633255528753), (-0.85, 48.97633255528753)])]
 )
 
-# ST_LengthSpheroid of the in-buffer portion (-0.90 → -0.85). Only the
-# planar-4326 clip yields this exactly; the geography (UTM) overload drifts
-# ~5 cm on recent GEOS and raises the production error on older GEOS.
-CRACK_EXPECTED_LENGTH = 3660.3227769668383
+# ST_LengthSpheroid of the in-buffer portion (lon -0.90 to -0.85).
+DEGENERATE_HOLE_EXPECTED_LENGTH = 3660.3227769668383
 
 
 @pytest.fixture
-def crack_geometries():
-    """Return (truncated_buffer, untruncated_circle) from the 2026-07 incident."""
-    truncated = GEOSGeometry(CRACK_TRUNCATED)
-    circle = GEOSGeometry(CRACK_CIRCLE)
-    # The fixture is only meaningful while the buffer stays invalid.
+def degenerate_hole_geometries():
+    """Return (truncated_buffer, untruncated_circle); the buffer is invalid."""
+    truncated = GEOSGeometry(DEGENERATE_HOLE_BUFFER)
+    circle = GEOSGeometry(DEGENERATE_HOLE_CIRCLE)
+    # These tests prove nothing if the buffer is accidentally valid.
     assert not truncated.valid
     return truncated, circle
 
 
-def test_query_hedge_length_handles_collapsed_crack_ring(crack_geometries):
-    """No TopologyException on the invalid buffer, and planar-4326 clip
-    semantics (the geography/UTM detour returned 3660.374)."""
-    truncated, circle = crack_geometries
-    LineFactory(geometry=CRACK_HEDGE)
+def test_query_hedge_length_clips_buffer_with_degenerate_hole(
+    degenerate_hole_geometries,
+):
+    """An invalid buffer must neither crash the query nor skew the clip."""
+    truncated, circle = degenerate_hole_geometries
+    LineFactory(geometry=DEGENERATE_HOLE_HEDGE)
 
     length = query_hedge_length(truncated, circle)
 
-    assert length == pytest.approx(CRACK_EXPECTED_LENGTH, **APPROX)
+    assert length == pytest.approx(DEGENERATE_HOLE_EXPECTED_LENGTH, **APPROX)
 
 
-def test_query_hedges_display_geojson_handles_collapsed_crack_ring(
-    crack_geometries,
+def test_query_hedges_display_geojson_handles_buffer_with_degenerate_hole(
+    degenerate_hole_geometries,
 ):
-    """Same collapsed-ring flaw, same fix, in the display query."""
-    truncated, circle = crack_geometries
-    LineFactory(geometry=CRACK_HEDGE)
+    """The display query runs the same clip and must survive the same buffer."""
+    truncated, circle = degenerate_hole_geometries
+    LineFactory(geometry=DEGENERATE_HOLE_HEDGE)
 
     display = query_hedges_display_geojson(truncated, circle)
 

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -624,9 +624,8 @@ def trim_land(geom):
 
     with connection.cursor() as cursor:
         cursor.execute(
-            # EWKB, not WKT: unioning near-coincident tiles leaves crack rings
-            # whose vertices differ below text precision — a WKT roundtrip
-            # collapses them into invalid rings (2026-07 TopologyException).
+            # EWKB: ST_AsText's precision merges near-identical vertices in
+            # the microscopic holes left by the tile union (see trim_land doc).
             """
             WITH input_poly AS (
               SELECT
@@ -677,14 +676,11 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
         (sea / forest) zone: measure it whole, skipping the costly clip.
       Slow path — hedge straddles a boundary: clip to the buffer first.
 
-    trunc is sanitized (ST_MakeValid + ST_CollectionExtract): the buffer can
-    arrive invalid — tile-seam crack rings collapsed by trim_land's WKT
-    roundtrip (2026-07 TopologyException incident).
+    trunc is sanitized (ST_MakeValid + ST_CollectionExtract): land-trimmed
+    buffers can carry degenerate holes (see trim_land).
 
-    Hedges are cast to ::geometry so the clip runs in planar 4326; the bare
-    geography ST_Intersection would reproject to UTM, where the 4326-valid
-    buffer can degenerate. Length is measured on the spheroid regardless.
-    Predicates keep the geography inputs to use the GIST index.
+    The clip casts hedges to ::geometry so it runs in planar 4326, the plane
+    the buffer was built in. Predicates stay on geography for the GIST index.
 
     Args:
         truncated_buffer: land-trimmed polygon, or None if off-land.
@@ -704,14 +700,13 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
                     ST_MakeValid(ST_GeomFromEWKT(%(truncated)s)), 3) AS trunc,
                 ST_GeomFromEWKT(%(circle)s) AS circ
         ),
-        -- zones: adds the excluded ring (circle minus buffer = sea / forest).
+        -- zones: adds the excluded area (circle minus buffer = sea / forest).
         zones AS (
             SELECT trunc, circ,
                 ST_Difference(ST_MakeValid(circ), trunc) AS excluded
             FROM inputs
         ),
-        -- candidates: hedges intersecting the circle, each flagged fully_inside
-        -- (covered by the circle and clear of the excluded zone).
+        -- candidates: hedges inside the circle, with fast/slow path flag.
         candidates AS (
             SELECT
                 l.geometry::geometry AS hedge,

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -615,12 +615,16 @@ def trim_land(geom):
     before merging them (which is a costly operation).
 
     Returns:
-        - the intersection of the input geometry with the union of land zones
+        - the intersection of the input geometry with the union of land zones,
+          guaranteed valid (consumers feed it to GEOS overlays)
         - None if there is no intersection (input is entirely off-land)
     """
 
     with connection.cursor() as cursor:
         cursor.execute(
+            # EWKB, not WKT: unioning near-coincident tiles leaves crack rings
+            # whose vertices differ below text precision — a WKT roundtrip
+            # collapses them into invalid rings (2026-07 TopologyException).
             """
             WITH input_poly AS (
               SELECT
@@ -639,18 +643,22 @@ def trim_land(geom):
               FROM clipped
               WHERE NOT ST_IsEmpty(g)
             )
-            SELECT ST_AsText(ST_Intersection(u.merged, i.geom))
+            SELECT ST_AsEWKB(ST_Intersection(u.merged, i.geom))
             FROM unioned u, input_poly i;
         """,
             [geom.ewkt, geom.ewkt, MAP_TYPES.density_reference],
         )
-        wkt = cursor.fetchone()[0]
-        if wkt:
-            trimmed_geom = GEOSGeometry(wkt)
-            trimmed_geom.srid = geom.srid  # Set SRID explicitly
-        else:
-            trimmed_geom = None
-        return trimmed_geom
+        ewkb = cursor.fetchone()[0]
+
+    if ewkb is None:
+        return None
+
+    # GEOSGeometry only reads WKB from a memoryview (bytes are parsed as text)
+    trimmed_geom = GEOSGeometry(memoryview(ewkb))
+    trimmed_geom.srid = geom.srid
+    if not trimmed_geom.valid:
+        trimmed_geom = trimmed_geom.make_valid()
+    return trimmed_geom
 
 
 WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -491,14 +491,12 @@ def fill_polygon_stats():
     This is only used manually when the need arises, for debugging purpose.
     """
     with connection.cursor() as cursor:
-        cursor.execute(
-            """
+        cursor.execute("""
         UPDATE geodata_zone
         SET
             area = ST_Area(geometry),
             npoints = ST_NPoints(geometry::geometry);
-        """
-        )
+        """)
 
 
 def get_catchment_area(lng, lat):
@@ -661,31 +659,22 @@ WGS84_SPHEROID = 'SPHEROID["WGS 84",6378137,298.257223563]'
 def query_hedge_length(truncated_buffer, untruncated_circle):
     """Sum the geodetic length of hedges clipped to the truncated buffer.
 
-    The truncated buffer is the circle intersected with terres émergées — it
-    can be a complex polygon (thousands of vertices along coastlines or forest
-    boundaries). Only hedges inside this polygon count toward density.
+    Only hedges inside the truncated buffer (circle ∩ terres émergées) count
+    toward density. The buffer is a complex polygon; the raw circle is simple.
+    Each candidate hedge is measured by one of two paths:
 
-    A CTE pre-computes three geometries once:
-      - trunc: the truncated buffer (complex, used for clipping)
-      - circ: the raw circle (simple, used for fast containment checks)
-      - excluded: ST_Difference(circ, trunc) — sea / forest zones
+      Fast path — hedge covered by the circle and clear of the excluded
+        (sea / forest) zone: measure it whole, skipping the costly clip.
+      Slow path — hedge straddles a boundary: clip to the buffer first.
 
-    ST_MakeValid guards both ST_Difference operands: the unioned truncated
-    buffer can carry near-zero-width spikes that GEOS can't node, otherwise
-    raising a non-noded TopologyException.
+    trunc is sanitized (ST_MakeValid + ST_CollectionExtract): the buffer can
+    arrive invalid — tile-seam crack rings collapsed by trim_land's WKT
+    roundtrip (2026-07 TopologyException incident).
 
-    The WHERE clause pre-filters hedges against the simple circle (efficient
-    spatial index lookup). Then for each hedge, a CASE chooses between:
-
-      Fast path — hedge is fully inside the truncated buffer:
-        ST_CoveredBy(hedge, circ) AND NOT ST_Intersects(hedge, excluded)
-        Both tests are cheap: the circle has few vertices, and the excluded
-        zone is small so bbox pre-filtering eliminates most hedges instantly.
-        The full hedge length is measured without clipping.
-
-      Slow path — hedge crosses a boundary (coast, forest, or circle edge):
-        ST_Intersection(hedge, trunc) clips the hedge to the truncated buffer
-        and measures the remaining portion.
+    Hedges are cast to ::geometry so the clip runs in planar 4326; the bare
+    geography ST_Intersection would reproject to UTM, where the 4326-valid
+    buffer can degenerate. Length is measured on the spheroid regardless.
+    Predicates keep the geography inputs to use the GIST index.
 
     Args:
         truncated_buffer: land-trimmed polygon, or None if off-land.
@@ -697,30 +686,41 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
     if truncated_buffer is None or truncated_buffer.empty:
         return 0.0
 
-    sql = f"""
-        WITH zones AS (
+    sql = """
+        -- inputs: the sanitized truncated buffer and the raw circle.
+        WITH inputs AS (
             SELECT
-                ST_GeomFromEWKT(%(truncated)s) AS trunc,
-                ST_GeomFromEWKT(%(circle)s) AS circ,
-                ST_Difference(
-                    ST_MakeValid(ST_GeomFromEWKT(%(circle)s)),
-                    ST_MakeValid(ST_GeomFromEWKT(%(truncated)s))
-                ) AS excluded
+                ST_CollectionExtract(
+                    ST_MakeValid(ST_GeomFromEWKT(%(truncated)s)), 3) AS trunc,
+                ST_GeomFromEWKT(%(circle)s) AS circ
+        ),
+        -- zones: adds the excluded ring (circle minus buffer = sea / forest).
+        zones AS (
+            SELECT trunc, circ,
+                ST_Difference(ST_MakeValid(circ), trunc) AS excluded
+            FROM inputs
+        ),
+        -- candidates: hedges intersecting the circle, each flagged fully_inside
+        -- (covered by the circle and clear of the excluded zone).
+        candidates AS (
+            SELECT
+                l.geometry::geometry AS hedge,
+                zones.trunc,
+                ST_CoveredBy(l.geometry, zones.circ)
+                    AND NOT ST_Intersects(l.geometry, zones.excluded)
+                        AS fully_inside
+            FROM geodata_line l
+            JOIN geodata_map m ON l.map_id = m.id
+            CROSS JOIN zones
+            WHERE m.map_type = %(map_type)s
+              AND ST_Intersects(l.geometry, zones.circ)
         )
-        SELECT COALESCE(SUM(CASE
-            WHEN ST_CoveredBy(l.geometry, zones.circ)
-                 AND NOT ST_Intersects(l.geometry, zones.excluded)
-            THEN ST_LengthSpheroid(
-                l.geometry::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
-            ELSE ST_LengthSpheroid(
-                ST_Intersection(l.geometry, zones.trunc)
-                ::geometry(GEOMETRY,4326), '{WGS84_SPHEROID}')
-        END), 0)
-        FROM geodata_line l
-        JOIN geodata_map m ON l.map_id = m.id
-        CROSS JOIN zones
-        WHERE m.map_type = %(map_type)s
-          AND ST_Intersects(l.geometry, zones.circ);
+        SELECT COALESCE(SUM(ST_LengthSpheroid(
+            CASE WHEN fully_inside THEN hedge
+                 ELSE ST_Intersection(hedge, trunc) END,
+            %(spheroid)s
+        )), 0)
+        FROM candidates;
     """
 
     with connection.cursor() as cursor:
@@ -730,6 +730,7 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
                 "truncated": truncated_buffer.ewkt,
                 "circle": untruncated_circle.ewkt,
                 "map_type": MAP_TYPES.haies,
+                "spheroid": WGS84_SPHEROID,
             },
         )
         return cursor.fetchone()[0]
@@ -738,7 +739,8 @@ def query_hedge_length(truncated_buffer, untruncated_circle):
 def query_hedges_display_geojson(truncated_buffer, untruncated_circle):
     """Return hedge geometries clipped to the truncated buffer for display.
 
-    Uses the same CTE excluded-zone strategy as `query_hedge_length`:
+    Uses the same CTE excluded-zone strategy as `query_hedge_length` — see
+    its docstring for the trunc sanitization and the ::geometry casts:
 
       Fast path — hedge fully inside the truncated buffer (covered by the
         simple circle and not touching the excluded zone): return as-is.
@@ -750,21 +752,23 @@ def query_hedges_display_geojson(truncated_buffer, untruncated_circle):
     """
 
     sql = """
-        WITH zones AS (
+        WITH inputs AS (
             SELECT
-                ST_GeomFromEWKT(%(circle)s) AS circ,
-                ST_GeomFromEWKT(%(truncated)s) AS trunc,
-                ST_Difference(
-                    ST_MakeValid(ST_GeomFromEWKT(%(circle)s)),
-                    ST_MakeValid(ST_GeomFromEWKT(%(truncated)s))
-                ) AS excluded
+                ST_CollectionExtract(
+                    ST_MakeValid(ST_GeomFromEWKT(%(truncated)s)), 3) AS trunc,
+                ST_GeomFromEWKT(%(circle)s) AS circ
+        ),
+        zones AS (
+            SELECT trunc, circ,
+                ST_Difference(ST_MakeValid(circ), trunc) AS excluded
+            FROM inputs
         )
         SELECT ST_AsGeoJSON(ST_CollectionExtract(ST_Collect(
             CASE
                 WHEN ST_CoveredBy(l.geometry, zones.circ)
                      AND NOT ST_Intersects(l.geometry, zones.excluded)
                 THEN l.geometry::geometry
-                ELSE ST_Intersection(l.geometry, zones.trunc)::geometry
+                ELSE ST_Intersection(l.geometry::geometry, zones.trunc)
             END
         ), 2))
         FROM geodata_line l

--- a/envergo/geodata/utils.py
+++ b/envergo/geodata/utils.py
@@ -491,12 +491,14 @@ def fill_polygon_stats():
     This is only used manually when the need arises, for debugging purpose.
     """
     with connection.cursor() as cursor:
-        cursor.execute("""
+        cursor.execute(
+            """
         UPDATE geodata_zone
         SET
             area = ST_Area(geometry),
             npoints = ST_NPoints(geometry::geometry);
-        """)
+        """
+        )
 
 
 def get_catchment_area(lng, lat):


### PR DESCRIPTION
Nouvelle instance du bug créé par les cartes de Terres Émergées.

Pour calculer la densité de haies, on réalise dans la requête l'union des polygones de terres emergées.

Malheureusement, ces polygones — issus d'un découpage d'une seule et même carte — ne correspondent pas *exactement* : deux sommets qui devraient être identiques ont parfois des différences.

Même si on est sur de la différence infinitésimale, c'est suffisant pour que Postgis créé des « trous » dans le polygone résultant.

Ces « trous », une fois passés dans le reste de la requête, subissent des opérations qui les rendent invalides (perte de précision via ST_AsText, reprojection).

Le résultat dépend de la version de Geos. Sur la version du serveur -> TopologyException.

Pour corriger, ceinture et bretelles :

 - on remplace ST_AsText (format texte avec précision moindre) par ST_AsEWKB (format binaire) qui évite la perte de précision
 - le clip entre les haies et le cercle se fait en calcul planaire au lieu de forcer une reprojection
 - usage de make_valid pour s'assurer de la validité des polygones obtenus.