### PR TITLE
Chargement des critères des réglementations non active

### DIFF
--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2168,12 +2168,8 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         We don't actually use the criteria directly, the returned queryset will only
         be used in a prefetch_related call when we fetch the regulations.
         """
-        activated_regulations = Regulation.objects.filter(
-            regulation__in=self.config.regulations_available
-        )
         criteria = (
-            Criterion.objects.filter(regulation__in=activated_regulations)
-            .valid_at(self.date)
+            Criterion.objects.valid_at(self.date)
             .order_by("weight")
             .distinct("weight", "id")
             .prefetch_related("templates")
@@ -2991,7 +2987,16 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             )
             final_q |= intersection_q
 
-        return super().get_criteria().filter(final_q)
+        # Activated regulations filter
+        activated_regulations_q = Regulation.objects.filter(
+            regulation__in=self.config.regulations_available
+        )
+        return (
+            super()
+            .get_criteria()
+            .filter(regulation__in=activated_regulations_q)
+            .filter(final_q)
+        )
 
     def get_intersecting_map_ids(self, hedges):
         """Find all map IDs whose zones intersect any of the given hedges.

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2939,6 +2939,7 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
 
     def get_criteria(self):
         """Fetch the criteria that can be activated for this project.
+
         Criteria can be activated only if its regulation is activated in config.
 
         There are two activation modes for a criterion:

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2988,14 +2988,10 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             )
             final_q |= intersection_q
 
-        # Activated regulations filter
-        activated_regulations_q = Regulation.objects.filter(
-            regulation__in=self.config.regulations_available
-        )
         return (
             super()
             .get_criteria()
-            .filter(regulation__in=activated_regulations_q)
+            .filter(regulation__regulation__in=self.config.regulations_available)
             .filter(final_q)
         )
 

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2168,8 +2168,12 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         We don't actually use the criteria directly, the returned queryset will only
         be used in a prefetch_related call when we fetch the regulations.
         """
+        activated_regulations = Regulation.objects.filter(
+            regulation__in=self.config.regulations_available
+        )
         criteria = (
-            Criterion.objects.valid_at(self.date)
+            Criterion.objects.filter(regulation__in=activated_regulations)
+            .valid_at(self.date)
             .order_by("weight")
             .distinct("weight", "id")
             .prefetch_related("templates")
@@ -2939,6 +2943,7 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
 
     def get_criteria(self):
         """Fetch the criteria that can be activated for this project.
+        Criteria can be activated only if its regulation is activated in config.
 
         There are two activation modes for a criterion:
          * department_centroid: activated if the department centroid is in the activation map,
@@ -2969,7 +2974,6 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
             & Exists(centroid_subquery)
             & ~Q(evaluator__in=empty_category_evaluators)
         )
-
         # Filter for hedges_intersection activation mode
         category_qs = []
         for category, hedges in hedges_by_category.items():

--- a/envergo/moulinette/tests/factories.py
+++ b/envergo/moulinette/tests/factories.py
@@ -112,11 +112,13 @@ class DCConfigHaieFactory(DjangoModelFactory):
         "ep",
         "natura2000_haie",
         "alignement_arbres",
+        "urbanisme_haie",
         "reserves_naturelles",
         "code_rural_haie",
         "regime_unique_haie",
         "sites_proteges_haie",
         "sites_inscrits_haie",
+        "sites_classes_haie",
         "protection_captages",
     ]
     aa_l3503_handling = "not_handled"

--- a/envergo/moulinette/tests/test_get_criteria.py
+++ b/envergo/moulinette/tests/test_get_criteria.py
@@ -244,6 +244,7 @@ def test_ep_regime_unique_included_with_ru_hedges(france_map, ep_regulation):
     )
     RUConfigHaieFactory()
     data = make_moulinette_haie_data(
+        reimplantation="remplacement",
         hedge_data=[make_hedge(type_haie="mixte")],
     )
     assert MoulinetteHaie(data).get_criteria().count() == 1

--- a/envergo/moulinette/tests/test_get_criteria.py
+++ b/envergo/moulinette/tests/test_get_criteria.py
@@ -245,3 +245,54 @@ def test_ep_regime_unique_included_with_ru_hedges(france_map):
         hedge_data=[make_hedge(type_haie="mixte")],
     )
     assert MoulinetteHaie(data).get_criteria().count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Criteria evaluated should have their regulation activated
+# ---------------------------------------------------------------------------
+
+
+EVALUATOR_EP_RU = "envergo.moulinette.regulations.ep.EspecesProtegeesRegimeUnique"
+
+
+def test_get_only_criteria_with_regulation_activated(france_map):
+    """Criteria evaluated should have their regulation activated"""
+    regulation_ep = RegulationFactory(regulation="ep")
+    regulation_lse = RegulationFactory(
+        regulation="loi_sur_leau_haie",
+        evaluator="envergo.moulinette.regulations.loi_sur_leau_haie.LoiSurLeauHaieRegulation",
+    )
+    CriterionFactory(
+        regulation=regulation_ep,
+        evaluator=EVALUATOR_EP_RU,
+        activation_map=france_map,
+        activation_mode="department_centroid",
+    )
+    CriterionFactory(
+        title="Loi sur l'eau Haie RU",
+        regulation=regulation_lse,
+        evaluator="envergo.moulinette.regulations.loi_sur_leau_haie.LoiSurLeauHaieRu",
+        activation_map=france_map,
+        activation_mode="department_centroid",
+    )
+    config = RUConfigHaieFactory(
+        regulations_available=[
+            "ep",
+            "loi_sur_leau_haie",
+        ]
+    )
+    data = make_moulinette_haie_data(
+        reimplantation="remplacement",
+        hedge_data=[make_hedge(type_haie="mixte")],
+    )
+    assert MoulinetteHaie(data).get_criteria().count() == 2
+
+    config.regulations_available = [
+        "ep",
+    ]
+    config.save()
+    data = make_moulinette_haie_data(
+        reimplantation="remplacement",
+        hedge_data=[make_hedge(type_haie="mixte")],
+    )
+    assert MoulinetteHaie(data).get_criteria().count() == 1

--- a/envergo/moulinette/tests/test_get_criteria.py
+++ b/envergo/moulinette/tests/test_get_criteria.py
@@ -43,6 +43,11 @@ def urbanisme_regulation():
     return RegulationFactory(regulation="urbanisme_haie")
 
 
+@pytest.fixture
+def ep_regulation():
+    return RegulationFactory(regulation="ep")
+
+
 # ---------------------------------------------------------------------------
 # department_centroid activation mode
 # ---------------------------------------------------------------------------
@@ -216,11 +221,10 @@ def test_intersection_ru_criterion_excluded_when_only_hru_hedge_intersects_zone(
 EVALUATOR_EP_RU = "envergo.moulinette.regulations.ep.EspecesProtegeesRegimeUnique"
 
 
-def test_ep_regime_unique_excluded_without_ru_hedges(france_map):
+def test_ep_regime_unique_excluded_without_ru_hedges(france_map, ep_regulation):
     """EP RU criterion (category=ru) is excluded in DC mode — no RU hedges exist."""
-    regulation = RegulationFactory(regulation="ep")
     CriterionFactory(
-        regulation=regulation,
+        regulation=ep_regulation,
         evaluator=EVALUATOR_EP_RU,
         activation_map=france_map,
         activation_mode="department_centroid",
@@ -230,18 +234,16 @@ def test_ep_regime_unique_excluded_without_ru_hedges(france_map):
     assert MoulinetteHaie(data).get_criteria().count() == 0
 
 
-def test_ep_regime_unique_included_with_ru_hedges(france_map):
+def test_ep_regime_unique_included_with_ru_hedges(france_map, ep_regulation):
     """EP RU criterion (category=ru) is included in RU mode with a RU hedge."""
-    regulation = RegulationFactory(regulation="ep")
     CriterionFactory(
-        regulation=regulation,
+        regulation=ep_regulation,
         evaluator=EVALUATOR_EP_RU,
         activation_map=france_map,
         activation_mode="department_centroid",
     )
     RUConfigHaieFactory()
     data = make_moulinette_haie_data(
-        reimplantation="remplacement",
         hedge_data=[make_hedge(type_haie="mixte")],
     )
     assert MoulinetteHaie(data).get_criteria().count() == 1
@@ -252,38 +254,31 @@ def test_ep_regime_unique_included_with_ru_hedges(france_map):
 # ---------------------------------------------------------------------------
 
 
-EVALUATOR_EP_RU = "envergo.moulinette.regulations.ep.EspecesProtegeesRegimeUnique"
-
-
-def test_get_only_criteria_with_regulation_activated(france_map):
+def test_get_only_criteria_with_regulation_activated(
+    france_map, bizous_town_center, ep_regulation, urbanisme_regulation
+):
     """Criteria evaluated should have their regulation activated"""
-    regulation_ep = RegulationFactory(regulation="ep")
-    regulation_lse = RegulationFactory(
-        regulation="loi_sur_leau_haie",
-        evaluator="envergo.moulinette.regulations.loi_sur_leau_haie.LoiSurLeauHaieRegulation",
-    )
     CriterionFactory(
-        regulation=regulation_ep,
+        regulation=ep_regulation,
         evaluator=EVALUATOR_EP_RU,
         activation_map=france_map,
         activation_mode="department_centroid",
     )
     CriterionFactory(
-        title="Loi sur l'eau Haie RU",
-        regulation=regulation_lse,
-        evaluator="envergo.moulinette.regulations.loi_sur_leau_haie.LoiSurLeauHaieRu",
-        activation_map=france_map,
-        activation_mode="department_centroid",
+        regulation=urbanisme_regulation,
+        evaluator=EVALUATOR_RU,
+        activation_map=bizous_town_center,
+        activation_mode="hedges_intersection",
     )
     config = RUConfigHaieFactory(
         regulations_available=[
             "ep",
-            "loi_sur_leau_haie",
+            "urbanisme_haie",
         ]
     )
     data = make_moulinette_haie_data(
         reimplantation="remplacement",
-        hedge_data=[make_hedge(type_haie="mixte")],
+        hedge_data=[make_hedge(coords=COORDS_BIZOUS_INSIDE, **HEDGE_RU)],
     )
     assert MoulinetteHaie(data).get_criteria().count() == 2
 
@@ -293,6 +288,6 @@ def test_get_only_criteria_with_regulation_activated(france_map):
     config.save()
     data = make_moulinette_haie_data(
         reimplantation="remplacement",
-        hedge_data=[make_hedge(type_haie="mixte")],
+        hedge_data=[make_hedge(coords=COORDS_BIZOUS_INSIDE, **HEDGE_RU)],
     )
     assert MoulinetteHaie(data).get_criteria().count() == 1


### PR DESCRIPTION
https://trello.com/c/KjpNO1I0/2528-chargement-des-crit%C3%A8res-des-r%C3%A9glementations-non-active

Je pensais corriger ça au niveau de la classe parent de `MoulinetteHaie`, mais ça casse pas mal de tests de aménagement.