### PR TITLE
Question réimplantation

### DIFF
--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -406,8 +406,40 @@ class BaseMoulinetteFormHaie(BaseMoulinetteForm):
             "geometry"
         ).annotate(centroid=Centroid("geometry"))
 
+    def validate_reimplantation(self):
+        """Reject impossible motif + reimplantation combos.
+
+        Reads from raw data so it works whether or not the reimplantation
+        field is declared on the form. Adds the error to the field when
+        it exists (HRU), or as a non-field error otherwise (RU).
+        """
+        reimplantation = self.data.get("reimplantation")
+        motif = self.data.get("motif")
+        error = None
+
+        if motif == "chemin_acces" and reimplantation == "remplacement":
+            error = ValidationError(
+                "Le remplacement de la haie au même endroit est incompatible avec la "
+                "raison « création d’un accès ». "
+                "Modifiez l’une ou l’autre des réponses du formulaire.",
+                code="inconsistent_motif",
+            )
+        elif motif == "amelioration_ecologique" and reimplantation == "non":
+            error = ValidationError(
+                "La destruction de la haie sans réimplantation est incompatible "
+                "avec la raison « amélioration écologique ». "
+                "Modifiez l’une ou l’autre des réponses du formulaire.",
+                code="inconsistent_motif",
+            )
+
+        if error:
+            field = "reimplantation" if "reimplantation" in self.fields else None
+            self.add_error(field, error)
+
     def clean(self):
         data = super().clean()
+
+        self.validate_reimplantation()
 
         localisation_pac = data.get("localisation_pac")
         haies = data.get("haies")
@@ -506,33 +538,6 @@ class MoulinetteFormHaieHRU(BaseMoulinetteFormHaie):
         required=True,
         get_display_value=extract_display_function(REIMPLANTATION_CHOICES),
     )
-
-    def clean(self):
-        data = super().clean()
-
-        reimplantation = data.get("reimplantation")
-        motif = data.get("motif")
-
-        if motif == "chemin_acces" and reimplantation == "remplacement":
-            self.add_error(
-                "reimplantation",
-                ValidationError(
-                    """Le remplacement de la haie au même endroit est incompatible avec la
-                    raison « création d’un accès ». Modifiez l’une ou l’autre des réponses du formulaire.""",
-                    code="inconsistent_motif",
-                ),
-            )
-        elif motif == "amelioration_ecologique" and reimplantation == "non":
-            self.add_error(
-                "reimplantation",
-                ValidationError(
-                    """La destruction de la haie sans réimplantation est incompatible avec la raison
-                    « amélioration écologique ». Modifiez l’une ou l’autre des réponses du formulaire.""",
-                    code="inconsistent_motif",
-                ),
-            )
-
-        return data
 
 
 class TriageFormHaie(forms.Form):

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -409,12 +409,15 @@ class BaseMoulinetteFormHaie(BaseMoulinetteForm):
     def validate_reimplantation(self):
         """Reject impossible motif + reimplantation combos.
 
-        Reads from raw data so it works whether or not the reimplantation
-        field is declared on the form. Adds the error to the field when
+        Checks both bound data (POST) and initial data (URL params),
+        because in RU mode the field is absent from the form and the
+        value only comes from the URL. Adds the error to the field when
         it exists (HRU), or as a non-field error otherwise (RU).
         """
-        reimplantation = self.data.get("reimplantation")
-        motif = self.data.get("motif")
+        reimplantation = self.data.get("reimplantation") or self.initial.get(
+            "reimplantation"
+        )
+        motif = self.data.get("motif") or self.initial.get("motif")
         error = None
 
         if motif == "chemin_acces" and reimplantation == "remplacement":

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -350,7 +350,7 @@ CONTEXT_CHOICES = (
 )
 
 
-class MoulinetteFormHaie(BaseMoulinetteForm):
+class BaseMoulinetteFormHaie(BaseMoulinetteForm):
     department = SafeModelChoiceField(
         queryset=Department.objects.all(),
         required=True,
@@ -381,13 +381,6 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
         required=True,
     )
 
-    reimplantation = DisplayChoiceField(
-        label="Est-il prévu de planter une nouvelle haie ?",
-        widget=forms.RadioSelect,
-        choices=extract_choices(REIMPLANTATION_CHOICES),
-        required=True,
-        get_display_value=extract_display_function(REIMPLANTATION_CHOICES),
-    )
     localisation_pac = forms.ChoiceField(
         label="Les haies à détruire sont-elles situées sur des parcelles agricoles déclarées à la PAC ?",
         widget=forms.RadioSelect,
@@ -403,9 +396,10 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
         },
     )
 
-    def __init__(self, *args, single_procedure=False, **kwargs):
+    single_procedure = False
+
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.single_procedure = single_procedure
 
         # We override the queryset here because it prevents a "models are not ready" exception
         self.fields["department"].queryset = Department.objects.defer(
@@ -415,30 +409,8 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
     def clean(self):
         data = super().clean()
 
-        reimplantation = data.get("reimplantation")
-        motif = data.get("motif")
         localisation_pac = data.get("localisation_pac")
         haies = data.get("haies")
-
-        if motif == "chemin_acces" and reimplantation == "remplacement":
-            self.add_error(
-                "reimplantation",
-                ValidationError(
-                    """Le remplacement de la haie au même endroit est incompatible avec la
-                    raison « création d’un accès ». Modifiez l'une ou l'autre des réponses du formulaire.""",
-                    code="inconsistent_motif",
-                ),
-            )
-
-        elif motif == "amelioration_ecologique" and reimplantation == "non":
-            self.add_error(
-                "reimplantation",
-                ValidationError(
-                    """La destruction de la haie sans réimplantation est incompatible avec la raison
-                    « amélioration écologique ». Modifiez l'une ou l'autre des réponses du formulaire.""",
-                    code="inconsistent_motif",
-                ),
-            )
 
         if localisation_pac == "oui" and haies:
             on_pac_values = [h.is_on_pac for h in haies.hedges_to_remove()]
@@ -518,6 +490,49 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
                 ),
             )
         return haies
+
+
+class MoulinetteFormHaieRU(BaseMoulinetteFormHaie):
+    single_procedure = True
+
+
+class MoulinetteFormHaieHRU(BaseMoulinetteFormHaie):
+    single_procedure = False
+
+    reimplantation = DisplayChoiceField(
+        label="Est-il prévu de planter une nouvelle haie ?",
+        widget=forms.RadioSelect,
+        choices=extract_choices(REIMPLANTATION_CHOICES),
+        required=True,
+        get_display_value=extract_display_function(REIMPLANTATION_CHOICES),
+    )
+
+    def clean(self):
+        data = super().clean()
+
+        reimplantation = data.get("reimplantation")
+        motif = data.get("motif")
+
+        if motif == "chemin_acces" and reimplantation == "remplacement":
+            self.add_error(
+                "reimplantation",
+                ValidationError(
+                    """Le remplacement de la haie au même endroit est incompatible avec la
+                    raison « création d’un accès ». Modifiez l’une ou l’autre des réponses du formulaire.""",
+                    code="inconsistent_motif",
+                ),
+            )
+        elif motif == "amelioration_ecologique" and reimplantation == "non":
+            self.add_error(
+                "reimplantation",
+                ValidationError(
+                    """La destruction de la haie sans réimplantation est incompatible avec la raison
+                    « amélioration écologique ». Modifiez l’une ou l’autre des réponses du formulaire.""",
+                    code="inconsistent_motif",
+                ),
+            )
+
+        return data
 
 
 class TriageFormHaie(forms.Form):

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -409,35 +409,34 @@ class BaseMoulinetteFormHaie(BaseMoulinetteForm):
     def validate_reimplantation(self):
         """Reject impossible motif + reimplantation combos.
 
-        Checks both bound data (POST) and initial data (URL params),
-        because in RU mode the field is absent from the form and the
-        value only comes from the URL. Adds the error to the field when
-        it exists (HRU), or as a non-field error otherwise (RU).
+        Only runs when the reimplantation field is on the form (non-RU).
+        In RU mode the value is forced to "replantation" so the check
+        is unnecessary and would produce an error the user cannot fix.
         """
-        reimplantation = self.data.get("reimplantation") or self.initial.get(
-            "reimplantation"
-        )
-        motif = self.data.get("motif") or self.initial.get("motif")
-        error = None
+        if "reimplantation" not in self.fields:
+            return
+
+        reimplantation = self.cleaned_data.get("reimplantation")
+        motif = self.cleaned_data.get("motif")
 
         if motif == "chemin_acces" and reimplantation == "remplacement":
-            error = ValidationError(
-                "Le remplacement de la haie au même endroit est incompatible avec la "
-                "raison « création d’un accès ». "
-                "Modifiez l’une ou l’autre des réponses du formulaire.",
-                code="inconsistent_motif",
+            self.add_error(
+                "reimplantation",
+                ValidationError(
+                    """Le remplacement de la haie au même endroit est incompatible avec la
+                    raison « création d’un accès ». Modifiez l’une ou l’autre des réponses du formulaire.""",
+                    code="inconsistent_motif",
+                ),
             )
         elif motif == "amelioration_ecologique" and reimplantation == "non":
-            error = ValidationError(
-                "La destruction de la haie sans réimplantation est incompatible "
-                "avec la raison « amélioration écologique ». "
-                "Modifiez l’une ou l’autre des réponses du formulaire.",
-                code="inconsistent_motif",
+            self.add_error(
+                "reimplantation",
+                ValidationError(
+                    """La destruction de la haie sans réimplantation est incompatible avec la raison
+                    « amélioration écologique ». Modifiez l’une ou l’autre des réponses du formulaire.""",
+                    code="inconsistent_motif",
+                ),
             )
-
-        if error:
-            field = "reimplantation" if "reimplantation" in self.fields else None
-            self.add_error(field, error)
 
     def clean(self):
         data = super().clean()
@@ -529,6 +528,7 @@ class BaseMoulinetteFormHaie(BaseMoulinetteForm):
 
 class MoulinetteFormHaieRU(BaseMoulinetteFormHaie):
     single_procedure = True
+    excluded_params = ["reimplantation"]
 
 
 class MoulinetteFormHaieHRU(BaseMoulinetteFormHaie):

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2850,8 +2850,11 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         data = super().get_catalog_data()
 
         if "reimplantation" not in data:
-            raw = self.bound_main_form.data
-            data["reimplantation"] = raw.get("reimplantation", "replantation")
+            raw_data = self.bound_main_form.data
+            initial = self.bound_main_form.initial or {}
+            data["reimplantation"] = raw_data.get("reimplantation") or initial.get(
+                "reimplantation", "replantation"
+            )
 
         if "haies" in data:
             hedges = data["haies"]

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -71,7 +71,8 @@ from envergo.moulinette.fields import (
 from envergo.moulinette.forms import (
     DisplayIntegerField,
     MoulinetteFormAmenagement,
-    MoulinetteFormHaie,
+    MoulinetteFormHaieHRU,
+    MoulinetteFormHaieRU,
     TriageFormHaie,
 )
 from envergo.moulinette.regulations import (
@@ -1462,7 +1463,8 @@ class ConfigHaie(ConfigBase):
         }
         main_form_fields = {
             (key, field.label)
-            for key, field in MoulinetteHaie.main_form_class.base_fields.items()
+            for form_class in (MoulinetteFormHaieRU, MoulinetteFormHaieHRU)
+            for key, field in form_class.base_fields.items()
         }
 
         identified_sources = {
@@ -2632,42 +2634,20 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
     result_available_soon = "haie/moulinette/result_non_disponible.html"
     result_non_disponible = "haie/moulinette/result_non_disponible.html"
     form_template = "haie/moulinette/form.html"
-    main_form_class = MoulinetteFormHaie
     triage_form_class = TriageFormHaie
 
     def _get_single_procedure(self):
         config = self.config
         return config.single_procedure if config else False
 
-    def get_main_form(self):
-        """Instantiate the main form with data.
-
-        Overridden to pass some context to the main form constructor
-        """
-        return self.get_main_form_class()(
-            single_procedure=self._get_single_procedure(), **self.form_kwargs
+    def get_main_form_class(self):
+        """Return the form class for the main questions."""
+        FormClass = (
+            MoulinetteFormHaieRU
+            if self._get_single_procedure()
+            else MoulinetteFormHaieHRU
         )
-
-    @cached_property
-    def bound_main_form(self):
-        """Get the main form with forced bound data.
-
-        Overridden to pass some context to the main form constructor
-
-        When we display the moulinette form, we show the main form with
-        initial values. But if the initial data would be valid data, then we
-        want to also display the additional forms.
-
-        In that case, we force a form validation by creating a moulinette form
-        where we pass initial data as validation data.
-        """
-        if self.main_form.is_bound:
-            return self.main_form
-        form_kwargs = self.form_kwargs.copy()
-        form_kwargs["data"] = form_kwargs.get("initial", {})
-        return self.get_main_form_class()(
-            single_procedure=self._get_single_procedure(), **form_kwargs
-        )
+        return FormClass
 
     @property
     def result(self):
@@ -2868,6 +2848,11 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         """Fetch / compute data required for further computations."""
 
         data = super().get_catalog_data()
+
+        if "reimplantation" not in data:
+            raw = self.bound_main_form.data
+            data["reimplantation"] = raw.get("reimplantation", "replantation")
+
         if "haies" in data:
             hedges = data["haies"]
             data["departments_lengths"] = hedges.departments_lengths()

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -1986,6 +1986,10 @@ class Moulinette(MoulinetteUrlMixin, ABC):
     def all_forms(self):
         return self.get_all_forms()
 
+    def get_excluded_params(self):
+        """URL params the main form says should be stripped from redirects."""
+        return getattr(self.main_form, "excluded_params", [])
+
     def get_prefixed_fields(self):
         """Return all known fields, with prefixed keys."""
 
@@ -2850,11 +2854,14 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         data = super().get_catalog_data()
 
         if "reimplantation" not in data:
-            raw_data = self.bound_main_form.data
-            initial = self.bound_main_form.initial or {}
-            data["reimplantation"] = raw_data.get("reimplantation") or initial.get(
-                "reimplantation", "replantation"
-            )
+            if self._get_single_procedure():
+                data["reimplantation"] = "replantation"
+            else:
+                raw_data = self.bound_main_form.data
+                initial = self.bound_main_form.initial or {}
+                data["reimplantation"] = raw_data.get("reimplantation") or initial.get(
+                    "reimplantation", "replantation"
+                )
 
         if "haies" in data:
             hedges = data["haies"]

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1030,3 +1030,120 @@ def test_triage_nul_byte_in_department(client):
     url = reverse("triage")
     res = client.get(f"{url}?department=44%00")
     assert res.status_code in (200, 302)
+
+
+class TestReimplantationFieldRemoval:
+    """The reimplantation question is removed from the main form.
+
+    It must not appear on the form page in any department configuration.
+    When absent from the submitted data, criteria that need it fall back
+    to a default value of "replantation". Saved simulations that include
+    the field in their URL still use the provided value.
+    """
+
+    REIMPLANTATION_LABEL = "Est-il prévu de planter une nouvelle haie"
+
+    def test_field_not_shown_on_form_page_ru(self, client):
+        """Regime unique: the reimplantation question does not appear."""
+        RUConfigHaieFactory()
+        url = reverse("moulinette_form")
+        params = "department=44&element=haie&travaux=destruction&contexte=non"
+        res = client.get(f"{url}?{params}")
+
+        assert res.status_code == 200
+        assert self.REIMPLANTATION_LABEL not in res.content.decode()
+
+    def test_simulation_valid_without_reimplantation_ru(self, client):
+        """Regime unique: a simulation is valid without reimplantation."""
+        RUConfigHaieFactory()
+        hedges = HedgeDataFactory(
+            hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=False)]
+        )
+        url = reverse("moulinette_form")
+        triage = urlencode(
+            {
+                "department": "44",
+                "element": "haie",
+                "travaux": "destruction",
+                "contexte": "non",
+            }
+        )
+        data = {
+            "department": "44",
+            "element": "haie",
+            "travaux": "destruction",
+            "contexte": "non",
+            "motif": "amelioration_culture",
+            "localisation_pac": "non",
+            "haies": str(hedges.id),
+        }
+        res = client.post(f"{url}?{triage}", data)
+
+        assert res.status_code == 200
+        content = res.content.decode()
+        assert FORM_ERROR not in content
+
+    def test_field_not_shown_on_form_page_dc(self, client):
+        """Droit constant: the reimplantation question does not appear either."""
+        DCConfigHaieFactory()
+        url = reverse("moulinette_form")
+        params = "department=44&element=haie&travaux=destruction&contexte=non"
+        res = client.get(f"{url}?{params}")
+
+        assert res.status_code == 200
+        assert self.REIMPLANTATION_LABEL not in res.content.decode()
+
+    def test_default_value_used_when_absent_dc_bcae8(self, client):
+        """Droit constant + BCAE8: without reimplantation in the data,
+        the criterion falls back to 'replantation'."""
+        DCConfigHaieFactory()
+        hedges = HedgeDataFactory(
+            hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=True)]
+        )
+        url = reverse("moulinette_result")
+        data = {
+            "element": "haie",
+            "travaux": "destruction",
+            "contexte": "non",
+            "motif": "amelioration_culture",
+            "localisation_pac": "oui",
+            "department": "44",
+            "haies": hedges.id,
+            "lineaire_total": 100,
+            "transfert_parcelles": "non",
+            "meilleur_emplacement": "non",
+        }
+        query = urlencode(data)
+        res = client.get(f"{url}?{query}")
+
+        assert res.status_code == 200
+        moulinette = res.context["moulinette"]
+        assert moulinette.catalog["reimplantation"] == "replantation"
+
+    def test_provided_value_used_when_present_dc_bcae8(self, client):
+        """Droit constant + BCAE8: when reimplantation is in the URL
+        (saved simulation), the provided value is used."""
+        DCConfigHaieFactory()
+        hedges = HedgeDataFactory(
+            hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=True)]
+        )
+        url = reverse("moulinette_result")
+        data = {
+            "element": "haie",
+            "travaux": "destruction",
+            "contexte": "non",
+            "motif": "amelioration_culture",
+            "reimplantation": "non",
+            "localisation_pac": "oui",
+            "department": "44",
+            "haies": hedges.id,
+            "lineaire_total": 100,
+            "transfert_parcelles": "non",
+            "meilleur_emplacement": "non",
+        }
+        query = urlencode(data)
+        res = client.get(f"{url}?{query}")
+
+        assert res.status_code == 200
+        moulinette = res.context["moulinette"]
+        assert moulinette.catalog["reimplantation"] == "non"

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1131,11 +1131,46 @@ class TestReimplantationFieldRemoval:
         assert moulinette.catalog["reimplantation"] == "replantation"
 
     def test_provided_value_used_when_present_dc_bcae8(self, client):
-        """BCAE8: when reimplantation is in the URL (saved simulation),
+        """When reimplantation is in the URL (saved simulation),
         the provided value is used."""
         DCConfigHaieFactory()
         hedges = HedgeDataFactory(
             hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=True)]
+        )
+        url = reverse("moulinette_result")
+        data = {
+            "element": "haie",
+            "travaux": "destruction",
+            "contexte": "non",
+            "motif": "amelioration_culture",
+            "reimplantation": "non",
+            "localisation_pac": "oui",
+            "department": "44",
+            "haies": hedges.id,
+            "lineaire_total": 100,
+            "transfert_parcelles": "non",
+            "meilleur_emplacement": "non",
+        }
+        query = urlencode(data)
+        res = client.get(f"{url}?{query}")
+
+        assert res.status_code == 200
+        moulinette = res.context["moulinette"]
+        assert moulinette.catalog["reimplantation"] == "non"
+
+    def test_provided_value_used_when_present_ru(self, client):
+        """Regime unique: when reimplantation is in the URL (saved
+        simulation), the provided value is used despite the field not
+        being on the form."""
+        RUConfigHaieFactory()
+        hedges = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(
+                    length=4,
+                    additionalData__sur_parcelle_pac=True,
+                    additionalData__type_haie="buissonnante",
+                )
+            ]
         )
         url = reverse("moulinette_result")
         data = {

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1033,12 +1033,12 @@ def test_triage_nul_byte_in_department(client):
 
 
 class TestReimplantationFieldRemoval:
-    """The reimplantation question is removed from the main form.
+    """In regime unique, the reimplantation question is removed from the
+    main form. When regime unique is not activated, it stays visible and
+    required.
 
-    It must not appear on the form page in any department configuration.
-    When absent from the submitted data, criteria that need it fall back
-    to a default value of "replantation". Saved simulations that include
-    the field in their URL still use the provided value.
+    When absent from the submitted data (RU or saved simulations),
+    criteria that need it fall back to "replantation".
     """
 
     REIMPLANTATION_LABEL = "Est-il prévu de planter une nouvelle haie"
@@ -1057,7 +1057,13 @@ class TestReimplantationFieldRemoval:
         """Regime unique: a simulation is valid without reimplantation."""
         RUConfigHaieFactory()
         hedges = HedgeDataFactory(
-            hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=False)]
+            hedges=[
+                HedgeFactory(
+                    length=4,
+                    additionalData__sur_parcelle_pac=False,
+                    additionalData__type_haie="buissonnante",
+                )
+            ]
         )
         url = reverse("moulinette_form")
         triage = urlencode(
@@ -1079,26 +1085,30 @@ class TestReimplantationFieldRemoval:
         }
         res = client.post(f"{url}?{triage}", data)
 
-        assert res.status_code == 200
-        content = res.content.decode()
-        assert FORM_ERROR not in content
+        assert FORM_ERROR not in res.content.decode()
 
-    def test_field_not_shown_on_form_page_dc(self, client):
-        """Droit constant: the reimplantation question does not appear either."""
+    def test_field_shown_on_form_page_dc(self, client):
+        """Regime unique not activated: the reimplantation question appears."""
         DCConfigHaieFactory()
         url = reverse("moulinette_form")
         params = "department=44&element=haie&travaux=destruction&contexte=non"
         res = client.get(f"{url}?{params}")
 
         assert res.status_code == 200
-        assert self.REIMPLANTATION_LABEL not in res.content.decode()
+        assert self.REIMPLANTATION_LABEL in res.content.decode()
 
-    def test_default_value_used_when_absent_dc_bcae8(self, client):
-        """Droit constant + BCAE8: without reimplantation in the data,
+    def test_default_value_used_when_absent_ru_bcae8(self, client):
+        """Regime unique + BCAE8: without reimplantation in the data,
         the criterion falls back to 'replantation'."""
-        DCConfigHaieFactory()
+        RUConfigHaieFactory()
         hedges = HedgeDataFactory(
-            hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=True)]
+            hedges=[
+                HedgeFactory(
+                    length=4,
+                    additionalData__sur_parcelle_pac=True,
+                    additionalData__type_haie="buissonnante",
+                )
+            ]
         )
         url = reverse("moulinette_result")
         data = {
@@ -1121,8 +1131,8 @@ class TestReimplantationFieldRemoval:
         assert moulinette.catalog["reimplantation"] == "replantation"
 
     def test_provided_value_used_when_present_dc_bcae8(self, client):
-        """Droit constant + BCAE8: when reimplantation is in the URL
-        (saved simulation), the provided value is used."""
+        """BCAE8: when reimplantation is in the URL (saved simulation),
+        the provided value is used."""
         DCConfigHaieFactory()
         hedges = HedgeDataFactory(
             hedges=[HedgeFactory(length=4, additionalData__sur_parcelle_pac=True)]

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -821,8 +821,10 @@ def test_result_p_view_with_hedges_to_plant_intersecting_perimeters(
     # # Given a department configured as régime unique
     config_44.delete()
     RUConfigHaieFactory()
-    # WHEN requesting the result plantation page with droit constant
-    res = client.get(f"{url}?{query}")
+    # WHEN requesting the result plantation page with RU config
+    ru_data = {k: v for k, v in data.items() if k != "reimplantation"}
+    ru_query = urlencode(ru_data)
+    res = client.get(f"{url}?{ru_query}")
 
     # THEN the result page is displayed with a warning listing only regulations that can be in "autorisation"
     assert (
@@ -1158,10 +1160,11 @@ class TestReimplantationFieldRemoval:
         moulinette = res.context["moulinette"]
         assert moulinette.catalog["reimplantation"] == "non"
 
-    def test_stale_reimplantation_ignored_in_ru(self, client):
-        """Regime unique: a stale reimplantation value in the URL is
-        ignored — the catalog always gets 'replantation' so the user
-        is never trapped by an invisible field they cannot change."""
+    def test_stale_reimplantation_redirects_to_form_in_ru(self, client):
+        """Regime unique: when the result URL contains a stale
+        reimplantation param, the result view redirects to the form
+        with that param stripped — rather than silently using a
+        different value than what the URL shows."""
         RUConfigHaieFactory()
         hedges = HedgeDataFactory(
             hedges=[
@@ -1189,9 +1192,9 @@ class TestReimplantationFieldRemoval:
         query = urlencode(data)
         res = client.get(f"{url}?{query}")
 
-        assert res.status_code == 200
-        moulinette = res.context["moulinette"]
-        assert moulinette.catalog["reimplantation"] == "replantation"
+        assert res.status_code == 302
+        assert "reimplantation" not in res["Location"]
+        assert "/simulateur/formulaire/" in res["Location"]
 
     def test_reimplantation_stripped_from_redirect_url_in_ru(self, client):
         """Regime unique: when the form view builds a redirect URL

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1158,10 +1158,10 @@ class TestReimplantationFieldRemoval:
         moulinette = res.context["moulinette"]
         assert moulinette.catalog["reimplantation"] == "non"
 
-    def test_provided_value_used_when_present_ru(self, client):
-        """Regime unique: when reimplantation is in the URL (saved
-        simulation), the provided value is used despite the field not
-        being on the form."""
+    def test_stale_reimplantation_ignored_in_ru(self, client):
+        """Regime unique: a stale reimplantation value in the URL is
+        ignored — the catalog always gets 'replantation' so the user
+        is never trapped by an invisible field they cannot change."""
         RUConfigHaieFactory()
         hedges = HedgeDataFactory(
             hedges=[
@@ -1191,4 +1191,42 @@ class TestReimplantationFieldRemoval:
 
         assert res.status_code == 200
         moulinette = res.context["moulinette"]
-        assert moulinette.catalog["reimplantation"] == "non"
+        assert moulinette.catalog["reimplantation"] == "replantation"
+
+    def test_reimplantation_stripped_from_redirect_url_in_ru(self, client):
+        """Regime unique: when the form view builds a redirect URL
+        (e.g. to the result page), the stale reimplantation param
+        from the original URL is stripped."""
+        RUConfigHaieFactory()
+        hedges = HedgeDataFactory(
+            hedges=[
+                HedgeFactory(
+                    length=4,
+                    additionalData__sur_parcelle_pac=False,
+                    additionalData__type_haie="buissonnante",
+                )
+            ]
+        )
+        url = reverse("moulinette_form")
+        triage = urlencode(
+            {
+                "department": "44",
+                "element": "haie",
+                "travaux": "destruction",
+                "contexte": "non",
+                "reimplantation": "non",
+            }
+        )
+        data = {
+            "department": "44",
+            "element": "haie",
+            "travaux": "destruction",
+            "contexte": "non",
+            "motif": "amelioration_culture",
+            "localisation_pac": "non",
+            "haies": str(hedges.id),
+        }
+        res = client.post(f"{url}?{triage}", data)
+
+        assert res.status_code == 302
+        assert "reimplantation" not in res["Location"]

--- a/envergo/moulinette/tests/test_views_haie.py
+++ b/envergo/moulinette/tests/test_views_haie.py
@@ -1160,11 +1160,11 @@ class TestReimplantationFieldRemoval:
         moulinette = res.context["moulinette"]
         assert moulinette.catalog["reimplantation"] == "non"
 
-    def test_stale_reimplantation_redirects_to_form_in_ru(self, client):
+    def test_stale_reimplantation_stripped_from_result_url_in_ru(self, client):
         """Regime unique: when the result URL contains a stale
-        reimplantation param, the result view redirects to the form
-        with that param stripped — rather than silently using a
-        different value than what the URL shows."""
+        reimplantation param, the result view redirects to the same
+        result URL with that param stripped. Following the redirect
+        renders the result with the default value."""
         RUConfigHaieFactory()
         hedges = HedgeDataFactory(
             hedges=[
@@ -1194,7 +1194,11 @@ class TestReimplantationFieldRemoval:
 
         assert res.status_code == 302
         assert "reimplantation" not in res["Location"]
-        assert "/simulateur/formulaire/" in res["Location"]
+
+        res = client.get(res["Location"])
+        assert res.status_code == 200
+        moulinette = res.context["moulinette"]
+        assert moulinette.catalog["reimplantation"] == "replantation"
 
     def test_reimplantation_stripped_from_redirect_url_in_ru(self, client):
         """Regime unique: when the form view builds a redirect URL

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -98,6 +98,7 @@ class MoulinetteMixin:
             for prefix in ignore_prefixes:
                 if key.startswith(prefix):
                     GET.pop(key)
+
         return GET
 
     def get_context_data(self, **kwargs):
@@ -245,6 +246,10 @@ class MoulinetteMixin:
 
         cleaned_data = self.moulinette.cleaned_data
         data.update(cleaned_data)
+
+        for key in self.moulinette.get_excluded_params():
+            data.pop(key, None)
+
         return data
 
     def get_triage_url(self):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -551,6 +551,15 @@ class BaseMoulinetteResult(FormView):
             redirect_url = reverse("moulinette_form")
             redirect_url = update_qs(redirect_url, request.GET)
 
+        # The URL contains params that the moulinette form excludes
+        # (e.g. reimplantation in RU mode). Redirect to the form so
+        # the excluded params are stripped via get_results_params().
+        elif any(key in request.GET for key in moulinette.get_excluded_params()):
+            redirect_url = reverse("moulinette_form")
+            redirect_url = update_qs(redirect_url, request.GET)
+            for key in moulinette.get_excluded_params():
+                redirect_url = remove_from_qs(redirect_url, key)
+
         if redirect_url:
             return HttpResponseRedirect(redirect_url)
 

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -551,12 +551,12 @@ class BaseMoulinetteResult(FormView):
             redirect_url = reverse("moulinette_form")
             redirect_url = update_qs(redirect_url, request.GET)
 
-        # The URL contains params that the moulinette form excludes
-        # (e.g. reimplantation in RU mode). Redirect to the form so
-        # the excluded params are stripped via get_results_params().
+        # The URL contains stale params that this moulinette form
+        # excludes (e.g. reimplantation in RU mode). Redirect to the
+        # same result URL with those params stripped so the moulinette
+        # evaluates with the default value.
         elif any(key in request.GET for key in moulinette.get_excluded_params()):
-            redirect_url = reverse("moulinette_form")
-            redirect_url = update_qs(redirect_url, request.GET)
+            redirect_url = request.get_full_path()
             for key in moulinette.get_excluded_params():
                 redirect_url = remove_from_qs(redirect_url, key)
 

--- a/envergo/templates/haie/moulinette/form.html
+++ b/envergo/templates/haie/moulinette/form.html
@@ -32,7 +32,9 @@
         {% include '_form_header.html' with form=form %}
 
         <div class="form-section">{% render_field form.motif %}</div>
-        <div class="form-section">{% render_field form.reimplantation %}</div>
+        {% if form.reimplantation %}
+          <div class="form-section">{% render_field form.reimplantation %}</div>
+        {% endif %}
         <div class="form-section">{% render_field form.localisation_pac %}</div>
 
         <div class="form-section">


### PR DESCRIPTION
Gère la question de la question « réimplantation ».

https://trello.com/c/mukDENtl/2533-dans-un-d%C3%A9partement-r%C3%A9gime-unique-on-supprimer-la-2e-question-du-formulaire-haie

Après plusieurs pistes, il s'avère que le plus simple était de splitter le formulaire haie en deux : RU et HRU.