### PR TITLE
Séquence « Éviter / réduire »

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,7 +441,8 @@ HAIE_SINGLE_PROCEDURE_ACTIVATED = env.bool(
     "DJANGO_HAIE_SINGLE_PROCEDURE_ACTIVATED", default=False
 )
 
-# Kill switch for the « Éviter / réduire » display block
+# Kill switch for the « Éviter / réduire » acknowledgment block and its
+# submission gate on the haie simulation form
 HAIE_EVITER_REDUIRE_ENABLED = env.bool(
     "DJANGO_HAIE_EVITER_REDUIRE_ENABLED", default=True
 )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,6 +441,11 @@ HAIE_SINGLE_PROCEDURE_ACTIVATED = env.bool(
     "DJANGO_HAIE_SINGLE_PROCEDURE_ACTIVATED", default=False
 )
 
+# Kill switch for the « Éviter / réduire » display block
+HAIE_EVITER_REDUIRE_ENABLED = env.bool(
+    "DJANGO_HAIE_EVITER_REDUIRE_ENABLED", default=True
+)
+
 DEMARCHE_NUMERIQUE = {
     # Documentation API de pré-remplissage :
     # https://doc.demarche.numerique.gouv.fr/pour-aller-plus-loin/api-de-preremplissage

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,8 +441,7 @@ HAIE_SINGLE_PROCEDURE_ACTIVATED = env.bool(
     "DJANGO_HAIE_SINGLE_PROCEDURE_ACTIVATED", default=False
 )
 
-# Kill switch for the « Éviter / réduire » acknowledgment block and its
-# submission gate on the haie simulation form
+# Kill switch for the « Éviter / réduire » gate on the haie simulation form
 HAIE_EVITER_REDUIRE_ENABLED = env.bool(
     "DJANGO_HAIE_EVITER_REDUIRE_ENABLED", default=True
 )

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 // The « Éviter / réduire » block appears once the form is valid and the
-// project removes RU or HRU hedges. It swaps its message when the motif
-// changes (unchecking the box), and gates the submission behind a
+// project removes RU or HRU hedges. When the motif changes, it swaps its
+// message and unchecks the box; the submission is gated behind a
 // "J'ai compris" checkbox.
 test('The éviter / réduire block gates the simulation submission', async ({ page }) => {
     await page.goto('/');

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 // The « Éviter / réduire » block appears once the form is valid and the
-// project removes RU or HRU hedges. When the motif changes, it swaps its
-// message and unchecks the box; the submission is gated behind a
-// "J'ai compris" checkbox.
+// project removes RU or HRU hedges; it gates submission behind a
+// "J'ai compris" checkbox and swaps its message when the motif changes.
 test('The éviter / réduire block gates the simulation submission', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('link', { name: 'Simuler un projet' }).click();

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -58,6 +58,6 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     // Acknowledging lets the submission through to the result page
     await block.getByText("J'ai compris").click();
     await page.getByRole('button', { name: 'Valider' }).click();
-    await expect(page).toHaveURL(/resultat/);
+    await expect(page).toHaveURL(/result/);
     await expect(page).not.toHaveURL(/eviter_reduire/);
 });

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -7,7 +7,7 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     await page.goto('/');
     await page.getByRole('link', { name: 'Simuler un projet' }).click();
     await page.getByRole('link', { name: 'Loire-Atlantique (44)' }).click();
-    await page.getByText('Haies ou alignements d’arbres').click();
+    await page.getByText('Haies ou alignements d'arbres').click();
     await page.getByText('Toute intervention supprimant définitivement la végétation').click();
     await page.getByText('Uniquement les travaux sur la végétation').click();
     await page.getByRole('button', { name: 'Valider' }).click();
@@ -17,7 +17,7 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     await page.locator('label').filter({ hasText: 'Oui, en plantant une haie à' }).click();
     await page.getByText('Non, aucune des haies').click();
 
-    // Draw a single "haie mixte" hedge: intrinsic category RU
+    // Draw a single "haie mixte" hedge: category RU
     await page.getByRole('button', { name: 'Localiser les haies' }).click();
     const frame = page.locator('#hedge-input-iframe').contentFrame();
     await frame.getByRole('combobox', { name: 'Rechercher une commune ou une' }).click();
@@ -34,7 +34,9 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     await page.getByRole('button', { name: 'Valider' }).click();
     const block = page.locator('#eviter-reduire');
     await expect(block.getByText('Évitement et réduction des impacts')).toBeVisible();
-    await expect(block.getByRole('checkbox', { name: "J'ai compris" })).not.toBeChecked();
+    // DSFR hides the raw <input> — assert its state without a visibility check
+    const checkbox = block.locator('input[name="eviter_reduire"]');
+    await expect(checkbox).not.toBeChecked();
     await expect(page.getByText('Vous devez confirmer avoir pris connaissance')).not.toBeVisible();
 
     // The message matches the selected motif
@@ -46,16 +48,16 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     await expect(page.getByText('Vous devez confirmer avoir pris connaissance de cette information.')).toBeVisible();
 
     // Changing the motif swaps the message and unchecks the box
-    await block.getByRole('checkbox', { name: "J'ai compris" }).check();
+    // Click the label — the DSFR-styled surface — not the hidden input
+    await block.getByText("J'ai compris").click();
     await page.getByText('Mise en sécurité, risque sanitaire').click();
     await expect(block.locator('[data-motif="securite"]')).toBeVisible();
     await expect(block.locator('[data-motif="chemin_acces"]')).toBeHidden();
-    await expect(block.getByRole('checkbox', { name: "J'ai compris" })).not.toBeChecked();
+    await expect(checkbox).not.toBeChecked();
 
     // Acknowledging lets the submission through to the result page
-    await block.getByRole('checkbox', { name: "J'ai compris" }).check();
+    await block.getByText("J'ai compris").click();
     await page.getByRole('button', { name: 'Valider' }).click();
     await expect(page).toHaveURL(/resultat/);
-    // The acknowledgment never leaks into the simulation url
     await expect(page).not.toHaveURL(/eviter_reduire/);
 });

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -7,7 +7,7 @@ test('The éviter / réduire block gates the simulation submission', async ({ pa
     await page.goto('/');
     await page.getByRole('link', { name: 'Simuler un projet' }).click();
     await page.getByRole('link', { name: 'Loire-Atlantique (44)' }).click();
-    await page.getByText('Haies ou alignements d'arbres').click();
+    await page.getByText('Haies ou alignements d’arbres').click();
     await page.getByText('Toute intervention supprimant définitivement la végétation').click();
     await page.getByText('Uniquement les travaux sur la végétation').click();
     await page.getByRole('button', { name: 'Valider' }).click();

--- a/e2e/haie/moulinette/eviter_reduire.spec.ts
+++ b/e2e/haie/moulinette/eviter_reduire.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+// The « Éviter / réduire » block appears once the form is valid and the
+// project removes RU or HRU hedges. It swaps its message when the motif
+// changes (unchecking the box), and gates the submission behind a
+// "J'ai compris" checkbox.
+test('The éviter / réduire block gates the simulation submission', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Simuler un projet' }).click();
+    await page.getByRole('link', { name: 'Loire-Atlantique (44)' }).click();
+    await page.getByText('Haies ou alignements d’arbres').click();
+    await page.getByText('Toute intervention supprimant définitivement la végétation').click();
+    await page.getByText('Uniquement les travaux sur la végétation').click();
+    await page.getByRole('button', { name: 'Valider' }).click();
+
+    // Fill the main form. "Non" to PAC so no additional question interferes.
+    await page.getByText('Création ou élargissement d\'un accès à la parcelle').click();
+    await page.locator('label').filter({ hasText: 'Oui, en plantant une haie à' }).click();
+    await page.getByText('Non, aucune des haies').click();
+
+    // Draw a single "haie mixte" hedge: intrinsic category RU
+    await page.getByRole('button', { name: 'Localiser les haies' }).click();
+    const frame = page.locator('#hedge-input-iframe').contentFrame();
+    await frame.getByRole('combobox', { name: 'Rechercher une commune ou une' }).click();
+    await frame.getByRole('combobox', { name: 'Rechercher une commune ou une' }).fill('coueron');
+    await frame.getByRole('option', { name: 'Couëron 44, Loire-Atlantique, Pays de la Loire', exact: true }).click();
+    await frame.getByRole('button', { name: 'Tracer une haie à détruire' }).click();
+    await frame.locator('#map').click({ position: { x: 300, y: 215 } });
+    await frame.locator('#map').dblclick({ position: { x: 310, y: 215 } });
+    await frame.getByRole('dialog', { name: 'Description de la haie D1' }).getByText('Haie mixte').check();
+    await frame.getByLabel('Description de la haie D1').getByRole('button', { name: 'Enregistrer' }).click();
+    await frame.locator('footer').getByRole('button', { name: 'Enregistrer', exact: true }).click();
+
+    // First submission: the block appears, unchecked, without error
+    await page.getByRole('button', { name: 'Valider' }).click();
+    const block = page.locator('#eviter-reduire');
+    await expect(block.getByText('Évitement et réduction des impacts')).toBeVisible();
+    await expect(block.getByRole('checkbox', { name: "J'ai compris" })).not.toBeChecked();
+    await expect(page.getByText('Vous devez confirmer avoir pris connaissance')).not.toBeVisible();
+
+    // The message matches the selected motif
+    await expect(block.locator('[data-motif="chemin_acces"]')).toBeVisible();
+    await expect(block.locator('[data-motif="securite"]')).toBeHidden();
+
+    // Submitting without checking shows the validation error
+    await page.getByRole('button', { name: 'Valider' }).click();
+    await expect(page.getByText('Vous devez confirmer avoir pris connaissance de cette information.')).toBeVisible();
+
+    // Changing the motif swaps the message and unchecks the box
+    await block.getByRole('checkbox', { name: "J'ai compris" }).check();
+    await page.getByText('Mise en sécurité, risque sanitaire').click();
+    await expect(block.locator('[data-motif="securite"]')).toBeVisible();
+    await expect(block.locator('[data-motif="chemin_acces"]')).toBeHidden();
+    await expect(block.getByRole('checkbox', { name: "J'ai compris" })).not.toBeChecked();
+
+    // Acknowledging lets the submission through to the result page
+    await block.getByRole('checkbox', { name: "J'ai compris" }).check();
+    await page.getByRole('button', { name: 'Valider' }).click();
+    await expect(page).toHaveURL(/resultat/);
+    // The acknowledgment never leaks into the simulation url
+    await expect(page).not.toHaveURL(/eviter_reduire/);
+});

--- a/e2e/haie/moulinette/form.spec.ts
+++ b/e2e/haie/moulinette/form.spec.ts
@@ -34,6 +34,7 @@ test('A petitioner can submit a project', async ({ page }) => {
     await page.getByRole('button', { name: 'Valider' }).click();
     await page.getByRole('textbox', { name: 'Linéaire total de haies sur l' }).click();
     await page.getByRole('textbox', { name: 'Linéaire total de haies sur l' }).fill('5000');
+    await page.getByRole('checkbox', { name: "J'ai compris" }).check();
     await page.getByRole('button', { name: 'Valider' }).click();
     await page.getByText('Autorisation', { exact: true }).click();
     await expect(await page.getByRole('heading', { name: 'Alignements d\'arbres (L350-3' })).toContainText('Autorisation');

--- a/e2e/haie/moulinette/form.spec.ts
+++ b/e2e/haie/moulinette/form.spec.ts
@@ -34,7 +34,7 @@ test('A petitioner can submit a project', async ({ page }) => {
     await page.getByRole('button', { name: 'Valider' }).click();
     await page.getByRole('textbox', { name: 'Linéaire total de haies sur l' }).click();
     await page.getByRole('textbox', { name: 'Linéaire total de haies sur l' }).fill('5000');
-    await page.getByRole('checkbox', { name: "J'ai compris" }).check();
+    await page.getByText("J'ai compris").click();
     await page.getByRole('button', { name: 'Valider' }).click();
     await page.getByText('Autorisation', { exact: true }).click();
     await expect(await page.getByRole('heading', { name: 'Alignements d\'arbres (L350-3' })).toContainText('Autorisation');

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -550,6 +550,33 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
         return haies
 
 
+class EviterReduireForm(forms.Form):
+    """Acknowledgment of the « Éviter / réduire » message.
+
+    This form gates the simulation form submission but is not part of the
+    simulation data: its values must never reach the result urls, and the
+    checkbox must never be prefilled.
+
+    An unchecked checkbox posts nothing. But we need to separate two cases:
+
+     - the checkbox is displayed for the first time (don't show any errors)
+     - the checkbox was displayed and not checked (field must be in error)
+
+    We need to use a hidden field "DISPLAYED_MARKER" for that.
+    """
+
+    # Name of the hidden input rendered alongside the checkbox
+    DISPLAYED_MARKER = "eviter_reduire_displayed"
+
+    eviter_reduire = forms.BooleanField(
+        label="J'ai compris",
+        required=True,
+        error_messages={
+            "required": "Vous devez confirmer avoir pris connaissance de cette information."
+        },
+    )
+
+
 class TriageFormHaie(forms.Form):
     department = DisplayCharField(
         label="Département",

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -553,18 +553,14 @@ class MoulinetteFormHaie(BaseMoulinetteForm):
 class EviterReduireForm(forms.Form):
     """Acknowledgment of the « Éviter / réduire » message.
 
-    This form gates the simulation form submission but is not part of the
+    Gates the simulation form submission without being part of the
     simulation data: its values must never reach the result urls, and the
     checkbox must never be prefilled.
 
-    An unchecked checkbox posts nothing, yet two cases must be told apart:
-
-     - the checkbox is displayed for the first time (don't show any errors)
-     - the checkbox was displayed and not checked (field must be in error)
-
-    A hidden input, named by DISPLAYED_MARKER and rendered next to the
-    checkbox by the template, marks the block as displayed: this form must
-    only be bound when the marker key was posted.
+    An unchecked checkbox posts nothing, so a hidden input (named by
+    DISPLAYED_MARKER, rendered by the template) marks the block as
+    displayed. Bind this form only when the marker key was posted: a first
+    display then shows no error, while an ignored checkbox does.
     """
 
     # Name of the hidden input rendered alongside the checkbox
@@ -573,8 +569,7 @@ class EviterReduireForm(forms.Form):
     eviter_reduire = forms.BooleanField(
         label="J'ai compris",
         required=True,
-        # Out of context — as screen-reader form mode presents it — the
-        # label alone is meaningless; point at the displayed message.
+        # The label alone is meaningless in a screen reader's form mode
         widget=forms.CheckboxInput(
             attrs={"aria-describedby": "eviter-reduire-message"}
         ),

--- a/envergo/moulinette/forms/__init__.py
+++ b/envergo/moulinette/forms/__init__.py
@@ -557,12 +557,14 @@ class EviterReduireForm(forms.Form):
     simulation data: its values must never reach the result urls, and the
     checkbox must never be prefilled.
 
-    An unchecked checkbox posts nothing. But we need to separate two cases:
+    An unchecked checkbox posts nothing, yet two cases must be told apart:
 
      - the checkbox is displayed for the first time (don't show any errors)
      - the checkbox was displayed and not checked (field must be in error)
 
-    We need to use a hidden field "DISPLAYED_MARKER" for that.
+    A hidden input, named by DISPLAYED_MARKER and rendered next to the
+    checkbox by the template, marks the block as displayed: this form must
+    only be bound when the marker key was posted.
     """
 
     # Name of the hidden input rendered alongside the checkbox
@@ -571,6 +573,11 @@ class EviterReduireForm(forms.Form):
     eviter_reduire = forms.BooleanField(
         label="J'ai compris",
         required=True,
+        # Out of context — as screen-reader form mode presents it — the
+        # label alone is meaningless; point at the displayed message.
+        widget=forms.CheckboxInput(
+            attrs={"aria-describedby": "eviter-reduire-message"}
+        ),
         error_messages={
             "required": "Vous devez confirmer avoir pris connaissance de cette information."
         },

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2101,10 +2101,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
     def is_acknowledgment_pending(self):
         """Return True when an acknowledgment is required but not displayed yet.
 
-        The form is unbound when the displayed-marker key was not posted,
-        i.e. the user never saw the block: it must be displayed without a
-        validation error. A displayed-but-unchecked submission binds the
-        form instead, making this False and `is_acknowledged` False too.
+        Unbound means not displayed: see EviterReduireForm for the mechanism.
         """
         form = self.acknowledgment_form
         return form is not None and not form.is_bound
@@ -2712,15 +2709,8 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
     def get_acknowledgment_form(self):
         """Return the « Éviter / réduire » acknowledgment form when required.
 
-        The block is required when any hedge to remove has a `Hedge.category`
-        of RU or HRU — i.e. every project except a pure L350-3 one. This is
-        the hedge's own category, not the department-dependent evaluator
-        routing.
-
-        The form is bound only when the displayed-marker key was posted:
-        binding from initial data would prefill the checkbox from the url,
-        and binding a marker-less POST would raise an error before the
-        block was ever displayed.
+        Required when any hedge to remove has a `Hedge.category` of RU or
+        HRU — every project except a pure L350-3 one.
         """
         if not settings.HAIE_EVITER_REDUIRE_ENABLED:
             return None

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -2082,9 +2082,9 @@ class Moulinette(MoulinetteUrlMixin, ABC):
     def get_acknowledgment_form(self):
         """Return a form gating the simulation form submission, or None.
 
-        The form has a single field (a "j'ai compris" checkbox), and it's data is
-        not part of the simulation: it must gatekeep form submission, but not reach the
-        simulation url, and make existing simulation urls invalid.
+        The form's data is not part of the simulation: it gates the form
+        submission but must never reach the result url, and existing
+        simulation urls must stay valid without it.
         """
         return None
 
@@ -2099,7 +2099,7 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         return form is None or form.is_valid()
 
     def is_acknowledgment_pending(self):
-        """Return True when the acknowledgment block was not displayed yet.
+        """Return True when an acknowledgment is required but not displayed yet.
 
         The form is unbound when the displayed-marker key was not posted,
         i.e. the user never saw the block: it must be displayed without a
@@ -2108,6 +2108,12 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         """
         form = self.acknowledgment_form
         return form is not None and not form.is_bound
+
+    def has_acknowledgment_error(self):
+        """Return True when the acknowledgment was displayed and refused."""
+
+        form = self.acknowledgment_form
+        return form is not None and form.is_bound and not form.is_valid()
 
     @cached_property
     def optional_fields(self):
@@ -2706,9 +2712,10 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
     def get_acknowledgment_form(self):
         """Return the « Éviter / réduire » acknowledgment form when required.
 
-        The block is required for every project that removes hedges of the
-        intrinsic RU or HRU categories — i.e. every project except a pure
-        L350-3 one.
+        The block is required when any hedge to remove has a `Hedge.category`
+        of RU or HRU — i.e. every project except a pure L350-3 one. This is
+        the hedge's own category, not the department-dependent evaluator
+        routing.
 
         The form is bound only when the displayed-marker key was posted:
         binding from initial data would prefill the checkbox from the url,

--- a/envergo/moulinette/models.py
+++ b/envergo/moulinette/models.py
@@ -10,6 +10,7 @@ from operator import attrgetter
 from typing import Literal
 
 from dateutil import parser
+from django.conf import settings
 from django.contrib.gis.db.models import MultiPolygonField
 from django.contrib.gis.db.models.functions import Centroid, Distance
 from django.contrib.gis.geos import Point
@@ -70,6 +71,7 @@ from envergo.moulinette.fields import (
 )
 from envergo.moulinette.forms import (
     DisplayIntegerField,
+    EviterReduireForm,
     MoulinetteFormAmenagement,
     MoulinetteFormHaie,
     TriageFormHaie,
@@ -2077,6 +2079,36 @@ class Moulinette(MoulinetteUrlMixin, ABC):
         data = self.data
         return any(key in data for key in self.additional_fields.keys())
 
+    def get_acknowledgment_form(self):
+        """Return a form gating the simulation form submission, or None.
+
+        The form has a single field (a "j'ai compris" checkbox), and it's data is
+        not part of the simulation: it must gatekeep form submission, but not reach the
+        simulation url, and make existing simulation urls invalid.
+        """
+        return None
+
+    @cached_property
+    def acknowledgment_form(self):
+        return self.get_acknowledgment_form()
+
+    def is_acknowledged(self):
+        """Return True when no acknowledgment is required, or it was confirmed."""
+
+        form = self.acknowledgment_form
+        return form is None or form.is_valid()
+
+    def is_acknowledgment_pending(self):
+        """Return True when the acknowledgment block was not displayed yet.
+
+        The form is unbound when the displayed-marker key was not posted,
+        i.e. the user never saw the block: it must be displayed without a
+        validation error. A displayed-but-unchecked submission binds the
+        form instead, making this False and `is_acknowledged` False too.
+        """
+        form = self.acknowledgment_form
+        return form is not None and not form.is_bound
+
     @cached_property
     def optional_fields(self):
         """Get a {field_name: field} dict of all optional questions fields."""
@@ -2670,6 +2702,37 @@ class MoulinetteHaie(MoulinetteHaieUrlMixin, Moulinette):
         return self.get_main_form_class()(
             single_procedure=self._get_single_procedure(), **form_kwargs
         )
+
+    def get_acknowledgment_form(self):
+        """Return the « Éviter / réduire » acknowledgment form when required.
+
+        The block is required for every project that removes hedges of the
+        intrinsic RU or HRU categories — i.e. every project except a pure
+        L350-3 one.
+
+        The form is bound only when the displayed-marker key was posted:
+        binding from initial data would prefill the checkbox from the url,
+        and binding a marker-less POST would raise an error before the
+        block was ever displayed.
+        """
+        if not settings.HAIE_EVITER_REDUIRE_ENABLED:
+            return None
+
+        if not self.is_evaluated():
+            return None
+
+        haies = self.catalog.get("haies")
+        if not haies:
+            return None
+
+        to_remove = haies.hedges_to_remove()
+        if not (to_remove.ru() or to_remove.hru()):
+            return None
+
+        form_kwargs = {}
+        if EviterReduireForm.DISPLAYED_MARKER in self.data:
+            form_kwargs["data"] = self.data
+        return EviterReduireForm(**form_kwargs)
 
     @property
     def result(self):

--- a/envergo/moulinette/tests/test_eviter_reduire.py
+++ b/envergo/moulinette/tests/test_eviter_reduire.py
@@ -1,0 +1,390 @@
+"""Tests for the « Éviter / réduire » acknowledgment block on the haie form.
+
+The block appears below the additional questions when the project removes
+hedges of the RU or HRU intrinsic categories. It gates the form submission
+behind a "J'ai compris" checkbox whose value is not part of the simulation:
+it must never reach the result urls, and result pages must never require it.
+"""
+
+import decimal
+import re
+from unittest.mock import patch
+from urllib.parse import urlencode
+
+import pytest
+from django.urls import reverse
+
+from envergo.hedges.models import HedgeCategory
+from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
+from envergo.moulinette.tests.factories import (
+    CriterionFactory,
+    DCConfigHaieFactory,
+    RegulationFactory,
+)
+
+pytestmark = pytest.mark.haie
+
+BLOCK_TITLE = "Évitement et réduction des impacts"
+CHECKBOX_NAME = "eviter_reduire"
+MARKER_NAME = "eviter_reduire_displayed"
+ACK_ERROR = "Vous devez confirmer avoir pris connaissance de cette information."
+FORM_ERROR = (
+    "Nous n'avons pas pu traiter votre demande car le formulaire contient des erreurs."
+)
+ALL_MOTIFS = [
+    "amelioration_culture",
+    "amenagement",
+    "chemin_acces",
+    "securite",
+    "amelioration_ecologique",
+    "embellissement",
+    "autre",
+]
+
+TRIAGE_PARAMS = {
+    "department": "44",
+    "element": "haie",
+    "travaux": "destruction",
+    "contexte": "non",
+}
+
+
+@pytest.fixture(autouse=True)
+def eviter_reduire_enabled(settings):
+    settings.HAIE_EVITER_REDUIRE_ENABLED = True
+
+
+@pytest.fixture(autouse=True)
+def conditionnalite_pac_criteria(loire_atlantique_map):  # noqa
+    """Activate the BCAE8 criterion, the source of real additional questions."""
+    regulation = RegulationFactory(
+        regulation="conditionnalite_pac",
+        evaluator="envergo.moulinette.regulations.conditionnalitepac.Bcae8Regulation",
+    )
+    return [
+        CriterionFactory(
+            title="Bonnes conditions agricoles et environnementales - Fiche VIII",
+            regulation=regulation,
+            evaluator="envergo.moulinette.regulations.conditionnalitepac.Bcae8Hru",
+            activation_map=loire_atlantique_map,
+            activation_mode="department_centroid",
+        ),
+    ]
+
+
+def ru_hedge(**kwargs):
+    """A hedge of intrinsic category RU (non-alignement, no urban property)."""
+    kwargs.setdefault("additionalData__sur_parcelle_pac", False)
+    return HedgeFactory(**kwargs)
+
+
+def hru_hedge():
+    """A hedge of intrinsic category HRU (alignement not along a road)."""
+    return HedgeFactory(
+        additionalData__type_haie="alignement",
+        additionalData__bord_voie=False,
+        additionalData__sur_parcelle_pac=False,
+    )
+
+
+def l350_3_hedge():
+    """A hedge of intrinsic category L350-3 (alignement along a road)."""
+    return HedgeFactory(
+        additionalData__type_haie="alignement",
+        additionalData__bord_voie=True,
+        additionalData__sur_parcelle_pac=False,
+    )
+
+
+def simulation_data(hedges, **overrides):
+    """Valid main form data that triggers no BCAE8 additional question."""
+    data = {
+        **TRIAGE_PARAMS,
+        "motif": "amelioration_culture",
+        "reimplantation": "remplacement",
+        "localisation_pac": "non",
+        "haies": str(hedges.id),
+    }
+    data.update(overrides)
+    return data
+
+
+def form_url(params=None):
+    url = reverse("moulinette_form")
+    return f"{url}?{urlencode(params or TRIAGE_PARAMS)}"
+
+
+def checkbox_tag(content):
+    """Extract the rendered acknowledgment checkbox input tag."""
+    match = re.search(rf'<input[^>]*name="{CHECKBOX_NAME}"[^>]*>', content)
+    return match.group(0) if match else None
+
+
+def motif_variant_tag(content, motif):
+    """Extract the opening tag of the message variant for the given motif."""
+    match = re.search(rf'<[a-z]+[^>]*data-motif="{motif}"[^>]*>', content)
+    return match.group(0) if match else None
+
+
+# Display rules
+
+
+def test_block_absent_on_pristine_form(client):
+    """The block does not show while the main form has no valid data."""
+    DCConfigHaieFactory()
+
+    res = client.get(form_url())
+
+    assert res.status_code == 200
+    assert BLOCK_TITLE not in res.content.decode()
+
+
+def test_block_displayed_on_prefilled_form(client):
+    """A form prefilled with valid url data shows the block, without error."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges)))
+
+    content = res.content.decode()
+    assert BLOCK_TITLE in content
+    tag = checkbox_tag(content)
+    assert tag is not None
+    assert "checked" not in tag
+    assert MARKER_NAME in content
+    assert ACK_ERROR not in content
+
+
+def test_block_absent_for_pure_l350_3_project(client):
+    """A single-category L350-3 project is the only case without the block."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[l350_3_hedge(), l350_3_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges)))
+
+    assert BLOCK_TITLE not in res.content.decode()
+
+
+def test_block_displayed_for_hru_project(client):
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[hru_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges)))
+
+    assert BLOCK_TITLE in res.content.decode()
+
+
+def test_block_displayed_for_mixed_categories_project(client):
+    """One RU or HRU hedge among L350-3 hedges is enough to show the block."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[l350_3_hedge(), ru_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges)))
+
+    assert BLOCK_TITLE in res.content.decode()
+
+
+# Submission flow
+
+
+def test_first_submission_redirects_to_display_the_block(client):
+    """A valid submission missing the acknowledgment redisplays the form.
+
+    Like the additional questions flow: redirect to the form url with the
+    submitted values as parameters, and no validation error yet.
+    """
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+
+    res = client.post(form_url(), simulation_data(hedges))
+
+    assert res.status_code == 302
+    location = res["Location"]
+    assert location.startswith(reverse("moulinette_form"))
+    assert location.endswith("#eviter-reduire")
+    assert CHECKBOX_NAME not in location
+    assert MARKER_NAME not in location
+
+    res = client.get(location.split("#")[0])
+    content = res.content.decode()
+    assert BLOCK_TITLE in content
+    assert ACK_ERROR not in content
+
+
+def test_resubmission_without_checking_shows_the_error(client):
+    """Once the block was displayed (marker posted), the checkbox is required."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+    data = simulation_data(hedges, **{MARKER_NAME: "true"})
+
+    res = client.post(form_url(), data)
+
+    assert res.status_code == 200
+    content = res.content.decode()
+    assert FORM_ERROR in content
+    assert ACK_ERROR in content
+
+
+def test_checked_submission_reaches_the_result(client):
+    """Acknowledging lets the submission through, without leaking to the url."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+    data = simulation_data(hedges, **{MARKER_NAME: "true", CHECKBOX_NAME: "on"})
+
+    res = client.post(form_url(), data)
+
+    assert res.status_code == 302
+    location = res["Location"]
+    assert location.startswith("/simulateur/resultat/")
+    assert CHECKBOX_NAME not in location
+    assert MARKER_NAME not in location
+
+
+def test_pure_l350_3_submission_is_not_gated(client):
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[l350_3_hedge()])
+
+    res = client.post(form_url(), simulation_data(hedges))
+
+    assert res.status_code == 302
+    assert res["Location"].startswith("/simulateur/resultat/")
+
+
+def test_block_appears_with_additional_questions_in_a_single_round_trip(client):
+    """The block and the additional questions display together, not in sequence."""
+    DCConfigHaieFactory()
+    # Default hedge is RU and on a PAC parcel: BCAE8 questions will trigger
+    hedges = HedgeDataFactory(hedges=[HedgeFactory()])
+    data = simulation_data(hedges, localisation_pac="oui")
+
+    res = client.post(form_url(), data)
+
+    assert res.status_code == 302
+    location = res["Location"]
+    assert location.startswith(reverse("moulinette_form"))
+    assert "#additional-forms" in location
+
+    res = client.get(location.split("#")[0])
+    content = res.content.decode()
+    assert "Questions complémentaires" in content
+    assert BLOCK_TITLE in content
+    assert ACK_ERROR not in content
+
+    # Answering everything at once reaches the result
+    data.update(
+        {
+            "lineaire_total": "5000",
+            "transfert_parcelles": "non",
+            "meilleur_emplacement": "non",
+            MARKER_NAME: "true",
+            CHECKBOX_NAME: "on",
+        }
+    )
+    res = client.post(form_url(), data)
+    assert res.status_code == 302
+    assert res["Location"].startswith("/simulateur/resultat/")
+
+
+# Checkbox state rules
+
+
+def test_checkbox_is_never_prefilled_from_the_url(client):
+    """Hand-crafted url values must neither pre-check the box nor bind the form."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+    params = simulation_data(hedges)
+    params[CHECKBOX_NAME] = "on"
+    params[MARKER_NAME] = "true"
+
+    res = client.get(form_url(params))
+
+    content = res.content.decode()
+    tag = checkbox_tag(content)
+    assert tag is not None
+    assert "checked" not in tag
+    assert ACK_ERROR not in content
+
+
+def test_checkbox_state_is_kept_when_another_field_fails(client):
+    """Within a single submission, the checked state survives an error re-render."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[HedgeFactory()])
+    # lineaire_total is posted empty: the BCAE8 form is bound and invalid
+    data = simulation_data(
+        hedges,
+        localisation_pac="oui",
+        lineaire_total="",
+        transfert_parcelles="non",
+        meilleur_emplacement="non",
+        **{MARKER_NAME: "true", CHECKBOX_NAME: "on"},
+    )
+
+    res = client.post(form_url(), data)
+
+    assert res.status_code == 200
+    tag = checkbox_tag(res.content.decode())
+    assert tag is not None
+    assert "checked" in tag
+
+
+# Motif-dependent message
+
+
+def test_all_motif_variants_are_rendered_but_only_the_selected_one_shows(client):
+    """Every variant is in the page so JS can swap them without a round-trip."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges, motif="securite")))
+
+    content = res.content.decode()
+    for motif in ALL_MOTIFS:
+        tag = motif_variant_tag(content, motif)
+        assert tag is not None, f"missing message variant for motif {motif}"
+        if motif == "securite":
+            assert "hidden" not in tag
+        else:
+            assert "hidden" in tag
+
+
+# Result pages are never gated
+
+
+def test_result_page_is_not_gated(client):
+    """The result page re-validates url data but never requires the checkbox."""
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+    url = reverse("moulinette_result")
+
+    res = client.get(f"{url}?{urlencode(simulation_data(hedges))}")
+
+    assert res.status_code == 200
+
+
+@patch("envergo.hedges.services.get_replantation_coefficient_by_category")
+def test_result_plantation_page_is_not_gated(mock_R, client):
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+    url = reverse("moulinette_result_plantation")
+    mock_R.return_value = {HedgeCategory.hru: decimal.Decimal(0.0)}
+
+    res = client.get(f"{url}?{urlencode(simulation_data(hedges))}")
+
+    assert res.status_code == 200
+
+
+# Kill switch
+
+
+def test_kill_switch_disables_the_feature(client, settings):
+    """Disabling the setting removes both the block and the submission gate."""
+    settings.HAIE_EVITER_REDUIRE_ENABLED = False
+    DCConfigHaieFactory()
+    hedges = HedgeDataFactory(hedges=[ru_hedge()])
+
+    res = client.get(form_url(simulation_data(hedges)))
+    assert BLOCK_TITLE not in res.content.decode()
+
+    res = client.post(form_url(), simulation_data(hedges))
+    assert res.status_code == 302
+    assert res["Location"].startswith("/simulateur/resultat/")

--- a/envergo/moulinette/tests/test_eviter_reduire.py
+++ b/envergo/moulinette/tests/test_eviter_reduire.py
@@ -66,9 +66,8 @@ def conditionnalite_pac_criteria(loire_atlantique_map):  # noqa
     ]
 
 
-# The helpers disable sur_parcelle_pac: it does not affect the hedge
-# category, but a PAC hedge would pull the BCAE8 additional questions
-# into the flow.
+# The hedge helpers disable sur_parcelle_pac to keep the BCAE8 additional
+# questions out of the flow; it plays no role in the category.
 
 
 def ru_hedge():
@@ -222,8 +221,7 @@ def test_resubmission_without_checking_shows_the_error(client):
     assert FORM_ERROR in content
     assert ACK_ERROR in content
 
-    # The error event carries the acknowledgment error, even though the
-    # acknowledgment form is not part of the moulinette forms
+    # The error is logged despite not being a moulinette form error
     error_event = Event.objects.get(category="erreur", event="formulaire-simu")
     assert CHECKBOX_NAME in error_event.metadata["errors"]
 

--- a/envergo/moulinette/tests/test_eviter_reduire.py
+++ b/envergo/moulinette/tests/test_eviter_reduire.py
@@ -1,9 +1,9 @@
 """Tests for the « Éviter / réduire » acknowledgment block on the haie form.
 
 The block appears below the additional questions when the project removes
-hedges of the RU or HRU intrinsic categories. It gates the form submission
-behind a "J'ai compris" checkbox whose value is not part of the simulation:
-it must never reach the result urls, and result pages must never require it.
+hedges whose category is RU or HRU. It gates the form submission behind a
+"J'ai compris" checkbox whose value is not part of the simulation: it must
+never reach the result urls, and result pages must never require it.
 """
 
 import decimal
@@ -14,8 +14,10 @@ from urllib.parse import urlencode
 import pytest
 from django.urls import reverse
 
+from envergo.analytics.models import Event
 from envergo.hedges.models import HedgeCategory
 from envergo.hedges.tests.factories import HedgeDataFactory, HedgeFactory
+from envergo.moulinette.forms import MOTIF_CHOICES
 from envergo.moulinette.tests.factories import (
     CriterionFactory,
     DCConfigHaieFactory,
@@ -31,15 +33,7 @@ ACK_ERROR = "Vous devez confirmer avoir pris connaissance de cette information."
 FORM_ERROR = (
     "Nous n'avons pas pu traiter votre demande car le formulaire contient des erreurs."
 )
-ALL_MOTIFS = [
-    "amelioration_culture",
-    "amenagement",
-    "chemin_acces",
-    "securite",
-    "amelioration_ecologique",
-    "embellissement",
-    "autre",
-]
+ALL_MOTIFS = [key for key, _ in MOTIF_CHOICES]
 
 TRIAGE_PARAMS = {
     "department": "44",
@@ -72,14 +66,18 @@ def conditionnalite_pac_criteria(loire_atlantique_map):  # noqa
     ]
 
 
-def ru_hedge(**kwargs):
-    """A hedge of intrinsic category RU (non-alignement, no urban property)."""
-    kwargs.setdefault("additionalData__sur_parcelle_pac", False)
-    return HedgeFactory(**kwargs)
+# The helpers disable sur_parcelle_pac: it does not affect the hedge
+# category, but a PAC hedge would pull the BCAE8 additional questions
+# into the flow.
+
+
+def ru_hedge():
+    """A hedge of category RU (non-alignement, no urban property)."""
+    return HedgeFactory(additionalData__sur_parcelle_pac=False)
 
 
 def hru_hedge():
-    """A hedge of intrinsic category HRU (alignement not along a road)."""
+    """A hedge of category HRU (alignement not along a road)."""
     return HedgeFactory(
         additionalData__type_haie="alignement",
         additionalData__bord_voie=False,
@@ -88,7 +86,7 @@ def hru_hedge():
 
 
 def l350_3_hedge():
-    """A hedge of intrinsic category L350-3 (alignement along a road)."""
+    """A hedge of category L350-3 (alignement along a road)."""
     return HedgeFactory(
         additionalData__type_haie="alignement",
         additionalData__bord_voie=True,
@@ -223,6 +221,11 @@ def test_resubmission_without_checking_shows_the_error(client):
     content = res.content.decode()
     assert FORM_ERROR in content
     assert ACK_ERROR in content
+
+    # The error event carries the acknowledgment error, even though the
+    # acknowledgment form is not part of the moulinette forms
+    error_event = Event.objects.get(category="erreur", event="formulaire-simu")
+    assert CHECKBOX_NAME in error_event.metadata["errors"]
 
 
 def test_checked_submission_reaches_the_result(client):

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -326,7 +326,7 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
     def post(self, request, *args, **kwargs):
         # The acknowledgment (e.g. « Éviter / réduire ») gates the submission
-        # but is not part of the simulation data: it is only ever checked
+        # but is not part of the simulation data: it is only ever enforced
         # here, never on the result pages, and its values must not reach the
         # result url.
 
@@ -358,8 +358,14 @@ class MoulinetteForm(MoulinetteMixin, FormView):
     def form_invalid(self, form):
         context = self.get_context_data(form=form)
 
+        # The acknowledgment form is excluded from the moulinette forms, so
+        # its errors must be merged into the logged metadata separately.
+        all_errors = dict(self.moulinette.form_errors)
+        if self.moulinette.has_acknowledgment_error():
+            all_errors.update(self.moulinette.acknowledgment_form.errors)
+
         form_errors = defaultdict(list)
-        for field, errors in self.moulinette.form_errors.items():
+        for field, errors in all_errors.items():
             for error in errors.as_data():
                 form_errors[field].append(
                     {"code": str(error.code), "message": str(error.message)}
@@ -384,12 +390,11 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
         # The acknowledgment block is only rendered on the form page: result
         # views must never see, nor require, this form.
-        moulinette = self.moulinette
-        context["acknowledgment_form"] = moulinette.acknowledgment_form
+        context["acknowledgment_form"] = self.moulinette.acknowledgment_form
 
-        # Neither confirmed nor pending display: the block was displayed and
-        # submitted unchecked, a validation error like any other
-        if not (moulinette.is_acknowledged() or moulinette.is_acknowledgment_pending()):
+        # A displayed-but-refused acknowledgment is a validation error like
+        # any other
+        if self.moulinette.has_acknowledgment_error():
             context["has_errors"] = True
 
         matomo_url = self.request.path

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -325,9 +325,14 @@ class MoulinetteForm(MoulinetteMixin, FormView):
         return self.moulinette.get_home_template()
 
     def post(self, request, *args, **kwargs):
+        # The acknowledgment (e.g. « Éviter / réduire ») gates the submission
+        # but is not part of the simulation data: it is only ever checked
+        # here, never on the result pages, and its values must not reach the
+        # result url.
+
         # If the moulinette is valid, i.e. it can run the evaluation and provide
         # a result, then we redirect to the result page
-        if self.moulinette.is_valid():
+        if self.moulinette.is_valid() and self.moulinette.is_acknowledged():
             return HttpResponseRedirect(self.get_result_url())
 
         # If the main form is valid and all the errors are missing data, it means
@@ -338,6 +343,12 @@ class MoulinetteForm(MoulinetteMixin, FormView):
             and not self.moulinette.are_additional_forms_bound()
         ):
             return HttpResponseRedirect(f"{self.get_form_url()}#additional-forms")
+
+        # If only the acknowledgment is missing and its block was never
+        # displayed, redirect to the form so it appears — without a
+        # validation error, like the additional questions above.
+        elif self.moulinette.is_valid() and self.moulinette.is_acknowledgment_pending():
+            return HttpResponseRedirect(f"{self.get_form_url()}#eviter-reduire")
 
         # In other cases, it means there are errors in one of the submitted forms,
         # so we just display back the page with the validation errors
@@ -370,6 +381,17 @@ class MoulinetteForm(MoulinetteMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        # The acknowledgment block is only rendered on the form page: result
+        # views must never see, nor require, this form.
+        moulinette = self.moulinette
+        context["acknowledgment_form"] = moulinette.acknowledgment_form
+
+        # Neither confirmed nor pending display: the block was displayed and
+        # submitted unchecked, a validation error like any other
+        if not (moulinette.is_acknowledged() or moulinette.is_acknowledgment_pending()):
+            context["has_errors"] = True
+
         matomo_url = self.request.path
 
         # Custom url when some values are pre-filled

--- a/envergo/moulinette/views.py
+++ b/envergo/moulinette/views.py
@@ -325,11 +325,6 @@ class MoulinetteForm(MoulinetteMixin, FormView):
         return self.moulinette.get_home_template()
 
     def post(self, request, *args, **kwargs):
-        # The acknowledgment (e.g. « Éviter / réduire ») gates the submission
-        # but is not part of the simulation data: it is only ever enforced
-        # here, never on the result pages, and its values must not reach the
-        # result url.
-
         # If the moulinette is valid, i.e. it can run the evaluation and provide
         # a result, then we redirect to the result page
         if self.moulinette.is_valid() and self.moulinette.is_acknowledged():
@@ -344,9 +339,8 @@ class MoulinetteForm(MoulinetteMixin, FormView):
         ):
             return HttpResponseRedirect(f"{self.get_form_url()}#additional-forms")
 
-        # If only the acknowledgment is missing and its block was never
-        # displayed, redirect to the form so it appears — without a
-        # validation error, like the additional questions above.
+        # If the acknowledgment block was never displayed, redirect to the form
+        # so it appears — without an error, like the additional questions above.
         elif self.moulinette.is_valid() and self.moulinette.is_acknowledgment_pending():
             return HttpResponseRedirect(f"{self.get_form_url()}#eviter-reduire")
 
@@ -358,8 +352,7 @@ class MoulinetteForm(MoulinetteMixin, FormView):
     def form_invalid(self, form):
         context = self.get_context_data(form=form)
 
-        # The acknowledgment form is excluded from the moulinette forms, so
-        # its errors must be merged into the logged metadata separately.
+        # The acknowledgment form is not part of moulinette.form_errors
         all_errors = dict(self.moulinette.form_errors)
         if self.moulinette.has_acknowledgment_error():
             all_errors.update(self.moulinette.acknowledgment_form.errors)
@@ -388,12 +381,9 @@ class MoulinetteForm(MoulinetteMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # The acknowledgment block is only rendered on the form page: result
-        # views must never see, nor require, this form.
+        # Exposed here rather than in the mixin: result views must never see it
         context["acknowledgment_form"] = self.moulinette.acknowledgment_form
 
-        # A displayed-but-refused acknowledgment is a validation error like
-        # any other
         if self.moulinette.has_acknowledgment_error():
             context["has_errors"] = True
 

--- a/envergo/static/js/libs/eviter_reduire.js
+++ b/envergo/static/js/libs/eviter_reduire.js
@@ -1,0 +1,38 @@
+(function (exports) {
+  'use strict';
+
+  // The « Éviter / réduire » acknowledgment block.
+  //
+  // The message depends on the "motif" value.
+  // The the value change, swap the message and uncheck the "J'ai compris" input.
+  const EviterReduire = function (sectionElt, form) {
+    this.sectionElt = sectionElt;
+    this.form = form;
+    this.checkbox = sectionElt.querySelector('input[type=checkbox][name=eviter_reduire]');
+    this.variants = sectionElt.querySelectorAll('.eviter-reduire-motif');
+  };
+  exports.EviterReduire = EviterReduire;
+
+  EviterReduire.prototype.init = function () {
+    const motifRadios = this.form.querySelectorAll('input[type=radio][name=motif]');
+    motifRadios.forEach(function (radio) {
+      radio.addEventListener('change', this.onMotifChange.bind(this));
+    }, this);
+  };
+
+  EviterReduire.prototype.onMotifChange = function (evt) {
+    const motif = evt.target.value;
+    this.variants.forEach(function (variant) {
+      variant.hidden = variant.dataset.motif !== motif;
+    });
+    this.checkbox.checked = false;
+  };
+})(this);
+
+window.addEventListener('load', function () {
+  const section = document.querySelector('#eviter-reduire');
+  const form = section && section.closest('form');
+  if (form) {
+    new EviterReduire(section, form).init();
+  }
+});

--- a/envergo/static/js/libs/eviter_reduire.js
+++ b/envergo/static/js/libs/eviter_reduire.js
@@ -1,11 +1,9 @@
 (function (exports) {
   'use strict';
 
-  // The « Éviter / réduire » acknowledgment block.
-  //
-  // The displayed message depends on the "motif" value. When the motif
-  // changes, swap the visible message variant and uncheck the "J'ai compris"
-  // input: the user must acknowledge the message matching their motif.
+  // The « Éviter / réduire » block: when the motif changes, swap the visible
+  // message variant and uncheck the box, so the user acknowledges the message
+  // matching their actual motif.
   const EviterReduire = function (sectionElt, form) {
     this.form = form;
     this.checkbox = sectionElt.querySelector('input[type=checkbox][name=eviter_reduire]');

--- a/envergo/static/js/libs/eviter_reduire.js
+++ b/envergo/static/js/libs/eviter_reduire.js
@@ -3,10 +3,10 @@
 
   // The « Éviter / réduire » acknowledgment block.
   //
-  // The message depends on the "motif" value.
-  // The the value change, swap the message and uncheck the "J'ai compris" input.
+  // The displayed message depends on the "motif" value. When the motif
+  // changes, swap the visible message variant and uncheck the "J'ai compris"
+  // input: the user must acknowledge the message matching their motif.
   const EviterReduire = function (sectionElt, form) {
-    this.sectionElt = sectionElt;
     this.form = form;
     this.checkbox = sectionElt.querySelector('input[type=checkbox][name=eviter_reduire]');
     this.variants = sectionElt.querySelectorAll('.eviter-reduire-motif');
@@ -14,10 +14,11 @@
   exports.EviterReduire = EviterReduire;
 
   EviterReduire.prototype.init = function () {
+    const onMotifChange = this.onMotifChange.bind(this);
     const motifRadios = this.form.querySelectorAll('input[type=radio][name=motif]');
     motifRadios.forEach(function (radio) {
-      radio.addEventListener('change', this.onMotifChange.bind(this));
-    }, this);
+      radio.addEventListener('change', onMotifChange);
+    });
   };
 
   EviterReduire.prototype.onMotifChange = function (evt) {

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -361,6 +361,15 @@ nav#evaluation-summary {
     }
   }
 
+  #eviter-reduire {
+    background-color: var(--blue-france-950-100-hover);
+    padding: 1rem;
+
+    .eviter-reduire-motif {
+      margin-bottom: 1.5rem;
+    }
+  }
+
   #optional-forms {
     padding: 0;
 

--- a/envergo/static/sass/project.scss
+++ b/envergo/static/sass/project.scss
@@ -330,10 +330,14 @@ nav#evaluation-summary {
     display: none;
   }
 
-  #additional-forms.unbound {
+  /* Shared highlight for the blocks that appear mid-simulation */
+  #additional-forms.unbound,
+  #eviter-reduire {
     background-color: var(--blue-france-950-100-hover);
     padding: 1rem;
+  }
 
+  #additional-forms.unbound {
     .fr-input-group--error {
       &::before {
         background-image: none;
@@ -361,13 +365,8 @@ nav#evaluation-summary {
     }
   }
 
-  #eviter-reduire {
-    background-color: var(--blue-france-950-100-hover);
-    padding: 1rem;
-
-    .eviter-reduire-motif {
-      margin-bottom: 1.5rem;
-    }
+  #eviter-reduire .eviter-reduire-motif {
+    margin-bottom: 1.5rem;
   }
 
   #optional-forms {

--- a/envergo/templates/haie/moulinette/_eviter_reduire.html
+++ b/envergo/templates/haie/moulinette/_eviter_reduire.html
@@ -1,23 +1,26 @@
 {% load utils %}
 
 {% comment %}
-The « Éviter / réduire » acknowledgment block.
+The « Éviter / réduire » acknowledgment block.
 
 Every motif variant is rendered so the message can be swapped client-side
 when the motif changes, without a server round-trip; only the variant
-matching the current motif is visible. The hidden marker input tells the
-server the block was displayed (an unchecked checkbox posts nothing).
+matching the current motif is visible. The variants live in a polite live
+region so assistive tech announces the swap. The hidden marker input tells
+the server the block was displayed (an unchecked checkbox posts nothing).
 {% endcomment %}
 <section id="eviter-reduire" class="form-section">
   <h4>
     <strong>Évitement et réduction des impacts</strong>
   </h4>
 
-  <p class="fr-callout fr-icon-information-line">
-    L'autorisation d’une destruction de haies dépend en grande partie de la
-    démonstration dans le dossier que le demandeur a cherché à limiter au
-    maximum les impacts sur les haies et sur la faune qu’elles abritent.
-  </p>
+  <div class="fr-callout fr-icon-information-line">
+    <p class="fr-callout__text">
+      L’autorisation d’une destruction de haies dépend en grande partie de la
+      démonstration dans le dossier que le demandeur a cherché à limiter au
+      maximum les impacts sur les haies et sur la faune qu’elles abritent.
+    </p>
+  </div>
 
   <p>
     <em>
@@ -25,139 +28,205 @@ server the block was displayed (an unchecked checkbox posts nothing).
       Prenez le temps de les examiner : certaines peuvent réduire le besoin
       d’échanges avec le service instructeur, accélérer l’instruction, et
       améliorer l’acceptabilité du dossier.
-
     </em>
   </p>
 
-  <div class="eviter-reduire-motif"
-       data-motif="amelioration_culture"
-       {% if motif != "amelioration_culture" %}hidden{% endif %}>
-    <p>
-      Le choix des haies à détruire doit tenir compte de leur valeur pour l'écoulement des eaux, la faune et la flore, et le paysage local. Par exemple, une haie en bas de pente ou en bordure de fossé retient l'eau et limite le ruissellement ; la justification de sa destruction sera examinée attentivement dans l’instruction du dossier.
-    </p>
+  <div id="eviter-reduire-message" aria-live="polite">
+    <div class="eviter-reduire-motif"
+         data-motif="amelioration_culture"
+         {% if motif != "amelioration_culture" %}hidden{% endif %}>
+      <p>
+        Le choix des haies à détruire doit tenir compte de leur valeur pour
+        l’écoulement des eaux, la faune et la flore, et le paysage local. Par
+        exemple, une haie en bas de pente ou en bordure de fossé retient l’eau
+        et limite le ruissellement ; la justification de sa destruction sera
+        examinée attentivement dans l’instruction du dossier.
+      </p>
 
-    <p>Est-il possible de :</p>
+      <p>Est-il possible de :</p>
 
-    <ul>
-      <li>
-        Ménager un chemin d'accès plutôt qu’une modification de parcelle ? Une brèche peut parfois répondre au même besoin, et sera plus facilement acceptée.
-      </li>
-      <li>Privilégier un regroupement de parcelles sans détruire les haies périphériques ?</li>
-      <li>Conserver une partie de la haie pour modifier la forme de la parcelle, plutôt que de l'agrandir ?</li>
-    </ul>
+      <ul>
+        <li>
+          Ménager un chemin d’accès plutôt qu’une modification de parcelle ?
+          Une brèche peut parfois répondre au même besoin, et sera plus
+          facilement acceptée.
+        </li>
+        <li>
+          Privilégier un regroupement de parcelles sans détruire les haies
+          périphériques ?
+        </li>
+        <li>
+          Conserver une partie de la haie pour modifier la forme de la
+          parcelle, plutôt que de l’agrandir ?
+        </li>
+      </ul>
 
-    <p>
-      Si la destruction est inévitable, limiter au strict nécessaire le linéaire détruit. Le gain économique attendu devra être clairement démontré dans le dossier.
-    </p>
+      <p>
+        Si la destruction est inévitable, limiter au strict nécessaire le
+        linéaire détruit. Le gain économique attendu devra être clairement
+        démontré dans le dossier.
+      </p>
+    </div>
 
-  </div>
+    <div class="eviter-reduire-motif"
+         data-motif="amenagement"
+         {% if motif != "amenagement" %}hidden{% endif %}>
+      <p>Est-il possible de :</p>
 
-  <div class="eviter-reduire-motif"
-       data-motif="amenagement"
-       {% if motif != "amenagement" %}hidden{% endif %}>
-    <p>Est-il possible de :</p>
+      <ul>
+        <li>
+          Privilégier un emplacement ou une orientation du projet épargnant
+          tout ou partie de la haie ?
+        </li>
+        <li>
+          Choisir un emplacement qui n’interrompt pas de corridor entre deux
+          espaces naturels (boisement, mare, cours d’eau) ni l’écoulement des
+          eaux ?
+        </li>
+        <li>
+          Pour une voirie, privilégier un tracé parallèle à la haie ? À
+          défaut, identifier en amont les portions de haie les plus sensibles
+          à éviter ?
+        </li>
+      </ul>
 
-    <ul>
-      <li>Privilégier un emplacement ou une orientation du projet épargnant tout ou partie de la haie ?</li>
-      <li>
-        Choisir un emplacement qui n’interrompt pas de corridor entre deux espaces naturels (boisement, mare, cours d’eau) ni l’écoulement des eaux ?
-      </li>
-      <li>
-        Pour une voirie, de privilégier un tracé parallèle à la haie ? À défaut, d’identifier en amont les portions de haie les plus sensibles à éviter ?
-      </li>
-    </ul>
+      <p>
+        Si la destruction est inévitable, limiter les haies affectées à la
+        stricte emprise des travaux. Mieux les améliorations apportées par
+        rapport au projet initial seront documentées dans le dossier, plus
+        l’instruction pourra aboutir rapidement.
+      </p>
+    </div>
 
-    <p>
-      Si la destruction est inévitable, limiter les haies affectées à la stricte emprise des travaux. Mieux les améliorations apportées par rapport au projet initial seront documentées dans le dossier, plus l’instruction pourra aboutir rapidement.
-    </p>
-  </div>
+    <div class="eviter-reduire-motif"
+         data-motif="chemin_acces"
+         {% if motif != "chemin_acces" %}hidden{% endif %}>
+      <p>
+        Le choix des haies à détruire doit tenir compte de leur valeur pour
+        l’écoulement des eaux, la faune et la flore, et le paysage local. Par
+        exemple, une haie en bas de pente ou en bordure de fossé retient l’eau
+        et limite le ruissellement ; la justification de sa destruction sera
+        examinée attentivement dans l’instruction du dossier.
+      </p>
 
-  <div class="eviter-reduire-motif"
-       data-motif="chemin_acces"
-       {% if motif != "chemin_acces" %}hidden{% endif %}>
+      <p>Est-il possible de :</p>
 
-    <p>
-      Le choix des haies à détruire doit tenir compte de leur valeur pour l'écoulement des eaux, la faune et la flore, et le paysage local. Par exemple, une haie en bas de pente ou en bordure de fossé retient l'eau et limite le ruissellement ; la justification de sa destruction sera examinée de très près dans l’instruction du dossier.
-    </p>
+      <ul>
+        <li>
+          Privilégier un accès alternatif n’impliquant pas la destruction de
+          la haie ?
+        </li>
+        <li>
+          Éviter les emplacements en bas de pente ou à proximité d’un fossé ?
+          Un déplacement de quelques mètres peut suffire à éviter un problème
+          d’écoulement des eaux.
+        </li>
+      </ul>
 
-    <p>Est-il possible de :</p>
-    <ul>
-      <li>Privilégier un accès alternatif n'impliquant pas la destruction de la haie ?</li>
-      <li>
-        Éviter les emplacements en bas de pente ou à proximité d'un fossé ? Un déplacement de quelques mètres peut suffire à éviter un problème d’écoulement des eaux.
-      </li>
-    </ul>
+      <p>
+        Si la destruction est inévitable, limiter l’ouverture au strict
+        nécessaire pour le passage des engins (généralement 4 à 6 m) et la
+        positionner sur la partie la moins arborée. Les contraintes d’accès de
+        l’existant devront être clairement démontrées et documentées dans le
+        dossier.
+      </p>
+    </div>
 
-    <p>
-      Si la destruction est inévitable, limiter l’ouverture au strict nécessaire pour le passage des engins (généralement 4 à 6 m) et la positionner sur la partie la moins arborée. Les contraintes d’accès de l’existant devront être clairement démontrées et documentées dans le dossier.
-    </p>
+    <div class="eviter-reduire-motif"
+         data-motif="securite"
+         {% if motif != "securite" %}hidden{% endif %}>
+      <p>Est-il possible de :</p>
 
-  </div>
+      <ul>
+        <li>
+          Privilégier une intervention arbre par arbre, ou branche par branche
+          plutôt qu’une destruction de l’ensemble du linéaire ? Supprimer
+          uniquement les arbres ou les branches présentant un danger réel
+          permet souvent de conserver le reste de la haie. En cas d’arbre
+          dépérissant, faire confirmer le diagnostic avant d’intervenir.
+        </li>
+        <li>
+          Envisager de conserver les troncs morts sur pied ou au sol ? Ils
+          sont favorables à la biodiversité.
+        </li>
+        <li>
+          Pour un enjeu de visibilité depuis une route, tailler uniquement la
+          face donnant sur la voie ?
+        </li>
+        <li>
+          Pour un risque d’incendie, dégager le pied de la haie et tailler les
+          branches basses ? Cela suffit souvent pour répondre aux obligations
+          légales.
+        </li>
+      </ul>
+    </div>
 
-  <div class="eviter-reduire-motif"
-       data-motif="securite"
-       {% if motif != "securite" %}hidden{% endif %}>
-    <p>Est-il possible de :</p>
+    <div class="eviter-reduire-motif"
+         data-motif="amelioration_ecologique"
+         {% if motif != "amelioration_ecologique" %}hidden{% endif %}>
+      <p>
+        Une haie existante, même dégradée, rend des services qu’une haie
+        nouvellement plantée mettra plusieurs décennies à égaler.
+      </p>
 
-    <ul>
-      <li>
-        Privilégier une intervention arbre par arbre, ou branche par branche plutôt qu’une destruction de l’ensemble du linéaire ? Supprimer uniquement les arbres ou les branches présentant un danger réel permet souvent de conserver le reste de la haie. En cas d’arbre dépérissant, faire confirmer le diagnostic avant d’intervenir.
-      </li>
-      <li>Envisager de conserver les troncs morts sur pied ou au sol ? Ils sont favorables à la biodiversité.</li>
-      <li>Pour un enjeu de visibilité depuis une route, tailler uniquement la face donnant sur la voie ?</li>
-      <li>
-        Pour un risque d'incendie, dégager le pied de la haie et tailler les branches basses ? Cela suffit souvent pour répondre aux obligations légales.
-      </li>
-    </ul>
-  </div>
+      <p>
+        Est-il possible de privilégier des actions de gestion ou de
+        remplacement progressif des essences avant toute destruction ? Elles
+        peuvent améliorer la valeur écologique de la haie sans la détruire.
+      </p>
 
-  <div class="eviter-reduire-motif"
-       data-motif="amelioration_ecologique"
-       {% if motif != "amelioration_ecologique" %}hidden{% endif %}>
-    <p>
-      Une haie existante, même dégradée, rend des services qu'une haie nouvellement plantée mettra plusieurs décennies à égaler.
-    </p>
+      <p>
+        Si la destruction est inévitable, s’assurer que le nouvel emplacement
+        et le profil de la haie apportent un réel gain environnemental par
+        rapport à la situation actuelle : grande largeur, essences variées et
+        locales, sur plusieurs strates arbustives et arborées.
+      </p>
+    </div>
 
-    <p>
-      Est-il possible de privilégier des actions de gestion ou de remplacement progressif des essences avant toute destruction ? Elles peuvent améliorer la valeur écologique de la haie sans la détruire.
-    </p>
+    <div class="eviter-reduire-motif"
+         data-motif="embellissement"
+         {% if motif != "embellissement" %}hidden{% endif %}>
+      <p>Est-il possible de :</p>
 
-    <p>
-      Si la destruction est inévitable, s'assurer que le nouvel emplacement et le profil de la haie apportent un réel gain environnemental par rapport à la situation actuelle : grande largeur, essences variées et locales, sur plusieurs strates arbustives et arborées.
-    </p>
-  </div>
+      <ul>
+        <li>
+          Privilégier une trouée plutôt qu’une destruction totale, en
+          maintenant certains arbres et en plantant des essences basses à la
+          place ?
+        </li>
+        <li>
+          Conserver en priorité les arbres les plus grands et les plus
+          anciens ? Leur suppression fera l’objet d’une attention particulière
+          lors de l’instruction.
+        </li>
+      </ul>
+    </div>
 
-  <div class="eviter-reduire-motif"
-       data-motif="embellissement"
-       {% if motif != "embellissement" %}hidden{% endif %}>
-    <p>Est-il possible de :</p>
+    <div class="eviter-reduire-motif"
+         data-motif="autre"
+         {% if motif != "autre" %}hidden{% endif %}>
+      <p>
+        Une haie existante, même dégradée, rend des services qu’une haie
+        nouvellement plantée mettra plusieurs décennies à égaler.
+      </p>
 
-    <ul>
-      <li>
-        Privilégier une trouée plutôt qu’une destruction totale, en maintenant certains arbres et en plantant des essences basses à la place ?
-      </li>
-      <li>
-        Conserver en priorité les arbres les plus grands et les plus anciens ? Leur suppression fera l’objet d’une attention particulière lors de l'instruction.
-      </li>
-    </ul>
-  </div>
+      <p>Est-il possible de :</p>
 
-  <div class="eviter-reduire-motif"
-       data-motif="autre"
-       {% if motif != "autre" %}hidden{% endif %}>
-    <p>
-      Une haie existante, même dégradée, rend des services qu'une haie nouvellement plantée mettra plusieurs décennies à égaler.
-    </p>
-
-    <p>Est-il possible de :</p>
-
-    <ul>
-      <li>Privilégier toute solution permettant de limiter ou d'éviter la destruction ?</li>
-      <li>
-        Pour une clôture, installer celle-ci le long de la haie en laissant quelques mètres pour son entretien, plutôt que de la détruire ?
-      </li>
-      <li>Pour des travaux hydrauliques (fossés, drains), choisir un tracé qui peut contourner les linéaires existants ?</li>
-    </ul>
+      <ul>
+        <li>
+          Privilégier toute solution permettant de limiter ou d’éviter la
+          destruction ?
+        </li>
+        <li>
+          Pour une clôture, installer celle-ci le long de la haie en laissant
+          quelques mètres pour son entretien, plutôt que de la détruire ?
+        </li>
+        <li>
+          Pour des travaux hydrauliques (fossés, drains), choisir un tracé qui
+          peut contourner les linéaires existants ?
+        </li>
+      </ul>
+    </div>
   </div>
 
   {% render_field acknowledgment_form.eviter_reduire %}

--- a/envergo/templates/haie/moulinette/_eviter_reduire.html
+++ b/envergo/templates/haie/moulinette/_eviter_reduire.html
@@ -1,13 +1,9 @@
 {% load utils %}
 
 {% comment %}
-The « Éviter / réduire » acknowledgment block.
-
-Every motif variant is rendered so the message can be swapped client-side
-when the motif changes, without a server round-trip; only the variant
-matching the current motif is visible. The variants live in a polite live
-region so assistive tech announces the swap. The hidden marker input tells
-the server the block was displayed (an unchecked checkbox posts nothing).
+All motif variants are rendered so JS can swap them without a round-trip;
+only the current one is visible, in a live region so the swap is announced.
+The hidden marker input tells the server the block was displayed.
 {% endcomment %}
 <section id="eviter-reduire" class="form-section">
   <h4>

--- a/envergo/templates/haie/moulinette/_eviter_reduire.html
+++ b/envergo/templates/haie/moulinette/_eviter_reduire.html
@@ -1,0 +1,168 @@
+{% load utils %}
+
+{% comment %}
+The « Éviter / réduire » acknowledgment block.
+
+Every motif variant is rendered so the message can be swapped client-side
+when the motif changes, without a server round-trip; only the variant
+matching the current motif is visible. The hidden marker input tells the
+server the block was displayed (an unchecked checkbox posts nothing).
+{% endcomment %}
+<section id="eviter-reduire" class="form-section">
+  <h4>
+    <strong>Évitement et réduction des impacts</strong>
+  </h4>
+
+  <p class="fr-callout fr-icon-information-line">
+    L'autorisation d’une destruction de haies dépend en grande partie de la
+    démonstration dans le dossier que le demandeur a cherché à limiter au
+    maximum les impacts sur les haies et sur la faune qu’elles abritent.
+  </p>
+
+  <p>
+    <em>
+      Des pistes concrètes de réduction des impacts sont proposées ci-dessous.
+      Prenez le temps de les examiner : certaines peuvent réduire le besoin
+      d’échanges avec le service instructeur, accélérer l’instruction, et
+      améliorer l’acceptabilité du dossier.
+
+    </em>
+  </p>
+
+  <div class="eviter-reduire-motif"
+       data-motif="amelioration_culture"
+       {% if motif != "amelioration_culture" %}hidden{% endif %}>
+    <p>
+      Le choix des haies à détruire doit tenir compte de leur valeur pour l'écoulement des eaux, la faune et la flore, et le paysage local. Par exemple, une haie en bas de pente ou en bordure de fossé retient l'eau et limite le ruissellement ; la justification de sa destruction sera examinée attentivement dans l’instruction du dossier.
+    </p>
+
+    <p>Est-il possible de :</p>
+
+    <ul>
+      <li>
+        Ménager un chemin d'accès plutôt qu’une modification de parcelle ? Une brèche peut parfois répondre au même besoin, et sera plus facilement acceptée.
+      </li>
+      <li>Privilégier un regroupement de parcelles sans détruire les haies périphériques ?</li>
+      <li>Conserver une partie de la haie pour modifier la forme de la parcelle, plutôt que de l'agrandir ?</li>
+    </ul>
+
+    <p>
+      Si la destruction est inévitable, limiter au strict nécessaire le linéaire détruit. Le gain économique attendu devra être clairement démontré dans le dossier.
+    </p>
+
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="amenagement"
+       {% if motif != "amenagement" %}hidden{% endif %}>
+    <p>Est-il possible de :</p>
+
+    <ul>
+      <li>Privilégier un emplacement ou une orientation du projet épargnant tout ou partie de la haie ?</li>
+      <li>
+        Choisir un emplacement qui n’interrompt pas de corridor entre deux espaces naturels (boisement, mare, cours d’eau) ni l’écoulement des eaux ?
+      </li>
+      <li>
+        Pour une voirie, de privilégier un tracé parallèle à la haie ? À défaut, d’identifier en amont les portions de haie les plus sensibles à éviter ?
+      </li>
+    </ul>
+
+    <p>
+      Si la destruction est inévitable, limiter les haies affectées à la stricte emprise des travaux. Mieux les améliorations apportées par rapport au projet initial seront documentées dans le dossier, plus l’instruction pourra aboutir rapidement.
+    </p>
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="chemin_acces"
+       {% if motif != "chemin_acces" %}hidden{% endif %}>
+
+    <p>
+      Le choix des haies à détruire doit tenir compte de leur valeur pour l'écoulement des eaux, la faune et la flore, et le paysage local. Par exemple, une haie en bas de pente ou en bordure de fossé retient l'eau et limite le ruissellement ; la justification de sa destruction sera examinée de très près dans l’instruction du dossier.
+    </p>
+
+    <p>Est-il possible de :</p>
+    <ul>
+      <li>Privilégier un accès alternatif n'impliquant pas la destruction de la haie ?</li>
+      <li>
+        Éviter les emplacements en bas de pente ou à proximité d'un fossé ? Un déplacement de quelques mètres peut suffire à éviter un problème d’écoulement des eaux.
+      </li>
+    </ul>
+
+    <p>
+      Si la destruction est inévitable, limiter l’ouverture au strict nécessaire pour le passage des engins (généralement 4 à 6 m) et la positionner sur la partie la moins arborée. Les contraintes d’accès de l’existant devront être clairement démontrées et documentées dans le dossier.
+    </p>
+
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="securite"
+       {% if motif != "securite" %}hidden{% endif %}>
+    <p>Est-il possible de :</p>
+
+    <ul>
+      <li>
+        Privilégier une intervention arbre par arbre, ou branche par branche plutôt qu’une destruction de l’ensemble du linéaire ? Supprimer uniquement les arbres ou les branches présentant un danger réel permet souvent de conserver le reste de la haie. En cas d’arbre dépérissant, faire confirmer le diagnostic avant d’intervenir.
+      </li>
+      <li>Envisager de conserver les troncs morts sur pied ou au sol ? Ils sont favorables à la biodiversité.</li>
+      <li>Pour un enjeu de visibilité depuis une route, tailler uniquement la face donnant sur la voie ?</li>
+      <li>
+        Pour un risque d'incendie, dégager le pied de la haie et tailler les branches basses ? Cela suffit souvent pour répondre aux obligations légales.
+      </li>
+    </ul>
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="amelioration_ecologique"
+       {% if motif != "amelioration_ecologique" %}hidden{% endif %}>
+    <p>
+      Une haie existante, même dégradée, rend des services qu'une haie nouvellement plantée mettra plusieurs décennies à égaler.
+    </p>
+
+    <p>
+      Est-il possible de privilégier des actions de gestion ou de remplacement progressif des essences avant toute destruction ? Elles peuvent améliorer la valeur écologique de la haie sans la détruire.
+    </p>
+
+    <p>
+      Si la destruction est inévitable, s'assurer que le nouvel emplacement et le profil de la haie apportent un réel gain environnemental par rapport à la situation actuelle : grande largeur, essences variées et locales, sur plusieurs strates arbustives et arborées.
+    </p>
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="embellissement"
+       {% if motif != "embellissement" %}hidden{% endif %}>
+    <p>Est-il possible de :</p>
+
+    <ul>
+      <li>
+        Privilégier une trouée plutôt qu’une destruction totale, en maintenant certains arbres et en plantant des essences basses à la place ?
+      </li>
+      <li>
+        Conserver en priorité les arbres les plus grands et les plus anciens ? Leur suppression fera l’objet d’une attention particulière lors de l'instruction.
+      </li>
+    </ul>
+  </div>
+
+  <div class="eviter-reduire-motif"
+       data-motif="autre"
+       {% if motif != "autre" %}hidden{% endif %}>
+    <p>
+      Une haie existante, même dégradée, rend des services qu'une haie nouvellement plantée mettra plusieurs décennies à égaler.
+    </p>
+
+    <p>Est-il possible de :</p>
+
+    <ul>
+      <li>Privilégier toute solution permettant de limiter ou d'éviter la destruction ?</li>
+      <li>
+        Pour une clôture, installer celle-ci le long de la haie en laissant quelques mètres pour son entretien, plutôt que de la détruire ?
+      </li>
+      <li>Pour des travaux hydrauliques (fossés, drains), choisir un tracé qui peut contourner les linéaires existants ?</li>
+    </ul>
+  </div>
+
+  {% render_field acknowledgment_form.eviter_reduire %}
+
+  <input type="hidden"
+         name="{{ acknowledgment_form.DISPLAYED_MARKER }}"
+         value="true">
+</section>

--- a/envergo/templates/haie/moulinette/_form_footer.html
+++ b/envergo/templates/haie/moulinette/_form_footer.html
@@ -1,5 +1,11 @@
 {% extends 'moulinette/_form_footer.html' %}
 
+{% block acknowledgment-section %}
+  {% if acknowledgment_form %}
+    {% include 'haie/moulinette/_eviter_reduire.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block submit-section %}
   <div class="hide-print cta-group fr-mt-4w">
     <div>

--- a/envergo/templates/haie/moulinette/home.html
+++ b/envergo/templates/haie/moulinette/home.html
@@ -9,4 +9,5 @@
 {% block extra_js %}
   {{ block.super }}
   <script defer src="{% static 'js/libs/hedges_input.js' %}"></script>
+  <script defer src="{% static 'js/libs/eviter_reduire.js' %}"></script>
 {% endblock %}

--- a/envergo/templates/moulinette/_form_footer.html
+++ b/envergo/templates/moulinette/_form_footer.html
@@ -59,6 +59,8 @@
   </section>
 {% endif %}
 
+{% block acknowledgment-section %}{% endblock %}
+
 {% block submit-section %}
   <div class="hide-print submit-section">
     <button type="submit" class="fr-btn">Démarrer la simulation</button>


### PR DESCRIPTION
https://trello.com/c/7C3HWAWy/2538-prise-en-compte-de-la-s%C3%A9quence-eviter-r%C3%A9duire

Ajoute un champ "j'ai compris" qui bloque la soumission du formulaire de simulation, sans que sa valeur ne soit intégrée dans l'url.